### PR TITLE
Correct addrlen comment for ngtcp_addr struct

### DIFF
--- a/lib/includes/ngtcp2/ngtcp2.h
+++ b/lib/includes/ngtcp2/ngtcp2.h
@@ -553,7 +553,7 @@ typedef struct ngtcp2_rcvry_stat {
  * ngtcp2_addr is the endpoint address.
  */
 typedef struct ngtcp2_addr {
-  /* len is the length of addr. */
+  /* addrlen is the length of addr. */
   size_t addrlen;
   /* addr points to the buffer which contains endpoint address.  It is
      opaque to the ngtcp2 library. */


### PR DESCRIPTION
This commit updates the comment for the addrlen to match the field
name change made in Commit 26440b084538f2c194057681e1031d7030937600 ("Rename len to addrlen").