### PR TITLE
prefer connect() + send() than sendto()

### DIFF
--- a/examples/client.cc
+++ b/examples/client.cc
@@ -473,6 +473,12 @@ int Client::init(int fd, const Address &remote_addr, const char *addr,
   fd_ = fd;
   datafd_ = datafd;
 
+
+  if (-1 == connect(fd_, &remote_addr_.su.sa, remote_addr_.len)) {
+    std::cerr << "connect: " << strerror(errno) << std::endl;
+    return -1;
+  }
+
   ssl_ = SSL_new(ssl_ctx_);
   auto bio = BIO_new(create_bio_method());
   BIO_set_data(bio, this);
@@ -866,12 +872,12 @@ int Client::send_packet() {
     return NETWORK_ERR_OK;
   }
 
+
   int eintr_retries = 5;
   ssize_t nwrite = 0;
 
   do {
-    nwrite = sendto(fd_, sendbuf_.rpos(), sendbuf_.size(), 0,
-                    &remote_addr_.su.sa, remote_addr_.len);
+    nwrite = send(fd_, sendbuf_.rpos(), sendbuf_.size(), 0);
   } while ((nwrite == -1) && (errno == EINTR) && (eintr_retries-- > 0));
 
   if (nwrite == -1) {
@@ -881,7 +887,7 @@ int Client::send_packet() {
     case 0:
       return NETWORK_ERR_SEND_NON_FATAL;
     default:
-      std::cerr << "sendto: " << strerror(errno) << std::endl;
+      std::cerr << "send: " << strerror(errno) << std::endl;
       return NETWORK_ERR_SEND_FATAL;
     }
   }


### PR DESCRIPTION
On Mac, sendto() may have a stricter implementation.
It can return `Socket is already connected` error.