### PR TITLE
examples: Support writing new keylog format

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -41,6 +41,7 @@ if(LIBEV_FOUND AND OPENSSL_FOUND)
     client.cc
     debug.cc
     util.cc
+    keylog.cc
     crypto_openssl.cc
     crypto.cc
   )
@@ -49,6 +50,7 @@ if(LIBEV_FOUND AND OPENSSL_FOUND)
     server.cc
     debug.cc
     util.cc
+    keylog.cc
     crypto_openssl.cc
     crypto.cc
     http.cc

--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -42,6 +42,7 @@ client_SOURCES = client.cc client.h \
 	template.h \
 	debug.cc debug.h \
 	util.cc util.h \
+	keylog.cc keylog.h \
 	shared.h \
 	crypto_openssl.cc \
 	crypto.cc
@@ -50,6 +51,7 @@ server_SOURCES = server.cc server.h \
 	template.h \
 	debug.cc debug.h \
 	util.cc util.h \
+	keylog.cc keylog.h \
 	shared.h \
 	crypto_openssl.cc \
 	crypto.cc \

--- a/examples/client.cc
+++ b/examples/client.cc
@@ -48,6 +48,7 @@
 #include "util.h"
 #include "crypto.h"
 #include "shared.h"
+#include "keylog.h"
 
 using namespace ngtcp2;
 
@@ -92,6 +93,8 @@ int key_cb(SSL *ssl, int name, const unsigned char *secret, size_t secretlen,
   if (c->on_key(name, secret, secretlen, key, keylen, iv, ivlen) != 0) {
     return 0;
   }
+
+  keylog::log_secret(ssl, name, secret, secretlen);
 
   return 1;
 }

--- a/examples/keylog.cc
+++ b/examples/keylog.cc
@@ -1,0 +1,69 @@
+/*
+ * ngtcp2
+ *
+ * Copyright (c) 2018 ngtcp2 contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+#include <string>
+
+#include "keylog.h"
+#include "util.h"
+
+namespace ngtcp2 {
+
+namespace keylog {
+
+void log_secret(SSL *ssl, int name, const unsigned char *secret,
+                size_t secretlen) {
+  if (auto keylog_cb = SSL_CTX_get_keylog_callback(SSL_get_SSL_CTX(ssl))) {
+    unsigned char crandom[32];
+    if (SSL_get_client_random(ssl, crandom, 32) != 32) {
+      return;
+    }
+    std::string line;
+    switch (name) {
+    case SSL_KEY_CLIENT_EARLY_TRAFFIC:
+      line = "QUIC_CLIENT_EARLY_TRAFFIC_SECRET";
+      break;
+    case SSL_KEY_CLIENT_HANDSHAKE_TRAFFIC:
+      line = "QUIC_CLIENT_HANDSHAKE_TRAFFIC_SECRET";
+      break;
+    case SSL_KEY_CLIENT_APPLICATION_TRAFFIC:
+      line = "QUIC_CLIENT_TRAFFIC_SECRET_0";
+      break;
+    case SSL_KEY_SERVER_HANDSHAKE_TRAFFIC:
+      line = "QUIC_SERVER_HANDSHAKE_TRAFFIC_SECRET";
+      break;
+    case SSL_KEY_SERVER_APPLICATION_TRAFFIC:
+      line = "QUIC_SERVER_TRAFFIC_SECRET_0";
+      break;
+    default:
+      return;
+    }
+    line += " " + util::format_hex(crandom, 32);
+    line += " " + util::format_hex(secret, secretlen);
+    keylog_cb(ssl, line.c_str());
+  }
+}
+
+} // namespace keylog
+
+} // namespace ngtcp2

--- a/examples/keylog.h
+++ b/examples/keylog.h
@@ -1,0 +1,47 @@
+/*
+ * ngtcp2
+ *
+ * Copyright (c) 2018 ngtcp2 contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+#ifndef KEYLOG_H
+#define KEYLOG_H
+
+#ifdef HAVE_CONFIG_H
+#  include <config.h>
+#endif // HAVE_CONFIG_H
+
+#include <ngtcp2/ngtcp2.h>
+
+#include <openssl/ssl.h>
+
+namespace ngtcp2 {
+
+namespace keylog {
+
+void log_secret(SSL *ssl, int name, const unsigned char *secret,
+                size_t secretlen);
+
+} // namespace keylog
+
+} // namespace ngtcp2
+
+#endif // KEYLOG_H

--- a/examples/server.cc
+++ b/examples/server.cc
@@ -48,6 +48,7 @@
 #include "crypto.h"
 #include "shared.h"
 #include "http.h"
+#include "keylog.h"
 
 using namespace ngtcp2;
 
@@ -83,6 +84,8 @@ int key_cb(SSL *ssl, int name, const unsigned char *secret, size_t secretlen,
   if (h->on_key(name, secret, secretlen, key, keylen, iv, ivlen) != 0) {
     return 0;
   }
+
+  keylog::log_secret(ssl, name, secret, secretlen);
 
   return 1;
 }


### PR DESCRIPTION
Since draft -13, the exporter secret has become useless for decryption.
While the client and server programs log appropriate secrets using the
"-s" option, let's make integration with Wireshark easier by including
the appropriate labels and identifier (client random).

The corresponding Wireshark patch that uses these secrets:
https://code.wireshark.org/review/29677
(tested with ngtcp2 master (draft -13) and draft-14)