### PR TITLE
Use TLS_client_method and TLS_server_method

### DIFF
--- a/examples/client.cc
+++ b/examples/client.cc
@@ -2166,7 +2166,7 @@ auto quic_method = SSL_QUIC_METHOD{
 
 namespace {
 SSL_CTX *create_ssl_ctx(const char *private_key_file, const char *cert_file) {
-  auto ssl_ctx = SSL_CTX_new(TLS_method());
+  auto ssl_ctx = SSL_CTX_new(TLS_client_method());
 
   SSL_CTX_set_min_proto_version(ssl_ctx, TLS1_3_VERSION);
   SSL_CTX_set_max_proto_version(ssl_ctx, TLS1_3_VERSION);

--- a/examples/server.cc
+++ b/examples/server.cc
@@ -2876,7 +2876,7 @@ namespace {
 SSL_CTX *create_ssl_ctx(const char *private_key_file, const char *cert_file) {
   constexpr static unsigned char sid_ctx[] = "ngtcp2 server";
 
-  auto ssl_ctx = SSL_CTX_new(TLS_method());
+  auto ssl_ctx = SSL_CTX_new(TLS_server_method());
 
   constexpr auto ssl_opts = (SSL_OP_ALL & ~SSL_OP_DONT_INSERT_EMPTY_FRAGMENTS) |
                             SSL_OP_SINGLE_ECDH_USE |


### PR DESCRIPTION
This commit changes the TLS_method() used by the client and server to
use more specific TLS_client_method() and TLS_server_method().

The main difference between these two are ossl_statem_accept is
undefined for the client, and ossl_statem_connect is undefined for the
server:
```
IMPLEMENT_tls_meth_func(TLS_ANY_VERSION, 0, 0,
                        TLS_server_method,
                        ossl_statem_accept,
                        ssl_undefined_function, TLSv1_2_enc_data)

IMPLEMENT_tls_meth_func(TLS_ANY_VERSION, 0, 0,
                        TLS_client_method,
                        ssl_undefined_function,
                        ossl_statem_connect, TLSv1_2_enc_data)
```
ossl_statem_accept and ossl_statem_connect are defined like this:
```c
int ossl_statem_accept(SSL *s) {
    return state_machine(s, 1);
}
int ossl_statem_connect(SSL *s) {
    return state_machine(s, 0);
}
```
So they are both calling state_machine but with setting the server
parameter to 1 and 0 (for the client).

The functions ossl_statem_accept and ossl_statem_connect are only usedin
ssl/statem/statem_lib.c as far as I can tell. The tls_finish_handshake
function has the following if statement:
```c
if (s->server) {
  ...
  s->handshake_func = ossl_statem_accept;
} else {
  ...
  s->handshake_func = ossl_statem_connect;
}
```
So for a server, s->handshake_func would be ossl_statem_accept which just
calls state_machine(s, 1), and or a client it would be
ossl_statem_connect which calls state_machine(s, 0).

So it looks like setting both, as in using TLS_method(), is not
neccessary and it should be safe to use TLS_client_method(),
TLS_server_method() instead.