### PR TITLE
use SSL_set_max_early_data

### DIFF
--- a/examples/client.cc
+++ b/examples/client.cc
@@ -770,7 +770,7 @@ int Client::init_ssl() {
           resumption_ = true;
 
           if (SSL_SESSION_get_max_early_data(session)) {
-            SSL_set_quic_early_data_enabled(ssl_, 1);
+            SSL_set_max_early_data(ssl_, std::numeric_limits<uint32_t>::max());
           }
         }
         SSL_SESSION_free(session);

--- a/examples/server.cc
+++ b/examples/server.cc
@@ -1341,7 +1341,7 @@ int Handler::init(const Endpoint &ep, const sockaddr *sa, socklen_t salen,
   ssl_ = SSL_new(ssl_ctx_);
   SSL_set_app_data(ssl_, this);
   SSL_set_accept_state(ssl_);
-  SSL_set_quic_early_data_enabled(ssl_, 1);
+  SSL_set_max_early_data(ssl_, std::numeric_limits<uint32_t>::max());
 
   auto callbacks = ngtcp2_conn_callbacks{
       nullptr, // client_initial


### PR DESCRIPTION
This commit attempts to fix the two following compilation errors:
```console
client.cc:773:13:
error: use of undeclared identifier 'SSL_set_quic_early_data_enabled'
            SSL_set_quic_early_data_enabled(ssl_, 1);
            ^
1 error generated.

server.cc:1344:3:
error: use of undeclared identifier 'SSL_set_quic_early_data_enabled'
  SSL_set_quic_early_data_enabled(ssl_, 1);
  ^
1 error generated.
```
This error is generated if one uses https://github.com/openssl/openssl/pull/8797. This can be reproduced by
with the following steps:
```console
$ cd ../openssl
$ git remote add upstream https://github.com/openssl/openssl.git
$ git fetch upstream master
$ git co -b pr8797
$ curl -L https://github.com/openssl/openssl/pull/8797.patch | git am
$ ./config enable-tls1_3 --prefix=$PWD/build
$ make -j8
$ make -j8 check
$ make install_sw
```
I'm using that PR as I was getting the same compilation error as reported in https://github.com/ngtcp2/ngtcp2/issues/149.

I realise that this will probably be fixed later when the above PR is
merged but this helped me compile and test successfully and might help
others.