### PR TITLE
Useless call to ngtcp2_conn_set_loss_detection_timer() upon PTO expir…

### DIFF
--- a/lib/ngtcp2_conn.c
+++ b/lib/ngtcp2_conn.c
@@ -9821,8 +9821,6 @@ int ngtcp2_conn_on_loss_detection_timer(ngtcp2_conn *conn, ngtcp2_tstamp ts) {
   ngtcp2_log_info(&conn->log, NGTCP2_LOG_EVENT_RCV, "pto_count=%zu",
                   cstat->pto_count);
 
-  ngtcp2_conn_set_loss_detection_timer(conn, ts);
-
   return 0;
 }
 


### PR DESCRIPTION
…ations.

AFAIU ngtcp2 QUIC implementation, ngtcp2_conn_on_loss_detection_timer() relies on the RFC pseudo-code logic found in OnLossDetectionTimeout() which finally sets the loss detection timer after having sent packets and before returning.

ngtcp2_conn_on_loss_detection_timer() does not really send the packet, so it should not call ngtcp2_conn_set_loss_detection_timer().

But it seems to me this is the responsability of conn_on_pkt_sent() which implements OnPacketSent() RFC pseudo-code function to set the timer value. According to me the call to ngtcp2_conn_set_loss_detection_timer() is useless in ngtcp2_conn_on_loss_detection_timer().