### PR TITLE
Remove unused parts of Buffer in example

### DIFF
--- a/examples/client.cc
+++ b/examples/client.cc
@@ -67,11 +67,8 @@ Buffer::Buffer(const uint8_t *data, size_t datalen)
       begin(buf.data()),
       head(begin),
       tail(begin + datalen) {}
-Buffer::Buffer(uint8_t *begin, uint8_t *end)
-    : begin(begin), head(begin), tail(end) {}
 Buffer::Buffer(size_t datalen)
     : buf(datalen), begin(buf.data()), head(begin), tail(begin) {}
-Buffer::Buffer() : begin(buf.data()), head(begin), tail(begin) {}
 
 Stream::Stream(const Request &req, int64_t stream_id)
     : req(req), stream_id(stream_id), fd(-1) {}

--- a/examples/client.h
+++ b/examples/client.h
@@ -118,15 +118,12 @@ struct Config {
 
 struct Buffer {
   Buffer(const uint8_t *data, size_t datalen);
-  Buffer(uint8_t *begin, uint8_t *end);
   explicit Buffer(size_t datalen);
-  Buffer();
 
   size_t size() const { return tail - head; }
   size_t left() const { return buf.data() + buf.size() - tail; }
   uint8_t *const wpos() { return tail; }
   const uint8_t *rpos() const { return head; }
-  void seek(size_t len) { head += len; }
   void push(size_t len) { tail += len; }
   void reset() {
     head = begin;

--- a/examples/server.cc
+++ b/examples/server.cc
@@ -78,11 +78,8 @@ Buffer::Buffer(const uint8_t *data, size_t datalen)
       begin(buf.data()),
       head(begin),
       tail(begin + datalen) {}
-Buffer::Buffer(uint8_t *begin, uint8_t *end)
-    : begin(begin), head(begin), tail(end) {}
 Buffer::Buffer(size_t datalen)
     : buf(datalen), begin(buf.data()), head(begin), tail(begin) {}
-Buffer::Buffer() : begin(buf.data()), head(begin), tail(begin) {}
 
 int Handler::on_key(ngtcp2_crypto_level level, const uint8_t *rx_secret,
                     const uint8_t *tx_secret, size_t secretlen) {

--- a/examples/server.h
+++ b/examples/server.h
@@ -93,15 +93,12 @@ struct Config {
 
 struct Buffer {
   Buffer(const uint8_t *data, size_t datalen);
-  Buffer(uint8_t *begin, uint8_t *end);
   explicit Buffer(size_t datalen);
-  Buffer();
 
   size_t size() const { return tail - head; }
   size_t left() const { return buf.data() + buf.size() - tail; }
   uint8_t *const wpos() { return tail; }
   const uint8_t *rpos() const { return head; }
-  void seek(size_t len) { head += len; }
   void push(size_t len) { tail += len; }
   void reset() { head = tail = begin; }
   size_t bufsize() const { return tail - begin; }


### PR DESCRIPTION
A subsequent PR can further simplify `Buffer` as `begin` is now always equal to `head` and `size()` is always equal to `bufsize()`.