### PR TITLE
Add SIGINT handler to example apps

### DIFF
--- a/examples/client.cc
+++ b/examples/client.cc
@@ -964,6 +964,12 @@ int transport_params_parse_cb(SSL *ssl, unsigned int ext_type,
 } // namespace
 
 namespace {
+void siginthandler(struct ev_loop *loop, ev_signal *watcher, int revents) {
+  ev_break(EV_DEFAULT, EVBREAK_ALL);
+}
+} // namespace
+
+namespace {
 SSL_CTX *create_ssl_ctx() {
   auto ssl_ctx = SSL_CTX_new(TLS_method());
 
@@ -1175,6 +1181,11 @@ int main(int argc, char **argv) {
 
   auto ssl_ctx = create_ssl_ctx();
   auto ssl_ctx_d = defer(SSL_CTX_free, ssl_ctx);
+
+  auto ev_loop_d = defer(ev_loop_destroy, EV_DEFAULT);
+  ev_signal sigint_watcher;
+  ev_signal_init(&sigint_watcher, siginthandler, SIGINT);
+  ev_signal_start(EV_DEFAULT, &sigint_watcher);
 
   debug::reset_timestamp();
 

--- a/examples/server.cc
+++ b/examples/server.cc
@@ -1144,6 +1144,12 @@ int transport_params_parse_cb(SSL *ssl, unsigned int ext_type,
 } // namespace
 
 namespace {
+void siginthandler(struct ev_loop *loop, ev_signal *watcher, int revents) {
+  ev_break(EV_DEFAULT, EVBREAK_ALL);
+}
+} // namespace
+
+namespace {
 SSL_CTX *create_ssl_ctx(const char *private_key_file, const char *cert_file) {
   auto ssl_ctx = SSL_CTX_new(TLS_method());
 
@@ -1377,6 +1383,11 @@ int main(int argc, char **argv) {
   }
 
   auto ssl_ctx_d = defer(SSL_CTX_free, ssl_ctx);
+
+  auto ev_loop_d = defer(ev_loop_destroy, EV_DEFAULT);
+  ev_signal sigint_watcher;
+  ev_signal_init(&sigint_watcher, siginthandler, SIGINT);
+  ev_signal_start(EV_DEFAULT, &sigint_watcher);
 
   debug::reset_timestamp();
 


### PR DESCRIPTION
This enables a graceful app exit and in future will allow:
- Closure procedures like CONNECTION_CLOSE on all connections
  to be performed
- Full cleanup of allocated memory and resources