### PR TITLE
Fix use of uninitialized data in tests

### DIFF
--- a/tests/ngtcp2_test_helper.c
+++ b/tests/ngtcp2_test_helper.c
@@ -99,6 +99,7 @@ static int null_encrypt(ngtcp2_conn *conn, uint8_t *dest,
   (void)ad;
   (void)adlen;
   (void)user_data;
+  memset(dest + plaintextlen, 0, conn->crypto.aead_overhead);
   return 0;
 }
 


### PR DESCRIPTION
write_single_frame_pkt() returns a packet length greater than the number of bytes it writes to the buffer. The returned length reflects a fake AEAD overhead, while this extra overhead is never written. As a result, ngtcp2_verify_stateless_reset_token() uses initialized data when reading the end of the packet. This causes noise when using a memory sanitizer.