### PR TITLE
Fix build failure for --disable-shared

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -119,6 +119,8 @@ fi
 
 AM_CONDITIONAL([HAVE_CUNIT], [ test "x${have_cunit}" = "xyes" ])
 
+AM_CONDITIONAL([ENABLE_SHARED], [ test "x${enable_shared}" = "xyes" ])
+
 # openssl (for examples)
 PKG_CHECK_MODULES([OPENSSL], [openssl >= 1.1.1],
                   [have_openssl=yes], [have_openssl=no])

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -70,7 +70,11 @@ main_SOURCES = $(HFILES) $(OBJECTS)
 
 # With static lib disabled and symbol hiding enabled, we have to link object
 # files directly because the tests use symbols not included in public API.
+if ENABLE_SHARED
 main_LDADD = ${top_builddir}/lib/.libs/*.o
+else
+main_LDADD = ${top_builddir}/lib/.libs/libngtcp2.la
+endif
 main_LDADD += @CUNIT_LIBS@
 main_LDFLAGS = -static
 


### PR DESCRIPTION
Currently, when configuring with --disable-shared the following error is
generated when running `make check`:
```console
make[2]: *** No rule to make target `../lib/.libs/*.o',
needed by `main'.  Stop.
make[2]: *** Waiting for unfinished jobs....
```
This commit adds a conditional for this case.