### PR TITLE
Not sending ack frames that acknowledge no blocks.

### DIFF
--- a/lib/ngtcp2_conn.c
+++ b/lib/ngtcp2_conn.c
@@ -1022,7 +1022,10 @@ static int conn_create_ack_frame(ngtcp2_conn *conn, ngtcp2_frame **pfr,
     ngtcp2_acktr_forget(acktr, ngtcp2_ksl_it_get(&it));
   }
 
-  *pfr = conn->tx.ack;
+  // Avoid sending ack frames without any ack ranges
+  if (ack->num_blks > 0) {
+    *pfr = conn->tx.ack;
+  }
 
   return 0;
 }


### PR DESCRIPTION
Current implementation of ngtcp2_conn will send ack frames even when there are no ranges to acknowledge. This causes ngtcp2 to send empty ack frames. 

This diff treats an ACK frame with an empty ACK range as "no packets to acknowledge": 
- *pfr is untouched.
- the function returns zero.
