### PR TITLE
Make HTTPHeader struct templated

### DIFF
--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -61,7 +61,8 @@ server_SOURCES = server.cc server.h \
 if HAVE_CUNIT
 check_PROGRAMS = examplestest
 examplestest_SOURCES = examplestest.cc \
-	util_test.cc util_test.h util.cc util.h
+	util_test.cc util_test.h util.cc util.h \
+	server_test.cc server_test.h server.h
 examplestest_LDADD = ${LDADD} @CUNIT_LIBS@
 
 TESTS = examplestest

--- a/examples/examplestest.cc
+++ b/examples/examplestest.cc
@@ -32,6 +32,7 @@
 #include <CUnit/Basic.h>
 // include test cases' include files here
 #include "util_test.h"
+#include "server_test.h"
 
 static int init_suite1(void) { return 0; }
 
@@ -54,7 +55,9 @@ int main(int argc, char *argv[]) {
 
   // add the tests to the suite
   if (!CU_add_test(pSuite, "util_format_duration",
-                   ngtcp2::test_util_format_duration)) {
+                   ngtcp2::test_util_format_duration) ||
+      !CU_add_test(pSuite, "structserver_httpheader_struct",
+                   ngtcp2::test_server_httpheader_struct)) {
     CU_cleanup_registry();
     return CU_get_error();
   }

--- a/examples/server.cc
+++ b/examples/server.cc
@@ -402,8 +402,8 @@ void Stream::http_acked_stream_data(size_t datalen) {
 }
 
 int Stream::send_status_response(nghttp3_conn *httpconn,
-                                 unsigned int status_code,
-                                 const std::vector<HTTPHeader> &extra_headers) {
+    unsigned int status_code,
+    const std::vector<HTTPHeaderStr> &extra_headers) {
   status_resp_body = make_status_body(status_code);
 
   auto status_code_str = std::to_string(status_code);

--- a/examples/server.h
+++ b/examples/server.h
@@ -117,13 +117,15 @@ struct Buffer {
   uint8_t *tail;
 };
 
+template <typename T1, typename T2>
 struct HTTPHeader {
-  template <typename T1, typename T2>
   HTTPHeader(const T1 &name, const T2 &value) : name(name), value(value) {}
 
-  std::string name;
-  std::string value;
+  T1 name;
+  T2 value;
 };
+
+using HTTPHeaderStr = HTTPHeader<std::string, std::string>;
 
 class Handler;
 
@@ -136,7 +138,7 @@ struct Stream {
   int open_file(const std::string &path);
   int map_file(size_t len);
   int send_status_response(nghttp3_conn *conn, unsigned int status_code,
-                           const std::vector<HTTPHeader> &extra_headers = {});
+      const std::vector<HTTPHeaderStr> &extra_headers = {});
   int send_redirect_response(nghttp3_conn *conn, unsigned int status_code,
                              const std::string &path);
   int64_t find_dyn_length(const std::string &path);

--- a/examples/server_test.cc
+++ b/examples/server_test.cc
@@ -1,0 +1,43 @@
+/*
+ * ngtcp2
+ *
+ * Copyright (c) 2018 ngtcp2 contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+#include "server_test.h"
+
+#include <CUnit/CUnit.h>
+
+#include "server.h"
+#include <string>
+
+namespace ngtcp2 {
+
+void test_server_httpheader_struct() {
+  HTTPHeader<std::string, std::string> str_header = {"key", "value"};
+  CU_ASSERT_EQUAL("key", str_header.name);
+  CU_ASSERT_EQUAL("value", str_header.value);
+
+  HTTPHeader<std::string, int> int_header = {"key", 18};
+  CU_ASSERT_EQUAL(18, int_header.value);
+}
+
+} // namespace ngtcp2

--- a/examples/server_test.h
+++ b/examples/server_test.h
@@ -1,0 +1,38 @@
+/*
+ * ngtcp2
+ *
+ * Copyright (c) 2018 ngtcp2 contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+#ifndef SERVER_TEST_H
+#define SERVER_TEST_H
+
+#ifdef HAVE_CONFIG_H
+#  include "config.h"
+#endif // HAVE_CONFIG_H
+
+namespace ngtcp2 {
+
+void test_server_httpheader_struct();
+
+} // namespace ngtcp2
+
+#endif // SERVER_TEST_H


### PR DESCRIPTION
Currently, the HTTPHeader constructor is templated with the types for
the header name and the value, but the actual name and value members are
of std::string type. It is currently not possible to have a different
type for the value for example.

This commit suggests making the struct templated to allow for values
other than std::string. I'm not sure if that is the way to go or perhaps
it would be acceptable to only allow std::string values, but wanted to
open this up for feedback.