### PR TITLE
Fix definition of ssize_t in CMake for 64-bit builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,8 +108,8 @@ include(CheckTypeSize)
 check_type_size("ssize_t" SIZEOF_SSIZE_T)
 if(SIZEOF_SSIZE_T STREQUAL "")
   # ssize_t is a signed type in POSIX storing at least -1.
-  # Set it to "int" to match the behavior of AC_TYPE_SSIZE_T (autotools).
-  set(ssize_t int)
+  # Set it to a pointer-size int.
+  set(ssize_t ptrdiff_t)
 endif()
 
 # Checks for symbols.


### PR DESCRIPTION
When using `CMake` to build ngtcp2, the definition of `ssize_t` is incorrect for 64-bit builds. It's defined as an `int`, which at least on Windows is a 32-bit type.

What this means is that any ngtcp2 function that returns an error code ends up returning a bit pattern that, on 64-bit builds, is interpreted by the caller as a _large positive number_ instead of a _small negative number_. That's because the caller (e.g. libcurl) will probably have a different definition of `ssize_t`, one that is correctly sized as a signed 64-bit integer, not a signed 32-bit integer.

Here's an example of the assembly code currently generated for ngtcp2 on 64-bit Windows for `conn_write_pkt`:

```
      return NGTCP2_ERR_WRITE_STREAM_MORE;
00007FF76790FEBE  mov         eax,0FFFFFF10h  
```

That instruction is only writing to the bottom half of the 64-bit `rax` register (with the top half being all zeroes), so the resulting 64-bit integer is 4294967056, instead of -240.

Here is that same code when built with the changes in this PR:

```
      return NGTCP2_ERR_WRITE_STREAM_MORE;
00007FF7902CFFB1  mov         rax,0FFFFFFFFFFFFFF10h  
```

That is now properly returning the 64-bit value -240.