### PR TITLE
build: Only build examples if nghttp3 is present

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -132,6 +132,7 @@ PKG_CHECK_MODULES([LIBNGHTTP3], [libnghttp3 >= 0.0.0],
 if test "${have_libnghttp3}" = "xno"; then
   AC_MSG_NOTICE($LIBNGHTTP3_PKG_ERRORS)
 fi
+AM_CONDITIONAL([HAVE_NGHTTP3], [ test "x${have_libnghttp3}" = "xyes" ])
 
 # libev (for examples)
 # libev does not have pkg-config file.  Check it in an old way.
@@ -325,6 +326,8 @@ AC_MSG_NOTICE([summary of build options:
     Library:
       Shared:         ${enable_shared}
       Static:         ${enable_static}
+    Examples:
+      nghttp3:        ${have_libnghttp3}
     Test:
       CUnit:          ${have_cunit} (CFLAGS='${CUNIT_CFLAGS}' LIBS='${CUNIT_LIBS}')
     Debug:

--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -38,7 +38,9 @@ LDADD = $(top_builddir)/lib/libngtcp2.la \
 	@LIBEV_LIBS@ \
 	@LIBNGHTTP3_LIBS@
 
+if HAVE_NGHTTP3
 noinst_PROGRAMS = client server
+endif
 
 client_SOURCES = client.cc client.h \
 	template.h \


### PR DESCRIPTION
This isn't critical to the installation of the core library, so don't force
users to have nghttp3 available.