### PR TITLE
Add note about need libevent for build examples

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -38,6 +38,10 @@ libngtcp2 uses cunit for its unit test frame work:
 
 * cunit >= 2.1
 
+To build sources under the examples directory, libev is required:
+
+* libev
+
 The client and server under examples directory require boringssl as
 crypto backend:
 


### PR DESCRIPTION
(May be also add check if libevent is available because the build fail :
In file included from client.cc:38:0:
client.h:38:16: fatal error: ev.h: No such file or directory