### PR TITLE
Use OpenSSL return values for client_hello_cb

### DIFF
--- a/examples/server.cc
+++ b/examples/server.cc
@@ -2857,10 +2857,10 @@ int client_hello_cb(SSL *ssl, int *al, void *arg) {
   if (!SSL_client_hello_get0_ext(ssl, NGTCP2_TLSEXT_QUIC_TRANSPORT_PARAMETERS,
                                  &tp, &tplen)) {
     *al = SSL_AD_INTERNAL_ERROR;
-    return 0;
+    return SSL_CLIENT_HELLO_ERROR;
   }
 
-  return 1;
+  return SSL_CLIENT_HELLO_SUCCESS;
 }
 } // namespace
 


### PR DESCRIPTION
This commit updates the `client_hello_cb` to use return values specified
in [SSL_CTX_set_client_hello_cb](https://www.openssl.org/docs/man1.1.1/man3/SSL_CTX_set_client_hello_cb.html).