### PR TITLE
Invalid memory access in Client Server examples

### DIFF
--- a/examples/client.h
+++ b/examples/client.h
@@ -99,6 +99,8 @@ private:
   struct ev_loop *loop_;
   SSL_CTX *ssl_ctx_;
   SSL *ssl_;
+  ngtcp2_conn_callbacks callbacks_;
+  ngtcp2_settings settings_;
   int fd_;
   int stdinfd_;
   uint32_t stream_id_;

--- a/examples/server.h
+++ b/examples/server.h
@@ -104,6 +104,8 @@ private:
   struct ev_loop *loop_;
   SSL_CTX *ssl_ctx_;
   SSL *ssl_;
+  ngtcp2_conn_callbacks callbacks_;
+  ngtcp2_settings settings_;
   Server *server_;
   int fd_;
   ev_timer timer_;


### PR DESCRIPTION
The ngtcp2_conn_callbacks and ngtcp2_settings structures that
are passed into ngtcp2_conn_{client,server}_new only exist in
the scope of the stack that the above function is called.

Once the function returns these objects no longer exist yet
they continue to be referenced throughout the lifetime of
the conn.

Fix this by making the callback and settings structures into
members of the Client and (Server) Handler classes.