### PR TITLE
Remove redundant Buffer::begin

### DIFF
--- a/examples/client.cc
+++ b/examples/client.cc
@@ -64,8 +64,8 @@ Config config{};
 } // namespace
 
 Buffer::Buffer(const uint8_t *data, size_t datalen)
-    : buf{data, data + datalen}, begin(buf.data()), tail(begin + datalen) {}
-Buffer::Buffer(size_t datalen) : buf(datalen), begin(buf.data()), tail(begin) {}
+    : buf{data, data + datalen}, tail(buf.data() + datalen) {}
+Buffer::Buffer(size_t datalen) : buf(datalen), tail(buf.data()) {}
 
 Stream::Stream(const Request &req, int64_t stream_id)
     : req(req), stream_id(stream_id), fd(-1) {}

--- a/examples/client.h
+++ b/examples/client.h
@@ -149,18 +149,14 @@ struct Buffer {
   Buffer(const uint8_t *data, size_t datalen);
   explicit Buffer(size_t datalen);
 
-  size_t size() const { return tail - begin; }
+  size_t size() const { return tail - buf.data(); }
   size_t left() const { return buf.data() + buf.size() - tail; }
   uint8_t *const wpos() { return tail; }
-  const uint8_t *rpos() const { return begin; }
+  const uint8_t *rpos() const { return buf.data(); }
   void push(size_t len) { tail += len; }
-  void reset() { tail = begin; }
+  void reset() { tail = buf.data(); }
 
   std::vector<uint8_t> buf;
-  // begin points to the beginning of the buffer.  This might point to
-  // buf.data() if a buffer space is allocated by this object.  It is
-  // also allowed to point to the external shared buffer.
-  uint8_t *begin;
   // tail points to the position of the buffer where write should
   // occur.
   uint8_t *tail;


### PR DESCRIPTION
It always equals to buf.data().