### PR TITLE
Remove redundant Buffer::head

### DIFF
--- a/examples/client.cc
+++ b/examples/client.cc
@@ -65,10 +65,8 @@ Config config{};
 Buffer::Buffer(const uint8_t *data, size_t datalen)
     : buf{data, data + datalen},
       begin(buf.data()),
-      head(begin),
       tail(begin + datalen) {}
-Buffer::Buffer(size_t datalen)
-    : buf(datalen), begin(buf.data()), head(begin), tail(begin) {}
+Buffer::Buffer(size_t datalen) : buf(datalen), begin(buf.data()), tail(begin) {}
 
 Stream::Stream(const Request &req, int64_t stream_id)
     : req(req), stream_id(stream_id), fd(-1) {}

--- a/examples/client.h
+++ b/examples/client.h
@@ -120,13 +120,12 @@ struct Buffer {
   Buffer(const uint8_t *data, size_t datalen);
   explicit Buffer(size_t datalen);
 
-  size_t size() const { return tail - head; }
+  size_t size() const { return tail - begin; }
   size_t left() const { return buf.data() + buf.size() - tail; }
   uint8_t *const wpos() { return tail; }
-  const uint8_t *rpos() const { return head; }
+  const uint8_t *rpos() const { return begin; }
   void push(size_t len) { tail += len; }
   void reset() {
-    head = begin;
     tail = begin;
   }
   size_t bufsize() const { return tail - begin; }
@@ -136,9 +135,6 @@ struct Buffer {
   // buf.data() if a buffer space is allocated by this object.  It is
   // also allowed to point to the external shared buffer.
   uint8_t *begin;
-  // head points to the position of the buffer where read should
-  // occur.
-  uint8_t *head;
   // tail points to the position of the buffer where write should
   // occur.
   uint8_t *tail;

--- a/examples/server.cc
+++ b/examples/server.cc
@@ -76,10 +76,8 @@ Config config{};
 Buffer::Buffer(const uint8_t *data, size_t datalen)
     : buf{data, data + datalen},
       begin(buf.data()),
-      head(begin),
       tail(begin + datalen) {}
-Buffer::Buffer(size_t datalen)
-    : buf(datalen), begin(buf.data()), head(begin), tail(begin) {}
+Buffer::Buffer(size_t datalen) : buf(datalen), begin(buf.data()), tail(begin) {}
 
 int Handler::on_key(ngtcp2_crypto_level level, const uint8_t *rx_secret,
                     const uint8_t *tx_secret, size_t secretlen) {

--- a/examples/server.h
+++ b/examples/server.h
@@ -95,12 +95,12 @@ struct Buffer {
   Buffer(const uint8_t *data, size_t datalen);
   explicit Buffer(size_t datalen);
 
-  size_t size() const { return tail - head; }
+  size_t size() const { return tail - begin; }
   size_t left() const { return buf.data() + buf.size() - tail; }
   uint8_t *const wpos() { return tail; }
-  const uint8_t *rpos() const { return head; }
+  const uint8_t *rpos() const { return begin; }
   void push(size_t len) { tail += len; }
-  void reset() { head = tail = begin; }
+  void reset() { tail = begin; }
   size_t bufsize() const { return tail - begin; }
 
   std::vector<uint8_t> buf;
@@ -108,9 +108,6 @@ struct Buffer {
   // buf.data() if a buffer space is allocated by this object.  It is
   // also allowed to point to the external shared buffer.
   uint8_t *begin;
-  // head points to the position of the buffer where read should
-  // occur.
-  uint8_t *head;
   // tail points to the position of the buffer where write should
   // occur.
   uint8_t *tail;


### PR DESCRIPTION
After removing `Buffer::seek`, `head` always equals `begin`. A subsequent diff can further simplify Buffer by removing bufsize(), which is now identical to size().