### PR TITLE
ngtcp2_crypto: add support for additional handshake err codes

### DIFF
--- a/crypto/includes/ngtcp2/ngtcp2_crypto.h
+++ b/crypto/includes/ngtcp2/ngtcp2_crypto.h
@@ -35,6 +35,15 @@ extern "C" {
 #define NGTCP2_CRYPTO_INITIAL_KEYLEN 16
 #define NGTCP2_CRYPTO_INITIAL_IVLEN 12
 
+#if defined(__cplusplus) && __cplusplus >= 201103L
+typedef enum ngtcp2_crypto_lib_error : int {
+#else
+typedef enum ngtcp2_crypto_lib_error {
+#endif
+  NGTCP2_CRYPTO_ERR_TLS_WANT_X509_LOOKUP = -301,
+  NGTCP2_CRYPTO_ERR_TLS_WANT_CLIENT_HELLO_CB = -302,
+} ngtcp2_crypto_lib_error;
+
 /**
  * @function
  *

--- a/crypto/openssl/openssl.c
+++ b/crypto/openssl/openssl.c
@@ -318,6 +318,10 @@ int ngtcp2_crypto_read_write_crypto_data(ngtcp2_conn *conn, void *tls,
       case SSL_ERROR_WANT_READ:
       case SSL_ERROR_WANT_WRITE:
         return 0;
+      case SSL_ERROR_WANT_CLIENT_HELLO_CB:
+        return NGTCP2_CRYPTO_ERR_TLS_WANT_CLIENT_HELLO_CB;
+      case SSL_ERROR_WANT_X509_LOOKUP:
+        return NGTCP2_CRYPTO_ERR_TLS_WANT_X509_LOOKUP;
       case SSL_ERROR_SSL:
         return -1;
       default:


### PR DESCRIPTION
When SSL_dl_handshake() returns either an SSL_ERROR_WANT_CLIENT_HELLO_CB
or SSL_ERROR_WANT_X509_LOOKUP, return specific error codes rather than
-1 so that those conditions can be differentiated and handled
appropriately
