### PR TITLE
Add functions to open user requested streams.

### DIFF
--- a/examples/client.cc
+++ b/examples/client.cc
@@ -2080,7 +2080,7 @@ void Client::make_stream_early() {
   ++nstreams_done_;
 
   int64_t stream_id;
-  rv = ngtcp2_conn_open_bidi_stream(conn_, &stream_id, nullptr);
+  rv = ngtcp2_conn_open_next_bidi_stream(conn_, &stream_id, nullptr);
   if (rv != 0) {
     std::cerr << "ngtcp2_conn_open_bidi_stream: " << ngtcp2_strerror(rv)
               << std::endl;
@@ -2109,7 +2109,7 @@ int Client::on_extend_max_streams() {
   }
 
   for (; nstreams_done_ < config.nstreams; ++nstreams_done_) {
-    rv = ngtcp2_conn_open_bidi_stream(conn_, &stream_id, nullptr);
+    rv = ngtcp2_conn_open_next_bidi_stream(conn_, &stream_id, nullptr);
     if (rv != 0) {
       assert(NGTCP2_ERR_STREAM_ID_BLOCKED == rv);
       break;
@@ -2515,7 +2515,7 @@ int Client::setup_httpconn() {
 
   int64_t ctrl_stream_id;
 
-  rv = ngtcp2_conn_open_uni_stream(conn_, &ctrl_stream_id, NULL);
+  rv = ngtcp2_conn_open_next_uni_stream(conn_, &ctrl_stream_id, NULL);
   if (rv != 0) {
     std::cerr << "ngtcp2_conn_open_uni_stream: " << ngtcp2_strerror(rv)
               << std::endl;
@@ -2535,14 +2535,14 @@ int Client::setup_httpconn() {
 
   int64_t qpack_enc_stream_id, qpack_dec_stream_id;
 
-  rv = ngtcp2_conn_open_uni_stream(conn_, &qpack_enc_stream_id, NULL);
+  rv = ngtcp2_conn_open_next_uni_stream(conn_, &qpack_enc_stream_id, NULL);
   if (rv != 0) {
     std::cerr << "ngtcp2_conn_open_uni_stream: " << ngtcp2_strerror(rv)
               << std::endl;
     return -1;
   }
 
-  rv = ngtcp2_conn_open_uni_stream(conn_, &qpack_dec_stream_id, NULL);
+  rv = ngtcp2_conn_open_next_uni_stream(conn_, &qpack_dec_stream_id, NULL);
   if (rv != 0) {
     std::cerr << "ngtcp2_conn_open_uni_stream: " << ngtcp2_strerror(rv)
               << std::endl;

--- a/examples/server.cc
+++ b/examples/server.cc
@@ -1149,7 +1149,7 @@ int Handler::push_content(int64_t stream_id, const std::string &authority,
   }
 
   int64_t push_stream_id;
-  rv = ngtcp2_conn_open_uni_stream(conn_, &push_stream_id, NULL);
+  rv = ngtcp2_conn_open_next_uni_stream(conn_, &push_stream_id, NULL);
   if (rv != 0) {
     std::cerr << "ngtcp2_conn_open_uni_stream: " << ngtcp2_strerror(rv)
               << std::endl;
@@ -1474,7 +1474,7 @@ int Handler::setup_httpconn() {
 
   int64_t ctrl_stream_id;
 
-  rv = ngtcp2_conn_open_uni_stream(conn_, &ctrl_stream_id, NULL);
+  rv = ngtcp2_conn_open_next_uni_stream(conn_, &ctrl_stream_id, NULL);
   if (rv != 0) {
     std::cerr << "ngtcp2_conn_open_uni_stream: " << ngtcp2_strerror(rv)
               << std::endl;
@@ -1494,14 +1494,14 @@ int Handler::setup_httpconn() {
 
   int64_t qpack_enc_stream_id, qpack_dec_stream_id;
 
-  rv = ngtcp2_conn_open_uni_stream(conn_, &qpack_enc_stream_id, NULL);
+  rv = ngtcp2_conn_open_next_uni_stream(conn_, &qpack_enc_stream_id, NULL);
   if (rv != 0) {
     std::cerr << "ngtcp2_conn_open_uni_stream: " << ngtcp2_strerror(rv)
               << std::endl;
     return -1;
   }
 
-  rv = ngtcp2_conn_open_uni_stream(conn_, &qpack_dec_stream_id, NULL);
+  rv = ngtcp2_conn_open_next_uni_stream(conn_, &qpack_dec_stream_id, NULL);
   if (rv != 0) {
     std::cerr << "ngtcp2_conn_open_uni_stream: " << ngtcp2_strerror(rv)
               << std::endl;

--- a/lib/includes/ngtcp2/ngtcp2.h
+++ b/lib/includes/ngtcp2/ngtcp2.h
@@ -2059,9 +2059,8 @@ ngtcp2_conn_get_local_transport_params(ngtcp2_conn *conn,
 /**
  * @function
  *
- * `ngtcp2_conn_open_bidi_stream` opens new bidirectional stream.  The
- * |stream_user_data| is the user data specific to the stream.  The
- * open stream ID is stored in |*pstream_id|.
+ * `ngtcp2_conn_open_bidi_stream` opens new bidirectional stream with id
+ * |stream_id|.  The |stream_user_data| is the user data specific to the stream.
  *
  * This function returns 0 if it succeeds, or one of the following
  * negative error codes:
@@ -2070,15 +2069,19 @@ ngtcp2_conn_get_local_transport_params(ngtcp2_conn *conn,
  *     Out of memory
  * :enum:`NGTCP2_ERR_STREAM_ID_BLOCKED`
  *     The remote peer does not allow |stream_id| yet.
+ * :enum:`NGTCP2_ERR_STREAM_IN_USE`
+ *     The stream has already been opened.
+ * :enum:`NGTCP2_ERR_INVALID_ARGUMENT`
+ *     The stream id is not a valid bidirectional stream id.
  */
 NGTCP2_EXTERN int ngtcp2_conn_open_bidi_stream(ngtcp2_conn *conn,
-                                               int64_t *pstream_id,
+                                               int64_t stream_id,
                                                void *stream_user_data);
 
 /**
  * @function
  *
- * `ngtcp2_conn_open_uni_stream` opens new unidirectional stream.  The
+ * `ngtcp2_conn_open_next_bidi_stream` opens new bidirectional stream.  The
  * |stream_user_data| is the user data specific to the stream.  The
  * open stream ID is stored in |*pstream_id|.
  *
@@ -2090,9 +2093,50 @@ NGTCP2_EXTERN int ngtcp2_conn_open_bidi_stream(ngtcp2_conn *conn,
  * :enum:`NGTCP2_ERR_STREAM_ID_BLOCKED`
  *     The remote peer does not allow |stream_id| yet.
  */
+NGTCP2_EXTERN int ngtcp2_conn_open_next_bidi_stream(ngtcp2_conn *conn,
+                                                    int64_t *pstream_id,
+                                                    void *stream_user_data);
+
+/**
+ * @function
+ *
+ * `ngtcp2_conn_open_uni_stream` opens new unidirectional stream with id
+ * |stream_id|.  The |stream_user_data| is the user data specific to the stream.
+ *
+ * This function returns 0 if it succeeds, or one of the following
+ * negative error codes:
+ *
+ * :enum:`NGTCP2_ERR_NOMEM`
+ *     Out of memory
+ * :enum:`NGTCP2_ERR_STREAM_ID_BLOCKED`
+ *     The remote peer does not allow |stream_id| yet.
+ * :enum:`NGTCP2_ERR_STREAM_IN_USE`
+ *     The stream has already been opened.
+ * :enum:`NGTCP2_ERR_INVALID_ARGUMENT`
+ *     The stream id is not a valid unidirectional stream id.
+ */
 NGTCP2_EXTERN int ngtcp2_conn_open_uni_stream(ngtcp2_conn *conn,
-                                              int64_t *pstream_id,
+                                              int64_t stream_id,
                                               void *stream_user_data);
+
+/**
+ * @function
+ *
+ * `ngtcp2_conn_open_next_uni_stream` opens new unidirectional stream.  The
+ * |stream_user_data| is the user data specific to the stream.  The
+ * open stream ID is stored in |*pstream_id|.
+ *
+ * This function returns 0 if it succeeds, or one of the following
+ * negative error codes:
+ *
+ * :enum:`NGTCP2_ERR_NOMEM`
+ *     Out of memory
+ * :enum:`NGTCP2_ERR_STREAM_ID_BLOCKED`
+ *     The remote peer does not allow |stream_id| yet.
+ */
+NGTCP2_EXTERN int ngtcp2_conn_open_next_uni_stream(ngtcp2_conn *conn,
+                                                   int64_t *pstream_id,
+                                                   void *stream_user_data);
 
 /**
  * @function


### PR DESCRIPTION
The current stream functions were repurposed to open a given stream id.
This is useful for independent HTTP/3 stacks that assign stream ids
themselves.

Two new functions `ngtcp2_conn_open_next_uni_stream` and
`ngtcp2_conn_open_next_bidi_stream` were added to open the next
available stream. These preserve the old functionality of the
original functions.

If a stream id higher than the next stream id is opened, the next stream
id is increased so that opening the next stream never tries to open an
already open stream.