### PR TITLE
Remove template from HTTPHeader constructor

### DIFF
--- a/examples/server.h
+++ b/examples/server.h
@@ -116,8 +116,8 @@ struct Buffer {
 };
 
 struct HTTPHeader {
-  template <typename T1, typename T2>
-  HTTPHeader(const T1 &name, const T2 &value) : name(name), value(value) {}
+  HTTPHeader(const std::string &name, const std::string &value)
+      : name(name), value(value) {}
 
   std::string name;
   std::string value;


### PR DESCRIPTION
Currently, the HTTPHeader constructor is templated with the types for
the header name and the value, but the actual name and value members are
of std::string type. It is currently not possible to have a different
type for the value for example.

This commit suggests removing the template for the constructor and
making the parameters to to be of type std::string instead.  I'd be
happy to look at a templated version but was not sure if it was worth
the effort as this is "just" in an example.