### PR TITLE
Add `ngtcp2_conn_get_aead_overhead`.

### DIFF
--- a/lib/includes/ngtcp2/ngtcp2.h
+++ b/lib/includes/ngtcp2/ngtcp2.h
@@ -1747,6 +1747,15 @@ NGTCP2_EXTERN void ngtcp2_conn_set_aead_overhead(ngtcp2_conn *conn,
 /**
  * @function
  *
+ * `ngtcp2_conn_get_aead_overhead` returns the aead overhead passed to
+ * `ngtcp2_conn_set_aead_overhead`. If `ngtcp2_conn_set_aead_overhead` hasn't
+ * been called yet this function returns 0.
+ */
+NGTCP2_EXTERN size_t ngtcp2_conn_get_aead_overhead(ngtcp2_conn *conn);
+
+/**
+ * @function
+ *
  * `ngtcp2_conn_install_early_rx_keys` installs packet protection key
  * |key| of length |keylen| and IV |iv| of length |ivlen|, and packet
  * header protection key |hp| of length |hplen| to encrypt or decrypt

--- a/lib/ngtcp2_conn.c
+++ b/lib/ngtcp2_conn.c
@@ -7297,6 +7297,10 @@ void ngtcp2_conn_set_aead_overhead(ngtcp2_conn *conn, size_t aead_overhead) {
   conn->crypto.aead_overhead = aead_overhead;
 }
 
+size_t ngtcp2_conn_get_aead_overhead(ngtcp2_conn *conn) {
+  return conn->crypto.aead_overhead;
+}
+
 int ngtcp2_conn_install_initial_tx_keys(ngtcp2_conn *conn, const uint8_t *key,
                                         size_t keylen, const uint8_t *iv,
                                         size_t ivlen, const uint8_t *pn,


### PR DESCRIPTION
Allows retrieving the aead overhead passed with `ngtcp2_conn_set_aead_overhead`.