### PR TITLE
Remove unused ngtcp2_macro include in ngtcp2_qlog

### DIFF
--- a/lib/ngtcp2_qlog.c
+++ b/lib/ngtcp2_qlog.c
@@ -28,7 +28,6 @@
 
 #include "ngtcp2_str.h"
 #include "ngtcp2_vec.h"
-#include "ngtcp2_macro.h"
 
 void ngtcp2_qlog_init(ngtcp2_qlog *qlog, ngtcp2_qlog_write write,
                       ngtcp2_tstamp ts, void *user_data) {


### PR DESCRIPTION
This commit removes the include of `ngtcp2_macro.h` as it does not seem to
be used.