### PR TITLE
add error argument in `nghttp3_conn_close_stream`

### DIFF
--- a/examples/client.cc
+++ b/examples/client.cc
@@ -2164,7 +2164,7 @@ int Client::on_stream_close(int64_t stream_id) {
   }
 
   if (httpconn_) {
-    auto rv = nghttp3_conn_close_stream(httpconn_, stream_id);
+    auto rv = nghttp3_conn_close_stream(httpconn_, stream_id, 0);
     if (rv != 0) {
       std::cerr << "nghttp3_conn_close_stream: " << nghttp3_strerror(rv)
                 << std::endl;

--- a/examples/server.cc
+++ b/examples/server.cc
@@ -2583,7 +2583,7 @@ int Handler::on_stream_close(int64_t stream_id) {
   assert(it != std::end(streams_));
 
   if (httpconn_) {
-    auto rv = nghttp3_conn_close_stream(httpconn_, stream_id);
+    auto rv = nghttp3_conn_close_stream(httpconn_, stream_id, 0);
     if (rv != 0) {
       std::cerr << "nghttp3_conn_close_stream: " << nghttp3_strerror(rv)
                 << std::endl;


### PR DESCRIPTION
the current call to  `nghttp3_conn_close_stream` isn't compatible with the definition in nghttp3.
