### PR TITLE
Allow creating streams with ids exceeding the max amount of streams.

### DIFF
--- a/examples/client.cc
+++ b/examples/client.cc
@@ -2111,8 +2111,7 @@ int Client::on_extend_max_streams() {
   for (; nstreams_done_ < config.nstreams; ++nstreams_done_) {
     rv = ngtcp2_conn_open_bidi_stream(conn_, &stream_id, nullptr);
     if (rv != 0) {
-      assert(NGTCP2_ERR_STREAM_ID_BLOCKED == rv);
-      break;
+      return -1;
     }
 
     if (submit_http_request(stream_id) != 0) {

--- a/examples/server.cc
+++ b/examples/server.cc
@@ -1153,10 +1153,7 @@ int Handler::push_content(int64_t stream_id, const std::string &authority,
   if (rv != 0) {
     std::cerr << "ngtcp2_conn_open_uni_stream: " << ngtcp2_strerror(rv)
               << std::endl;
-    if (rv != NGTCP2_ERR_STREAM_ID_BLOCKED) {
-      return -1;
-    }
-    return 0;
+    return -1;
   }
 
   if (!config.quiet) {

--- a/lib/includes/ngtcp2/ngtcp2.h
+++ b/lib/includes/ngtcp2/ngtcp2.h
@@ -2104,8 +2104,6 @@ ngtcp2_conn_get_local_transport_params(ngtcp2_conn *conn,
  *
  * :enum:`NGTCP2_ERR_NOMEM`
  *     Out of memory
- * :enum:`NGTCP2_ERR_STREAM_ID_BLOCKED`
- *     The remote peer does not allow |stream_id| yet.
  */
 NGTCP2_EXTERN int ngtcp2_conn_open_bidi_stream(ngtcp2_conn *conn,
                                                int64_t *pstream_id,
@@ -2123,8 +2121,6 @@ NGTCP2_EXTERN int ngtcp2_conn_open_bidi_stream(ngtcp2_conn *conn,
  *
  * :enum:`NGTCP2_ERR_NOMEM`
  *     Out of memory
- * :enum:`NGTCP2_ERR_STREAM_ID_BLOCKED`
- *     The remote peer does not allow |stream_id| yet.
  */
 NGTCP2_EXTERN int ngtcp2_conn_open_uni_stream(ngtcp2_conn *conn,
                                               int64_t *pstream_id,
@@ -2307,6 +2303,8 @@ NGTCP2_EXTERN ssize_t ngtcp2_conn_write_stream(
  *
  * :enum:`NGTCP2_ERR_NOMEM`
  *     Out of memory
+ * :enum:`NGTCP2_ERR_STREAM_ID_BLOCKED`
+ *     The remote peer does not allow |stream_id| yet.
  * :enum:`NGTCP2_ERR_STREAM_NOT_FOUND`
  *     Stream does not exist
  * :enum:`NGTCP2_ERR_STREAM_SHUT_WR`

--- a/tests/ngtcp2_conn_test.c
+++ b/tests/ngtcp2_conn_test.c
@@ -692,10 +692,6 @@ void test_ngtcp2_conn_stream_open_close(void) {
   CU_ASSERT(0 == rv);
   CU_ASSERT(3 == stream_id);
 
-  rv = ngtcp2_conn_open_uni_stream(conn, &stream_id, NULL);
-
-  CU_ASSERT(NGTCP2_ERR_STREAM_ID_BLOCKED == rv);
-
   ngtcp2_conn_del(conn);
 }
 
@@ -3820,6 +3816,20 @@ void test_ngtcp2_conn_writev_stream(void) {
 
   /* Make sure that packet is padded */
   CU_ASSERT(1200 == spktlen);
+
+  ngtcp2_conn_del(conn);
+
+  setup_default_client(&conn);
+  conn->local.bidi.max_streams = 0;
+
+  rv = ngtcp2_conn_open_bidi_stream(conn, &stream_id, NULL);
+
+  CU_ASSERT(0 == rv);
+
+  spktlen = ngtcp2_conn_writev_stream(conn, NULL, NULL, 0, NULL, 0,
+                                              stream_id, 0, NULL, 0, 0);
+
+  CU_ASSERT(NGTCP2_ERR_STREAM_ID_BLOCKED == spktlen);
 
   ngtcp2_conn_del(conn);
 }


### PR DESCRIPTION
This allows users to acquire stream ids during setup instead of having
to wait for the handshake to complete which can vastly simplify their
code.

The `STREAM_ID_BLOCKED` check was moved to `ngtcp2_conn_writev_stream`
which does not allow writing to a stream until its id is unblocked.