### PR TITLE
Make ngtcp2_pkt_write_stateless_reset use const for input

### DIFF
--- a/lib/includes/ngtcp2/ngtcp2.h
+++ b/lib/includes/ngtcp2/ngtcp2.h
@@ -835,8 +835,8 @@ NGTCP2_EXTERN ngtcp2_ssize ngtcp2_pkt_decode_hd_short(ngtcp2_pkt_hd *dest,
  *     :macro:`NGTCP2_MIN_STATELESS_RETRY_RANDLEN`.
  */
 NGTCP2_EXTERN ngtcp2_ssize ngtcp2_pkt_write_stateless_reset(
-    uint8_t *dest, size_t destlen, uint8_t *stateless_reset_token,
-    uint8_t *rand, size_t randlen);
+    uint8_t *dest, size_t destlen, const uint8_t *stateless_reset_token,
+    const uint8_t *rand, size_t randlen);
 
 /**
  * @function

--- a/lib/ngtcp2_pkt.c
+++ b/lib/ngtcp2_pkt.c
@@ -2017,9 +2017,10 @@ int ngtcp2_pkt_validate_ack(ngtcp2_ack *fr) {
   return 0;
 }
 
-ngtcp2_ssize ngtcp2_pkt_write_stateless_reset(uint8_t *dest, size_t destlen,
-                                              uint8_t *stateless_reset_token,
-                                              uint8_t *rand, size_t randlen) {
+ngtcp2_ssize
+ngtcp2_pkt_write_stateless_reset(uint8_t *dest, size_t destlen,
+                                 const uint8_t *stateless_reset_token,
+                                 const uint8_t *rand, size_t randlen) {
   uint8_t *p;
 
   if (destlen <


### PR DESCRIPTION
These two input buffers are not modified as part of the function
and can/should thus be `const`.