### PR TITLE
Move ngtcp2_range.h into ngtcp2_gaptr.c

### DIFF
--- a/lib/ngtcp2_gaptr.c
+++ b/lib/ngtcp2_gaptr.c
@@ -23,6 +23,7 @@
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 #include "ngtcp2_gaptr.h"
+#include "ngtcp2_range.h"
 
 #include <string.h>
 #include <assert.h>

--- a/lib/ngtcp2_gaptr.h
+++ b/lib/ngtcp2_gaptr.h
@@ -32,7 +32,6 @@
 #include <ngtcp2/ngtcp2.h>
 
 #include "ngtcp2_mem.h"
-#include "ngtcp2_range.h"
 #include "ngtcp2_ksl.h"
 
 /*


### PR DESCRIPTION
The header `ngtcp2_gaptr.h` does not use anything from `ngtcp2_range.h` and
this commit suggests moving the include to `ngtcp2_gaptr.c` instead.