### PR TITLE
Add packet send error checking and retry

### DIFF
--- a/examples/network.h
+++ b/examples/network.h
@@ -44,6 +44,12 @@
 
 namespace ngtcp2 {
 
+enum {
+  NETWORK_ERR_OK = 0,
+  NETWORK_ERR_SEND_FATAL = -10,
+  NETWORK_ERR_SEND_NON_FATAL = -11
+} network_error;
+
 union sockaddr_union {
   sockaddr_storage storage;
   sockaddr sa;


### PR DESCRIPTION
This patch represents phase 2 of the "Close all
connections on exit" feature, as well as including
a number of other benefits for both client and server:

- Packet writing is now moved to a function: send_packet
  this function will sense a number of different errors
  on the sendto system call, and categorise these as
  either fatal or non fatal (able to be retried).
  Non fatal errors will most likely be caused by the
  kernel tx queue being full, which means the packet
  should be writable at a later time.
  This code is loosely based on similar code in the
  Berkeley Internet Name Daemon (BIND), which I
  assume would know how to send UDP packets.
- Functions that write packets will observe the
  send_packet return value and if the network error is
  non fatal, the packet that was to be sent will be
  queued in the backend and write action on the
  socket file descriptor will be polled through the
  event reactor.
- When writes are once again possible on the socket,
  queued packets will be retried first, to preserve
  ordering at the send side, and only once these
  packets are all sent will the core library be queried
  for more new transport level and application level
  packets, which themselves may need to be queued.

----

Hello Tatsuhiro, this change is both a Phase 2 and a
Phase 1.  Firstly, it is a Phase 2 as it addresses the
issue of retrying packets when writes to the socket
fail in non-fatal ways, as I discussed in the previous
PR, however, it is also a Phase 1 because there is
much more to do at this level:  This PR uses a basic
queue to store packets, however I believe there is
much more information that we need to store along
with the queued packet data, and there are also some
changes that need to be made to the packet writing
process:

- I believe the packet header, and the pointer to the 
  ngtcp2_conn need to be stored in a struct along
  with the packet bytes.  In addition, there probably
  needs to be some kind of retry counter or timeout
  to fail a packet if it takes too long to send.
- Currently, when a packet is written, it is constructed
  using the ngtcp2_upe_final or ngtcp2_ppe_final
  function, then immediately following that, the rtb
  entry is created and stored.  Only after that does
  the function return so that the packet can be
  written to the UDP socket.  I believe that the order
  of these operations should be changed:
- The UDP write should be called after packet
  construction but before rtb registration.  This
  could be done as another ngtcp2_conn_callback:
  (write_pkt), and this is where the UDP packet will
  be written (like the send_packet function I added
  n this PR)
- If the return value of this write_pkt callback
  function is OK, then the core library will continue
  to create the rtb.  If there is a non-fatal error, the
  library will queue the packet and other information,
  but not create the rtb, as we have not written the
  UDP packet yet, therefore shouldn't start the
  timer for its ACK.

What this will achieve is: the movement of more
responsibility from the example applications and
into the core library (the transport layer), as I'm
sure you agree that the client and server examples
are doing a too much.  However, I didn't want to go
that far in this PR in order to keep the size of the
change under control.

Please let me know what you think.  Thanks!