### PR TITLE
Fix format specifier in log_fr_connection_close()

### DIFF
--- a/lib/ngtcp2_log.c
+++ b/lib/ngtcp2_log.c
@@ -270,7 +270,7 @@ static void log_fr_connection_close(ngtcp2_log *log, const ngtcp2_pkt_hd *hd,
   log->log_printf(log->user_data,
                   (NGTCP2_LOG_PKT
                    " CONNECTION_CLOSE(0x%02x) error_code=%s(0x%" PRIx64 ") "
-                   "frame_type=%" PRIx64 " reason_len=%" PRIu64 " reason=[%s]"),
+                   "frame_type=%" PRIx64 " reason_len=%zu reason=[%s]"),
                   NGTCP2_LOG_FRM_HD_FIELDS(dir), fr->type,
                   fr->type == NGTCP2_FRAME_CONNECTION_CLOSE
                       ? strerrorcode(fr->error_code)


### PR DESCRIPTION
ngtcp2_connection_close.reason_len is size_t, which is not necessarily 64-bit.