### PR TITLE
Fix example server's write callback never being called

### DIFF
--- a/examples/server.cc
+++ b/examples/server.cc
@@ -1474,6 +1474,7 @@ int Handler::init(const Endpoint &ep, const sockaddr *sa, socklen_t salen,
     return -1;
   }
 
+  ev_io_set(&wev_, endpoint_->fd, EV_WRITE);
   ev_timer_again(loop_, &timer_);
 
   return 0;


### PR DESCRIPTION
Handler::wev_ is initialized with a file descriptor set to 0. ev_io_set() is never called for this watcher, so its file descriptor remains 0 and all calls to ev_io_start() have no effect. As a result writecb() is never called.

There may still be an issue due to all endpoints sharing the same watcher, but this is mostly orthogonal to the problem fixed here.