### PR TITLE
Remove client -i --interactive option from README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -98,8 +98,6 @@ The notable options are:
 
 - ``-d``, ``--data=<PATH>``: Read data from <PATH> and send it to a
   peer.
-- ``-i``, ``--interactive``: Read data from terminal and send it to a
-  peer interactively.  This does not work with 0-RTT.  See below.
 
 Server
 ~~~~~~


### PR DESCRIPTION
This commit removes the `-i, --interactive` option for the client example
which was removed in Commit 9ea17af6ef48281d015a73ce46d6689b2255a037 ("h3 client and server").