### PR TITLE
Fix static library builds, clarify shared libs situation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -313,6 +313,8 @@ message(STATUS "summary of build options:
       CXXFLAGS:       ${CMAKE_CXX_FLAGS_${_build_type}} ${CMAKE_CXX_FLAGS}
       WARNCFLAGS:     ${WARNCFLAGS}
       WARNCXXFLAGS:   ${WARNCXXFLAGS}
+    Library:
+      Shared:         ${BUILD_SHARED_LIBS}
     Test:
       CUnit:          ${HAVE_CUNIT} (LIBS='${CUNIT_LIBRARIES}')
     Libs:

--- a/CMakeOptions.txt
+++ b/CMakeOptions.txt
@@ -1,5 +1,7 @@
 # Features that can be enabled for cmake (see CMakeLists.txt)
 
+option(BUILD_SHARED_LIBS "Build using shared libraries" OFF)
+
 option(ENABLE_WERROR    "Make compiler warnings fatal" OFF)
 option(ENABLE_DEBUG     "Turn on debug output" OFF)
 option(ENABLE_ASAN      "Enable AddressSanitizer (ASAN)" OFF)

--- a/crypto/gnutls/CMakeLists.txt
+++ b/crypto/gnutls/CMakeLists.txt
@@ -47,6 +47,7 @@ set_target_properties(ngtcp2_crypto_gnutls PROPERTIES
   COMPILE_FLAGS "${WARNCFLAGS}"
   VERSION ${LT_VERSION} SOVERSION ${LT_SOVERSION}
   C_VISIBILITY_PRESET hidden
+  POSITION_INDEPENDENT_CODE ON
 )
 
 target_include_directories(ngtcp2_crypto_gnutls PUBLIC

--- a/crypto/gnutls/CMakeLists.txt
+++ b/crypto/gnutls/CMakeLists.txt
@@ -41,7 +41,7 @@ foreach(name libngtcp2_crypto_gnutls.pc)
   configure_file("${name}.in" "${name}" @ONLY)
 endforeach()
 
-# Public shared library
+# Public shared or static library
 add_library(ngtcp2_crypto_gnutls ${ngtcp2_crypto_gnutls_SOURCES})
 set_target_properties(ngtcp2_crypto_gnutls PROPERTIES
   COMPILE_FLAGS "${WARNCFLAGS}"

--- a/crypto/openssl/CMakeLists.txt
+++ b/crypto/openssl/CMakeLists.txt
@@ -41,7 +41,7 @@ foreach(name libngtcp2_crypto_openssl.pc)
   configure_file("${name}.in" "${name}" @ONLY)
 endforeach()
 
-# Public shared library
+# Public shared or static library
 add_library(ngtcp2_crypto_openssl ${ngtcp2_crypto_openssl_SOURCES})
 set_target_properties(ngtcp2_crypto_openssl PROPERTIES
   COMPILE_FLAGS "${WARNCFLAGS}"

--- a/crypto/openssl/CMakeLists.txt
+++ b/crypto/openssl/CMakeLists.txt
@@ -47,6 +47,7 @@ set_target_properties(ngtcp2_crypto_openssl PROPERTIES
   COMPILE_FLAGS "${WARNCFLAGS}"
   VERSION ${LT_VERSION} SOVERSION ${LT_SOVERSION}
   C_VISIBILITY_PRESET hidden
+  POSITION_INDEPENDENT_CODE ON
 )
 
 target_include_directories(ngtcp2_crypto_openssl PUBLIC

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -70,6 +70,7 @@ set_target_properties(ngtcp2 PROPERTIES
   COMPILE_FLAGS "${WARNCFLAGS}"
   VERSION ${LT_VERSION} SOVERSION ${LT_SOVERSION}
   C_VISIBILITY_PRESET hidden
+  POSITION_INDEPENDENT_CODE ON
 )
 
 target_include_directories(ngtcp2 PUBLIC ${ngtcp2_INCLUDE_DIRS})

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -64,7 +64,7 @@ set(ngtcp2_INCLUDE_DIRS
   "${CMAKE_CURRENT_BINARY_DIR}/includes"
 )
 
-# Public shared library
+# Public shared or static library
 add_library(ngtcp2 ${ngtcp2_SOURCES})
 set_target_properties(ngtcp2 PROPERTIES
   COMPILE_FLAGS "${WARNCFLAGS}"
@@ -79,7 +79,7 @@ if(NOT BUILD_SHARED_LIBS)
 endif()
 
 if(HAVE_CUNIT)
-  # Static library (for unittests because of symbol visibility)
+  # Private static library (for unittests because of symbol visibility)
   add_library(ngtcp2_static STATIC ${ngtcp2_SOURCES})
   set_target_properties(ngtcp2_static PROPERTIES
     COMPILE_FLAGS "${WARNCFLAGS}"


### PR DESCRIPTION
A functional fix and a documentation fix:

* CMake: ensure libs are built position-independent

  Static libraries have to be built as position-independent, otherwise
  they cannot be linked into a shared library which is built
  position-independent (-fPIC).

  Without this, linking objects into libcurl.so fails with:

      /usr/bin/ld: libngtcp2.a(ngtcp2_conn.c.o): relocation R_X86_64_PC32 against symbol `__asan_option_detect_stack_use_after_return' can not be used when making a shared object; recompile with -fPIC

* CMake: add BUILD_SHARED_LIBS option

  Prior to commit 4e955731d3a6ac344a593ee9d9c5d00982846adf, ngtcp2 was
  built as shared library. That has changed into a static or shared
  library depending on the BUILD_SHARED_LIBS option, but this option was
  not documented and the comments were misleading. Rectify both issues.

  Note that autotools builds both libraries by default, but the current
  CMake config is only able to build one of them.

__
cc @DaanDeMeyer 