### PR TITLE
Remove unused errno.h include from ngtcp2_log

### DIFF
--- a/lib/ngtcp2_log.c
+++ b/lib/ngtcp2_log.c
@@ -29,7 +29,6 @@
 #  include <unistd.h>
 #endif
 #include <assert.h>
-#include <errno.h>
 #include <string.h>
 
 #include "ngtcp2_str.h"


### PR DESCRIPTION
Commit 0999d327a1511acdc3fed93d2c6d040b5256dbad ("Pass user-defined printf function rather than passing file descriptor") removed the usage of errno so it does not need to be included.