### PR TITLE
Fix the recovery period

### DIFF
--- a/lib/ngtcp2_rtb.c
+++ b/lib/ngtcp2_rtb.c
@@ -505,7 +505,7 @@ void ngtcp2_rtb_detect_lost_pkt(ngtcp2_rtb *rtb, ngtcp2_rcvry_stat *rcs,
       /* OnPacketsLost in recovery draft */
       /* TODO I'm not sure we should do this for handshake packets. */
       if (!rtb_in_rcvry(rtb, ent->hd.pkt_num)) {
-        ccs->eor_pkt_num = ent->hd.pkt_num;
+        ccs->eor_pkt_num = last_tx_pkt_num;
         ccs->cwnd =
             (uint64_t)((double)ccs->cwnd * NGTCP2_LOSS_REDUCTION_FACTOR);
         ccs->cwnd = ngtcp2_max(rtb->ccs.cwnd, NGTCP2_MIN_CWND);


### PR DESCRIPTION
Spec 10
```
   OnPacketsLost(lost_packets):
     // Remove lost packets from bytes_in_flight.
     for (lost_packet : lost_packets):
       bytes_in_flight -= lost_packet.bytes
     largest_lost_packet = lost_packets.last()
     // Start a new recovery epoch if the lost packet is larger
     // than the end of the previous recovery epoch.
     if (!InRecovery(largest_lost_packet.packet_number)):
       end_of_recovery = largest_sent_packet
       congestion_window *= kLossReductionFactor
       congestion_window = max(congestion_window, kMinimumWindow)
       ssthresh = congestion_window
```

`end_of_recovery` should be last sent packet number. Otherwise will decrease the congestion window ,which caused by one network jitter, to a low value(decrease too many times).

logs
```
21554 I00001187 0xdbba100dfc696cc4 rcv reduce cwnd because of packet loss cwnd=1737915
21555 I00001187 0xdbba100dfc696cc4 frm 2634204974 rx S02(0x1e) MAX_DATA(0x04) max_data=24238583
21556 I00001187 0xdbba100dfc696cc4 frm 2634204974 rx S02(0x1e) MAX_STREAM_DATA(0x05) id=0x4 max_stream_data=13752823
21557 I00001187 0xdbba100dfc696cc4 con recv packet len=99
21558 I00001187 0xdbba100dfc696cc4 frm 2634204975 rx S02(0x1e) ACK(0x0e) largest_ack=3016995404 ack_delay=0(0) ack_block_count=24
21559 I00001187 0xdbba100dfc696cc4 frm 2634204975 rx S02(0x1e) ACK(0x0e) block=[3016995404..3016995403] block_count=1
21560 I00001187 0xdbba100dfc696cc4 frm 2634204975 rx S02(0x1e) ACK(0x0e) block=[3016995391..3016995388] gap=10 block_count=3
21561 I00001187 0xdbba100dfc696cc4 frm 2634204975 rx S02(0x1e) ACK(0x0e) block=[3016995372..3016995372] gap=14 block_count=0
21562 I00001187 0xdbba100dfc696cc4 frm 2634204975 rx S02(0x1e) ACK(0x0e) block=[3016995370..3016995369] gap=0 block_count=1
21563 I00001187 0xdbba100dfc696cc4 frm 2634204975 rx S02(0x1e) ACK(0x0e) block=[3016995343..3016995340] gap=24 block_count=3
21564 I00001187 0xdbba100dfc696cc4 frm 2634204975 rx S02(0x1e) ACK(0x0e) block=[3016995321..3016995320] gap=17 block_count=1
21565 I00001187 0xdbba100dfc696cc4 frm 2634204975 rx S02(0x1e) ACK(0x0e) block=[3016995305..3016995304] gap=13 block_count=1
21566 I00001187 0xdbba100dfc696cc4 frm 2634204975 rx S02(0x1e) ACK(0x0e) block=[3016995295..3016995292] gap=7 block_count=3
21567 I00001187 0xdbba100dfc696cc4 frm 2634204975 rx S02(0x1e) ACK(0x0e) block=[3016995273..3016995272] gap=17 block_count=1
21568 I00001187 0xdbba100dfc696cc4 frm 2634204975 rx S02(0x1e) ACK(0x0e) block=[3016995246..3016995245] gap=24 block_count=1
21569 I00001187 0xdbba100dfc696cc4 frm 2634204975 rx S02(0x1e) ACK(0x0e) block=[3016995239..3016995236] gap=4 block_count=3
21570 I00001187 0xdbba100dfc696cc4 frm 2634204975 rx S02(0x1e) ACK(0x0e) block=[3016995231..3016995230] gap=3 block_count=1
21571 I00001187 0xdbba100dfc696cc4 frm 2634204975 rx S02(0x1e) ACK(0x0e) block=[3016995221..3016995220] gap=7 block_count=1
21572 I00001187 0xdbba100dfc696cc4 frm 2634204975 rx S02(0x1e) ACK(0x0e) block=[3016995200..3016995197] gap=18 block_count=3
21573 I00001187 0xdbba100dfc696cc4 frm 2634204975 rx S02(0x1e) ACK(0x0e) block=[3016995178..3016995177] gap=17 block_count=1
21574 I00001187 0xdbba100dfc696cc4 frm 2634204975 rx S02(0x1e) ACK(0x0e) block=[3016995157..3016995156] gap=18 block_count=1
21575 I00001187 0xdbba100dfc696cc4 frm 2634204975 rx S02(0x1e) ACK(0x0e) block=[3016995152..3016995149] gap=2 block_count=3
21576 I00001187 0xdbba100dfc696cc4 frm 2634204975 rx S02(0x1e) ACK(0x0e) block=[3016995139..3016995138] gap=8 block_count=1
21577 I00001187 0xdbba100dfc696cc4 frm 2634204975 rx S02(0x1e) ACK(0x0e) block=[3016995093..3016995085] gap=43 block_count=8
21578 I00001187 0xdbba100dfc696cc4 frm 2634204975 rx S02(0x1e) ACK(0x0e) block=[3016995069..3016995060] gap=14 block_count=9
21579 I00001187 0xdbba100dfc696cc4 frm 2634204975 rx S02(0x1e) ACK(0x0e) block=[3016995056..3016995055] gap=2 block_count=1
21580 I00001187 0xdbba100dfc696cc4 frm 2634204975 rx S02(0x1e) ACK(0x0e) block=[3016995042..3016995041] gap=11 block_count=1
21581 I00001187 0xdbba100dfc696cc4 frm 2634204975 rx S02(0x1e) ACK(0x0e) block=[3016995034..3016995033] gap=5 block_count=1
21582 I00001187 0xdbba100dfc696cc4 frm 2634204975 rx S02(0x1e) ACK(0x0e) block=[3016995017..3016995010] gap=14 block_count=7
21583 I00001187 0xdbba100dfc696cc4 frm 2634204975 rx S02(0x1e) ACK(0x0e) block=[3016995007..3016994064] gap=1 block_count=943
21584 I00001187 0xdbba100dfc696cc4 rcv latest_rtt=182 min_rtt=102 smoothed_rtt=182.811 rttvar=0.009 max_ack_delay=0
21585 I00001187 0xdbba100dfc696cc4 rcv packet acked cwnd=1737916 bytes=860295
21586 I00001187 0xdbba100dfc696cc4 rcv reduce cwnd because of packet loss cwnd=868958
21587 I00001187 0xdbba100dfc696cc4 rcv packet lost 3016995400 sent_ts=1523328756703605248 unprotected=0
21588 I00001187 0xdbba100dfc696cc4 frm 2634204975 rx S02(0x1e) MAX_DATA(0x04) max_data=24238583
21589 I00001187 0xdbba100dfc696cc4 frm 2634204975 rx S02(0x1e) MAX_STREAM_DATA(0x05) id=0x4 max_stream_data=13752823
21590 I00001187 0xdbba100dfc696cc4 con recv packet len=101 
```