### PR TITLE
Fix inconsistent "defined()" operator usage which causes compile warn…

### DIFF
--- a/lib/ngtcp2_conv.h
+++ b/lib/ngtcp2_conv.h
@@ -51,18 +51,18 @@
 
 #include <ngtcp2/ngtcp2.h>
 
-#if defined HAVE_BSWAP_64 || HAVE_DECL_BSWAP_64
+#if defined(HAVE_BSWAP_64) || (defined(HAVE_DECL_BSWAP_64) && HAVE_DECL_BSWAP_64 > 0)
 #  define ngtcp2_bswap64 bswap_64
 #else /* !HAVE_BSWAP_64 */
 #  define ngtcp2_bswap64(N)                                                    \
     ((uint64_t)(ntohl((uint32_t)(N))) << 32 | ntohl((uint32_t)((N) >> 32)))
 #endif /* !HAVE_BSWAP_64 */
 
-#if defined HAVE_BE64TOH || HAVE_DECL_BE64TOH
+#if defined(HAVE_BE64TOH) || (defined(HAVE_DECL_BE64TOH) && HAVE_DECL_BE64TOH > 0)
 #  define ngtcp2_ntohl64(N) be64toh(N)
 #  define ngtcp2_htonl64(N) htobe64(N)
 #else /* !HAVE_BE64TOH */
-#  if defined WORDS_BIGENDIAN
+#  if defined(WORDS_BIGENDIAN)
 #    define ngtcp2_ntohl64(N) (N)
 #    define ngtcp2_htonl64(N) (N)
 #  else /* !WORDS_BIGENDIAN */


### PR DESCRIPTION
…ings if undefined.

Signed-off-by: Toni Uhlig <matzeton@googlemail.com>