### PR TITLE
Fix coalesced 0-RTT ACK packet with short header packet

### DIFF
--- a/lib/ngtcp2_conn.c
+++ b/lib/ngtcp2_conn.c
@@ -1993,17 +1993,6 @@ static ngtcp2_ssize conn_write_server_handshake(ngtcp2_conn *conn,
   dest += nwrite;
   destlen -= (size_t)nwrite;
 
-  /* Acknowledge 0-RTT packet here. */
-  if (conn->pktns.crypto.tx.ckm) {
-    nwrite = conn_write_ack_pkt(conn, dest, destlen, NGTCP2_PKT_SHORT, ts);
-    if (nwrite < 0) {
-      assert(nwrite != NGTCP2_ERR_NOBUF);
-      return nwrite;
-    }
-
-    res += nwrite;
-  }
-
   return res;
 }
 
@@ -7423,18 +7412,6 @@ static ngtcp2_ssize conn_write_handshake(ngtcp2_conn *conn, uint8_t *dest,
         res += nwrite;
         dest += nwrite;
         origlen -= (size_t)nwrite;
-
-        /* Acknowledge 0-RTT packet here. */
-        if (conn->pktns.crypto.tx.ckm) {
-          nwrite =
-              conn_write_ack_pkt(conn, dest, origlen, NGTCP2_PKT_SHORT, ts);
-          if (nwrite < 0) {
-            assert(nwrite != NGTCP2_ERR_NOBUF);
-            return nwrite;
-          }
-
-          res += nwrite;
-        }
       }
 
       conn->hs_sent += (size_t)res;


### PR DESCRIPTION
Sometimes the ACK to 0-RTT packet is coalesced with other short header packet. In ngtcp2_conn_writev_stream, if server has not received ClientFinish, it will invoke ngtcp2_conn_write_handshake. And inside that function, it tries to write ACK to 0-RTT packet as pure ACK packet. After returning from ngtcp2_conn_write_handshake, writev_stream can write more stream data as another QUIC packet. These 2 QUIC packets will then be coalesced into one UDP packet.
Removing this 2 blocks seems working, as ngtcp2_conn_writev_stream will also check if ACK needs to be written. It'll then contain the ACK frame in the following short header packet (previously coalesced with) instead of having ACK as a separate QUIC packet.