### PR TITLE
Fix Windows build

### DIFF
--- a/lib/ngtcp2_conv.c
+++ b/lib/ngtcp2_conv.c
@@ -45,19 +45,19 @@ uint64_t ngtcp2_get_uint48(const uint8_t *p) {
 uint32_t ngtcp2_get_uint32(const uint8_t *p) {
   uint32_t n;
   memcpy(&n, p, 4);
-  return ntohl(n);
+  return ngtcp2_ntohl(n);
 }
 
 uint32_t ngtcp2_get_uint24(const uint8_t *p) {
   uint32_t n = 0;
   memcpy(((uint8_t *)&n) + 1, p, 3);
-  return ntohl(n);
+  return ngtcp2_ntohl(n);
 }
 
 uint16_t ngtcp2_get_uint16(const uint8_t *p) {
   uint16_t n;
   memcpy(&n, p, 2);
-  return ntohs(n);
+  return ngtcp2_ntohs(n);
 }
 
 uint64_t ngtcp2_get_varint(size_t *plen, const uint8_t *p) {
@@ -76,11 +76,11 @@ uint64_t ngtcp2_get_varint(size_t *plen, const uint8_t *p) {
   case 2:
     memcpy(&n, p, 2);
     n.b[0] &= 0x3f;
-    return ntohs(n.n16);
+    return ngtcp2_ntohs(n.n16);
   case 4:
     memcpy(&n, p, 4);
     n.b[0] &= 0x3f;
-    return ntohl(n.n32);
+    return ngtcp2_ntohl(n.n32);
   case 8:
     memcpy(&n, p, 8);
     n.b[0] &= 0x3f;
@@ -116,17 +116,17 @@ uint8_t *ngtcp2_put_uint48be(uint8_t *p, uint64_t n) {
 }
 
 uint8_t *ngtcp2_put_uint32be(uint8_t *p, uint32_t n) {
-  n = htonl(n);
+  n = ngtcp2_htonl(n);
   return ngtcp2_cpymem(p, (const uint8_t *)&n, sizeof(n));
 }
 
 uint8_t *ngtcp2_put_uint24be(uint8_t *p, uint32_t n) {
-  n = htonl(n);
+  n = ngtcp2_htonl(n);
   return ngtcp2_cpymem(p, ((const uint8_t *)&n) + 1, 3);
 }
 
 uint8_t *ngtcp2_put_uint16be(uint8_t *p, uint16_t n) {
-  n = htons(n);
+  n = ngtcp2_htons(n);
   return ngtcp2_cpymem(p, (const uint8_t *)&n, sizeof(n));
 }
 

--- a/lib/ngtcp2_conv.h
+++ b/lib/ngtcp2_conv.h
@@ -82,7 +82,7 @@
 #    define STIN static inline
 #  endif
 
-STIN uint32_t htonl(uint32_t hostlong) {
+STIN uint32_t ngtcp2_htonl(uint32_t hostlong) {
   uint32_t res;
   unsigned char *p = (unsigned char *)&res;
   *p++ = hostlong >> 24;
@@ -92,7 +92,7 @@ STIN uint32_t htonl(uint32_t hostlong) {
   return res;
 }
 
-STIN uint16_t htons(uint16_t hostshort) {
+STIN uint16_t ngtcp2_htons(uint16_t hostshort) {
   uint16_t res;
   unsigned char *p = (unsigned char *)&res;
   *p++ = hostshort >> 8;
@@ -100,7 +100,7 @@ STIN uint16_t htons(uint16_t hostshort) {
   return res;
 }
 
-STIN uint32_t ntohl(uint32_t netlong) {
+STIN uint32_t ngtcp2_ntohl(uint32_t netlong) {
   uint32_t res;
   unsigned char *p = (unsigned char *)&netlong;
   res = *p++ << 24;
@@ -110,13 +110,20 @@ STIN uint32_t ntohl(uint32_t netlong) {
   return res;
 }
 
-STIN uint16_t ntohs(uint16_t netshort) {
+STIN uint16_t ngtcp2_ntohs(uint16_t netshort) {
   uint16_t res;
   unsigned char *p = (unsigned char *)&netshort;
   res = *p++ << 8;
   res += *p;
   return res;
 }
+
+#else /* WIN32 */
+
+#define ngtcp2_htonl htonl
+#define ngtcp2_htons htons
+#define ngtcp2_ntohl ntohl
+#define ngtcp2_ntohs ntohs
 
 #endif /* WIN32 */
 


### PR DESCRIPTION
`ngtcp2` defines its own version of the `htonl` functions on Windows in order to avoid having to link against `ws2_32.lib`. However, the way it defines these functions conflicts with the declarations on the Windows headers, causing build errors on 32-bit Windows builds:

```
$ cmake -G "Visual Studio 16 2019" -A Win32 ..
-- Selecting Windows SDK version 10.0.20180.0 to target Windows 10.0.20190.
-- The C compiler identification is MSVC 19.28.29115.0
-- The CXX compiler identification is MSVC 19.28.29115.0
...
-- Configuring done
-- Generating done
-- Build files have been written to: _build

$ cmake --build .
...
lib\ngtcp2_conv.h(85,15): error C2373: 'htonl': redefinition; different type modifiers [_build\lib\
ngtcp2.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.20180.0\um\winsock2.h(1797): message : see declaration of 'htonl' [
lib\ngtcp2.vcxproj]
lib\ngtcp2_conv.h(95,15): error C2373: 'htons': redefinition; different type modifiers [_build\lib\
ngtcp2.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.20180.0\um\winsock2.h(1814): message : see declaration of 'htons' [
_build\lib\ngtcp2.vcxproj]
lib\ngtcp2_conv.h(103,15): error C2373: 'ntohl': redefinition; different type modifiers [_build\lib
\ngtcp2.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.20180.0\um\winsock2.h(1969): message : see declaration of 'ntohl' [
_build\lib\ngtcp2.vcxproj]
lib\ngtcp2_conv.h(113,15): error C2373: 'ntohs': redefinition; different type modifiers [_build\lib
\ngtcp2.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.20180.0\um\winsock2.h(1986): message : see declaration of 'ntohs' [
_build\lib\ngtcp2.vcxproj]
  ngtcp2_conv.c
...
```

That's because the Windows headers define these functions like this:

```
WINSOCK_API_LINKAGE
u_long
WSAAPI
ntohl(
    _In_ u_long netlong
    );
```

Where that translates to:

```
__declspec(dllimport)
u_long
__stdcall
ntohl(
    _In_ u_long netlong
    );
```

And that doesn't match the declaration in `ngtcp2_conv.h`:

```
static __inline uint32_t htonl(uint32_t hostlong);
```

So this change moves these custom Windows implementations to the `ngtcp2_conv.c` file, which is their only user, and prepends `ngtcp2_` to them so we don't try to redefine existing functions.