### PR TITLE
Add a counter to rtb_entry

### DIFF
--- a/lib/ngtcp2_conn.c
+++ b/lib/ngtcp2_conn.c
@@ -498,8 +498,8 @@ static ssize_t conn_retransmit_unprotected(ngtcp2_conn *conn, uint8_t *dest,
     /* We have retransmit complete packet.  Update ent with new packet
        header, and push it into rbt again. */
     ent->hd = hd;
-    /* TODO Should we change expiry time in 2nd try? */
-    ent->expiry = ts + NGTCP2_INITIAL_EXPIRY;
+    ++ent->count;
+    ent->expiry = ts + (size_t)(NGTCP2_INITIAL_EXPIRY << ent->count);
 
     if (hd.type == NGTCP2_PKT_CLIENT_INITIAL) {
       localfr.type = NGTCP2_FRAME_PADDING;
@@ -665,8 +665,8 @@ static ssize_t conn_retransmit_protected(ngtcp2_conn *conn, uint8_t *dest,
     /* We have retransmit complete packet.  Update ent with new packet
        header, and push it into rbt again. */
     ent->hd = hd;
-    /* TODO Should we change expiry time in 2nd try? */
-    ent->expiry = ts + NGTCP2_INITIAL_EXPIRY;
+    ++ent->count;
+    ent->expiry = ts + (size_t)(NGTCP2_INITIAL_EXPIRY << ent->count);
 
     nwrite = ngtcp2_ppe_final(&ppe, NULL);
     if (nwrite < 0) {

--- a/lib/ngtcp2_rtb.c
+++ b/lib/ngtcp2_rtb.c
@@ -57,6 +57,7 @@ int ngtcp2_rtb_entry_new(ngtcp2_rtb_entry **pent, const ngtcp2_pkt_hd *hd,
   (*pent)->frc = frc;
   (*pent)->expiry = expiry;
   (*pent)->deadline = deadline;
+  (*pent)->count = 0;
   (*pent)->pktlen = pktlen;
   (*pent)->unprotected = unprotected;
 

--- a/lib/ngtcp2_rtb.h
+++ b/lib/ngtcp2_rtb.h
@@ -85,6 +85,8 @@ struct ngtcp2_rtb_entry {
   /* deadline is the time point when the library gives up
      retransmission of a packet, and closes its connection. */
   ngtcp2_tstamp deadline;
+  /* count is the number of times a retransmission has been sent. */
+  size_t count;
   /* pktlen is the length of QUIC packet */
   size_t pktlen;
   /* unprotected is nonzero if a packet is unprotected. */


### PR DESCRIPTION
Count the number of times a packet has been retransmitted.
At this stage, it's only purpose is to slowly backoff
retransmit timeouts so as not to cause flooding.
In future it could be used for statistics reporting and
telemetry, especially if a similar counter is kept at
the connection level.

Note: a good way to observe retransmit behaviour before
and after this change is to put a gdb breakpoint at
'ngtcp2_conn_recv' in the example client then run the
client and observe the already running server.