### PR TITLE
Close all connections on exit (Phase 1)

### DIFF
--- a/examples/client.h
+++ b/examples/client.h
@@ -74,6 +74,8 @@ public:
 
   int init(int fd, const Address &remote_addr, const char *addr, int stdinfd);
   void disconnect();
+  void disconnect(int liberr);
+  void close();
 
   int tls_handshake();
   int on_read();

--- a/examples/server.h
+++ b/examples/server.h
@@ -126,6 +126,7 @@ public:
   ~Handler();
 
   int init(int fd, const sockaddr *sa, socklen_t salen);
+
   int tls_handshake();
   int on_read(uint8_t *data, size_t datalen);
   int on_write();
@@ -192,6 +193,10 @@ public:
   ~Server();
 
   int init(int fd);
+  void disconnect();
+  void disconnect(int liberr);
+  void close();
+
   int on_read();
   int send_version_negotiation(const ngtcp2_pkt_hd *hd, const sockaddr *sa,
                                socklen_t salen);

--- a/lib/ngtcp2_conn.c
+++ b/lib/ngtcp2_conn.c
@@ -2978,7 +2978,6 @@ ssize_t ngtcp2_conn_write_connection_close(ngtcp2_conn *conn, uint8_t *dest,
 
   switch (conn->state) {
   case NGTCP2_CS_POST_HANDSHAKE:
-  case NGTCP2_CS_CLOSE_WAIT:
     fr.type = NGTCP2_FRAME_CONNECTION_CLOSE;
     fr.connection_close.error_code = error_code;
     fr.connection_close.reasonlen = 0;
@@ -2988,7 +2987,6 @@ ssize_t ngtcp2_conn_write_connection_close(ngtcp2_conn *conn, uint8_t *dest,
     if (nwrite > 0) {
       conn->state = NGTCP2_CS_CLOSE_WAIT;
     }
-
     break;
   default:
     return NGTCP2_ERR_INVALID_STATE;


### PR DESCRIPTION
When an example application exits, iterate over all client
and server connections and send a CONNECTION_CLOSE message
on each before cleaning up all resources.

This is only a simple initial implementation (Phase 1)
that will successfully close a small number of connections.
Phase 2 will deal with larger numbers of connections and
the load that closing these will place on a single UDP
socket.

----

Hello Tatsuhiro, this is only phase 1 of this feature.  It works, but
only for our simple example client and server applications.
A more complete solution (phase 2) will be submitted as a
future PR.

The reason why a phase 2 is needed is this: for an application
with more connections, for example a busy server, I predict
that sending a large number of CONNECTION_CLOSE
packets will cause the network layer tx buffer to fill up,
particularly if the application was busy just prior to shutdown.

When this happens, the `sendmsg` system call will probably
return `-1` with `errno` set to `EAGAIN`.  At this time we will
need to enter a final event loop, observing the write side ev_io
watcher (as well as a deadline timer), continue the cycle of:
`((UDP write)* + io_wait)*` until all connections are closed,
then exit, unless the deadline timeout is hit, then we just give
up.

So in phase 2, the connection close procedure will be split
into two phases: `disconnect`, `disconnect_continue` and
`close`.  Currently in phase 1, I have split: `disconnect` and
`close`, as an indicator of what I intend to do.

Sorry to be so quiet lately, I was on holiday.