### PR TITLE
Add unordered_data flag at application level.

### DIFF
--- a/lib/includes/ngtcp2/ngtcp2.h
+++ b/lib/includes/ngtcp2/ngtcp2.h
@@ -503,6 +503,10 @@ typedef struct {
    ngtcp2_conn_server_new. */
 typedef void (*ngtcp2_printf)(void *user_data, const char *format, ...);
 
+typedef enum {
+  NGTCP2_SETTINGS_FLAG_UNORDERED_DATA = 0x1u
+} ngtcp2_settings_flags;
+
 typedef struct {
   ngtcp2_tstamp initial_ts;
   /* log_printf is a function that the library uses to write logs.
@@ -517,6 +521,7 @@ typedef struct {
   uint16_t max_packet_size;
   uint8_t stateless_reset_token[NGTCP2_STATELESS_RESET_TOKENLEN];
   uint8_t ack_delay_exponent;
+  ngtcp2_settings_flags flags;
 } ngtcp2_settings;
 
 /**

--- a/lib/ngtcp2_rob.h
+++ b/lib/ngtcp2_rob.h
@@ -168,6 +168,11 @@ int ngtcp2_rob_push(ngtcp2_rob *rob, uint64_t offset, const uint8_t *data,
 void ngtcp2_rob_remove_prefix(ngtcp2_rob *rob, uint64_t offset);
 
 /*
+ * ngtcp2_rob_remove_gap removes gap from |offset| for |datalen| bytes.
+ */
+void ngtcp2_rob_remove_gap(ngtcp2_rob *rob, uint64_t offset, size_t datalen);
+
+/*
  * ngtcp2_rob_data_at stores the pointer to the buffer of stream
  * offset |offset| to |*pdest| if it is available, and returns the
  * valid length of available data.  If no data is available, it

--- a/lib/ngtcp2_strm.h
+++ b/lib/ngtcp2_strm.h
@@ -57,6 +57,10 @@ typedef enum {
   /* NGTCP2_STRM_FLAG_STOP_SENDING indicates that STOP_SENDING is sent
      from the local endpoint. */
   NGTCP2_STRM_FLAG_STOP_SENDING = 0x10,
+  /* NGTCP2_STRM_FLAG_UNORDERED_DATA indicates that stream data should be
+   * returned to the application as soon as it is available, without reordering
+   * the data into sequence. */
+  NGTCP2_STRM_FLAG_UNORDERED_DATA = 0x20,
 } ngtcp2_strm_flags;
 
 struct ngtcp2_strm;


### PR DESCRIPTION
This adds an flag to the ngtcp2_settings to change the behaviour of ngtcp2 when it encounters reordered packets or packets following missing packets. When the flag is set it will return stream data to application immediately without waiting for the missing (or reordered) packets. This allows the application to process the stream data while the missing parts are being waited for. It also reduces the buffering overhead in ngtcp2 as no stream data needs to be buffered.

The patch maintains existing gaps/data records for the stream, but if the unordered_data flag is set then the actual data buffer stored is a NULL pointer and the data structure contains no data part to indicate that the data was not kept and has already been passed onto the application. These blocks can then be skipped when reassembling the stream.