### PR TITLE
Fix read-heap-buffer-overflow in decode_varint_param()

### DIFF
--- a/lib/ngtcp2_crypto.c
+++ b/lib/ngtcp2_crypto.c
@@ -371,6 +371,10 @@ static ngtcp2_ssize decode_varint_param(uint64_t *pdest, const uint8_t *p,
 
   p += nread;
 
+  if (p == end) {
+    return -1;
+  }
+
   if ((uint64_t)(end - p) < valuelen) {
     return -1;
   }


### PR DESCRIPTION
If `valuelen` is 0 and `p` equals `end`, `decode_varint_param()` reads an extra byte past the end of the buffer.