### PR TITLE
docs: fix simple typo, excceds -> exceeds

### DIFF
--- a/lib/ngtcp2_conn.c
+++ b/lib/ngtcp2_conn.c
@@ -2550,7 +2550,7 @@ static size_t conn_required_num_new_connection_id(ngtcp2_conn *conn) {
   }
 
   /* len includes retired CID.  We don't provide extra CID if doing so
-     excceds NGTCP2_MAX_SCID_POOL_SIZE. */
+     exceeds NGTCP2_MAX_SCID_POOL_SIZE. */
 
   n = conn->remote.transport_params.active_connection_id_limit +
       conn->scid.num_retired;


### PR DESCRIPTION
There is a small typo in lib/ngtcp2_conn.c.

Should read `exceeds` rather than `excceds`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md