### PR TITLE
Move template.h include to client.cc

### DIFF
--- a/examples/client.cc
+++ b/examples/client.cc
@@ -50,6 +50,7 @@
 #include "debug.h"
 #include "util.h"
 #include "shared.h"
+#include "template.h"
 #include "keylog.h"
 
 using namespace ngtcp2;

--- a/examples/client.h
+++ b/examples/client.h
@@ -42,7 +42,6 @@
 #include <ev.h>
 
 #include "network.h"
-#include "template.h"
 #include "shared.h"
 
 using namespace ngtcp2;


### PR DESCRIPTION
This commit moves the include of `template.h` into `client.cc` as it does
not seem to be used any longer by `client.h`.

Commit a7d6c8c44ce5304c4983d0cc276dd2e6b47f3c1c ("Addngtcp2_acked_stream_data_offset callback")
removed the field streambuf_ which was using the user-defined literal `_k` from template.h:
```c
std::array<uint8_t, 32_k> streambuf_;
```