### PR TITLE
Remove chunk comment from ngtcp2_idtr_init

### DIFF
--- a/lib/ngtcp2_idtr.h
+++ b/lib/ngtcp2_idtr.h
@@ -47,8 +47,7 @@ typedef struct {
 } ngtcp2_idtr;
 
 /*
- * ngtcp2_idtr_init initializes |idtr|.  |chunk| is the size of buffer
- * per chunk.
+ * ngtcp2_idtr_init initializes |idtr|.
  *
  * If this object records server initiated ID (even number), set
  * |server| to nonzero.


### PR DESCRIPTION
This commit removes the comment for a `chunk` argument for
`ngtcp2_idtr_init` as it does not seem to be relative to this function
declaration.