### PR TITLE
change NGTCP2_MAX_VARINT unsigned long to compile on 32bits

### DIFF
--- a/lib/ngtcp2_conn.c
+++ b/lib/ngtcp2_conn.c
@@ -5410,7 +5410,7 @@ int ngtcp2_conn_extend_max_stream_offset(ngtcp2_conn *conn, uint64_t stream_id,
 }
 
 void ngtcp2_conn_extend_max_offset(ngtcp2_conn *conn, size_t datalen) {
-  if (NGTCP2_MAX_VARINT < datalen ||
+  if (NGTCP2_MAX_VARINT < (uint64_t)datalen ||
       conn->unsent_max_rx_offset > NGTCP2_MAX_VARINT - datalen) {
     conn->unsent_max_rx_offset = NGTCP2_MAX_VARINT;
     return;

--- a/lib/ngtcp2_pkt.h
+++ b/lib/ngtcp2_pkt.h
@@ -61,7 +61,7 @@
 
 /* NGTCP2_MAX_VARINT is the maximum value which can be encoded in
    variable-length integer encoding */
-#define NGTCP2_MAX_VARINT ((1UL << 31) - 1)
+#define NGTCP2_MAX_VARINT ((1ULL << 62) - 1)
 
 /* NGTCP2_MAX_NUM_ACK_BLK is the maximum number of Additional ACK
    blocks which this library can create, or decode. */

--- a/lib/ngtcp2_pkt.h
+++ b/lib/ngtcp2_pkt.h
@@ -61,7 +61,7 @@
 
 /* NGTCP2_MAX_VARINT is the maximum value which can be encoded in
    variable-length integer encoding */
-#define NGTCP2_MAX_VARINT ((1ULL << 62) - 1)
+#define NGTCP2_MAX_VARINT ((1UL << 31) - 1)
 
 /* NGTCP2_MAX_NUM_ACK_BLK is the maximum number of Additional ACK
    blocks which this library can create, or decode. */


### PR DESCRIPTION
When compiles for 32 bits (iPhone 5 ), ['NGTCP2_MAX_VARINT < datalen'](https://github.com/ngtcp2/ngtcp2/blob/361c0accc2c6317226ce180f58ca446c363fdfdc/lib/ngtcp2_conn.c#L5490) would be evaluated as false as size_t is Long type on arm 32 bits architecture.
Changing NGTCP2_MAX_VARINT to Long type to be able to compile on both arm 32 bits and 64 bits.

```
void ngtcp2_conn_extend_max_offset(ngtcp2_conn *conn, size_t datalen) {
  if (NGTCP2_MAX_VARINT < datalen ||
      conn->unsent_max_rx_offset > NGTCP2_MAX_VARINT - datalen) {
    conn->unsent_max_rx_offset = NGTCP2_MAX_VARINT;
    return;
  }

  conn->unsent_max_rx_offset += datalen;
}
```