### PR TITLE
Make memory leak checking easier by adding cleanups

### DIFF
--- a/examples/client.h
+++ b/examples/client.h
@@ -67,6 +67,12 @@ struct Buffer {
   std::vector<uint8_t>::const_iterator pos;
 };
 
+struct BIOMethod {
+  BIOMethod();
+  ~BIOMethod();
+  BIO_METHOD *meth;
+};
+
 class Client {
 public:
   Client(struct ev_loop *loop, SSL_CTX *ssl_ctx);

--- a/examples/server.h
+++ b/examples/server.h
@@ -65,6 +65,12 @@ struct Buffer {
   std::vector<uint8_t>::const_iterator pos;
 };
 
+struct BIOMethod {
+  BIOMethod();
+  ~BIOMethod();
+  BIO_METHOD *meth;
+};
+
 struct Stream {
   Stream(uint32_t stream_id);
 


### PR DESCRIPTION
Some static objects used by the client and server
examples need cleanups so that they don't add noise
to valgrind output, and for the sake of correctness:
- Allow static BIOMETHOD struct to be cleaned up at
  exit
- Add defered cleanup for the default ev_loop
- Add a signal handler so that example app exits
  gracefully instead of dying