### PR TITLE
Avoid use-after-free if key update is initiated while ppe is pending

### DIFF
--- a/lib/ngtcp2_conn.c
+++ b/lib/ngtcp2_conn.c
@@ -5893,6 +5893,7 @@ static void conn_rotate_keys(ngtcp2_conn *conn, int64_t pkt_num) {
   assert(conn->crypto.key_update.new_rx_ckm);
   assert(conn->crypto.key_update.new_tx_ckm);
   assert(!conn->crypto.key_update.old_rx_ckm);
+  assert(!(conn->flags & NGTCP2_CONN_FLAG_PPE_PENDING));
 
   conn->crypto.key_update.old_rx_ckm = pktns->crypto.rx.ckm;
 


### PR DESCRIPTION
conn_rotate_keys() frees conn->pktns->crypto.tx.ckm. If there is a pending ppe, the ppe object still holds a reference to the freed memory and will eventually try to use it in ngtcp2_ppe_final().