### PR TITLE
modify for FreeBSD

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -145,6 +145,7 @@ LIBS=$save_LIBS
 # Checks for header files.
 AC_CHECK_HEADERS([ \
   arpa/inet.h \
+  netinet/in.h \
   stddef.h \
   stdint.h \
   stdlib.h \

--- a/examples/crypto.cc
+++ b/examples/crypto.cc
@@ -36,12 +36,14 @@ namespace ngtcp2 {
 
 namespace crypto {
 
+#ifndef bswap64
 #ifdef WORDS_BIGENDIAN
 #  define bswap64(N) (N)
 #else /* !WORDS_BIGENDIAN */
 #  define bswap64(N)                                                           \
     ((uint64_t)(ntohl((uint32_t)(N))) << 32 | ntohl((uint32_t)((N) >> 32)))
 #endif /* !WORDS_BIGENDIAN */
+#endif
 
 int derive_initial_secret(uint8_t *dest, size_t destlen,
                           const ngtcp2_cid *secret, const uint8_t *salt,

--- a/examples/util.cc
+++ b/examples/util.cc
@@ -28,6 +28,9 @@
 #ifdef HAVE_ARPA_INET_H
 #  include <arpa/inet.h>
 #endif // HAVE_ARPA_INET_H
+#ifdef HAVE_NETINET_IN_H
+#  include <netinet/in.h>
+#endif
 #include <netdb.h>
 
 #include <cassert>


### PR DESCRIPTION
For using in6_addr structure in IPv6 protocl stack  KAME project, add netinet/in.h header in util.cc . And for privent for conflict with bswap64 which defined in OS header, add #ifndef in crypto.cc.