### PR TITLE
Add struct tags for structs used in callbacks.

### DIFF
--- a/examples/client.cc
+++ b/examples/client.cc
@@ -2111,8 +2111,7 @@ int Client::on_extend_max_streams() {
   for (; nstreams_done_ < config.nstreams; ++nstreams_done_) {
     rv = ngtcp2_conn_open_bidi_stream(conn_, &stream_id, nullptr);
     if (rv != 0) {
-      assert(NGTCP2_ERR_STREAM_ID_BLOCKED == rv);
-      break;
+      return -1;
     }
 
     if (submit_http_request(stream_id) != 0) {

--- a/examples/server.cc
+++ b/examples/server.cc
@@ -1153,10 +1153,7 @@ int Handler::push_content(int64_t stream_id, const std::string &authority,
   if (rv != 0) {
     std::cerr << "ngtcp2_conn_open_uni_stream: " << ngtcp2_strerror(rv)
               << std::endl;
-    if (rv != NGTCP2_ERR_STREAM_ID_BLOCKED) {
-      return -1;
-    }
-    return 0;
+    return -1;
   }
 
   if (!config.quiet) {

--- a/lib/includes/ngtcp2/ngtcp2.h
+++ b/lib/includes/ngtcp2/ngtcp2.h
@@ -355,7 +355,7 @@ typedef uint64_t ngtcp2_duration;
  *
  * ngtcp2_cid holds a Connection ID.
  */
-typedef struct {
+typedef struct ngtcp2_cid {
   size_t datalen;
   uint8_t data[NGTCP2_MAX_CIDLEN];
 } ngtcp2_cid;
@@ -385,7 +385,7 @@ typedef struct {
 NGTCP2_EXTERN void ngtcp2_cid_init(ngtcp2_cid *cid, const uint8_t *data,
                                    size_t datalen);
 
-typedef struct {
+typedef struct ngtcp2_pkt_hd {
   ngtcp2_cid dcid;
   ngtcp2_cid scid;
   int64_t pkt_num;
@@ -405,13 +405,13 @@ typedef struct {
   uint8_t flags;
 } ngtcp2_pkt_hd;
 
-typedef struct {
+typedef struct ngtcp2_pkt_stateless_reset {
   const uint8_t *stateless_reset_token;
   const uint8_t *rand;
   size_t randlen;
 } ngtcp2_pkt_stateless_reset;
 
-typedef struct {
+typedef struct ngtcp2_pkt_retry {
   ngtcp2_cid odcid;
   const uint8_t *token;
   size_t tokenlen;
@@ -663,7 +663,7 @@ typedef enum ngtcp2_rand_ctx {
  */
 #define NGTCP2_TLSEXT_QUIC_TRANSPORT_PARAMETERS 0xffa5u
 
-typedef struct {
+typedef struct ngtcp2_preferred_addr {
   ngtcp2_cid cid;
   uint16_t ipv4_port;
   uint16_t ipv6_port;
@@ -752,7 +752,7 @@ typedef struct {
  *
  * ngtcp2_addr is the endpoint address.
  */
-typedef struct {
+typedef struct ngtcp2_addr {
   /* len is the length of addr. */
   size_t addrlen;
   /* addr points to the buffer which contains endpoint address.  It is
@@ -768,7 +768,7 @@ typedef struct {
  * ngtcp2_path is the network endpoints where a packet is sent and
  * received.
  */
-typedef struct {
+typedef struct ngtcp2_path {
   /* local is the address of local endpoint. */
   ngtcp2_addr local;
   /* remote is the address of remote endpoint. */

--- a/tests/ngtcp2_conn_test.c
+++ b/tests/ngtcp2_conn_test.c
@@ -692,10 +692,6 @@ void test_ngtcp2_conn_stream_open_close(void) {
   CU_ASSERT(0 == rv);
   CU_ASSERT(3 == stream_id);
 
-  rv = ngtcp2_conn_open_uni_stream(conn, &stream_id, NULL);
-
-  CU_ASSERT(NGTCP2_ERR_STREAM_ID_BLOCKED == rv);
-
   ngtcp2_conn_del(conn);
 }
 
@@ -3822,6 +3818,18 @@ void test_ngtcp2_conn_writev_stream(void) {
   CU_ASSERT(1200 == spktlen);
 
   ngtcp2_conn_del(conn);
+
+  setup_default_client(&conn);
+  conn->local.bidi.max_streams = 0;
+
+  rv = ngtcp2_conn_open_bidi_stream(conn, &stream_id, NULL);
+
+  CU_ASSERT(0 == rv);
+
+  rv = ngtcp2_conn_writev_stream(conn, NULL, NULL, 0, NULL, 0, stream_id, 0,
+                                 NULL, 0, 0);
+
+  CU_ASSERT(NGTCP2_ERR_STREAM_ID_BLOCKED == rv);
 }
 
 void test_ngtcp2_conn_recv_new_connection_id(void) {


### PR DESCRIPTION
This allows them to be forward declared. Typedefed anonymous structs
cannot be forward declared without a tag.