### PR TITLE
Add BBR congestion control.

### DIFF
--- a/examples/client.cc
+++ b/examples/client.cc
@@ -712,8 +712,15 @@ int Client::init(int fd, const Address &local_addr, const Address &remote_addr,
     }
     settings.qlog.write = qlog_write_cb;
   }
-  settings.cc_algo =
-      config.cc == "cubic" ? NGTCP2_CC_ALGO_CUBIC : NGTCP2_CC_ALGO_RENO;
+
+  if (config.cc == "cubic") {
+    settings.cc_algo = NGTCP2_CC_ALGO_CUBIC;
+  } else if (config.cc == "bbr") {
+    settings.cc_algo = NGTCP2_CC_ALGO_BBR;
+  } else {
+    settings.cc_algo = NGTCP2_CC_ALGO_RENO;
+  }
+
   settings.initial_ts = util::timestamp(loop_);
   settings.initial_rtt = config.initial_rtt;
   settings.max_window = config.max_window;
@@ -2031,7 +2038,7 @@ void config_set_default(Config &config) {
   config.max_window = 6_m;
   config.max_stream_window = 6_m;
   config.max_streams_uni = 100;
-  config.cc = "cubic"sv;
+  config.cc = "bbr"sv;
   config.initial_rtt = NGTCP2_DEFAULT_INITIAL_RTT;
 }
 } // namespace

--- a/examples/h09client.cc
+++ b/examples/h09client.cc
@@ -689,8 +689,18 @@ int Client::init(int fd, const Address &local_addr, const Address &remote_addr,
     }
     settings.qlog.write = qlog_write_cb;
   }
-  settings.cc_algo =
-      config.cc == "cubic" ? NGTCP2_CC_ALGO_CUBIC : NGTCP2_CC_ALGO_RENO;
+
+  if (config.cc == "cubic") {
+    settings.cc_algo = NGTCP2_CC_ALGO_CUBIC;
+  } else if (config.cc == "bbr") {
+    settings.cc_algo = NGTCP2_CC_ALGO_BBR;
+  } else {
+    settings.cc_algo = NGTCP2_CC_ALGO_RENO;
+  }
+
+  settings.initial_rtt = config.initial_rtt;
+  settings.max_window = config.max_window;
+
   settings.initial_ts = util::timestamp(loop_);
   settings.initial_rtt = config.initial_rtt;
 
@@ -1599,7 +1609,7 @@ void config_set_default(Config &config) {
   config.max_stream_data_bidi_remote = 256_k;
   config.max_stream_data_uni = 256_k;
   config.max_streams_uni = 100;
-  config.cc = "cubic"sv;
+  config.cc = "bbr"sv;
   config.initial_rtt = NGTCP2_DEFAULT_INITIAL_RTT;
 }
 } // namespace

--- a/examples/server.cc
+++ b/examples/server.cc
@@ -1498,8 +1498,15 @@ int Handler::init(const Endpoint &ep, const Address &local_addr,
   settings.log_printf = config.quiet ? nullptr : debug::log_printf;
   settings.initial_ts = util::timestamp(loop_);
   settings.token = ngtcp2_vec{const_cast<uint8_t *>(token), tokenlen};
-  settings.cc_algo =
-      config.cc == "cubic" ? NGTCP2_CC_ALGO_CUBIC : NGTCP2_CC_ALGO_RENO;
+
+  if (config.cc == "cubic") {
+    settings.cc_algo = NGTCP2_CC_ALGO_CUBIC;
+  } else if (config.cc == "bbr") {
+    settings.cc_algo = NGTCP2_CC_ALGO_BBR;
+  } else {
+    settings.cc_algo = NGTCP2_CC_ALGO_RENO;
+  }
+
   settings.initial_rtt = config.initial_rtt;
   settings.max_window = config.max_window;
   settings.max_stream_window = config.max_stream_window;
@@ -3307,7 +3314,7 @@ void config_set_default(Config &config) {
   config.max_streams_bidi = 100;
   config.max_streams_uni = 3;
   config.max_dyn_length = 20_m;
-  config.cc = "cubic"sv;
+  config.cc = "bbr"sv;
   config.initial_rtt = NGTCP2_DEFAULT_INITIAL_RTT;
   config.max_gso_dgrams = 10;
 }

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -52,6 +52,7 @@ set(ngtcp2_SOURCES
   ngtcp2_cid.c
   ngtcp2_ksl.c
   ngtcp2_cc.c
+  ngtcp2_bbr.c
   ngtcp2_addr.c
   ngtcp2_path.c
   ngtcp2_pv.c

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -58,6 +58,7 @@ OBJECTS = \
 	ngtcp2_cid.c \
 	ngtcp2_ksl.c \
 	ngtcp2_cc.c \
+	ngtcp2_bbr.c \
 	ngtcp2_addr.c \
 	ngtcp2_path.c \
 	ngtcp2_pv.c \
@@ -90,6 +91,7 @@ HFILES = \
 	ngtcp2_cid.h \
 	ngtcp2_ksl.h \
 	ngtcp2_cc.h \
+	ngtcp2_bbr.h \
 	ngtcp2_addr.h \
 	ngtcp2_path.h \
 	ngtcp2_pv.h \

--- a/lib/includes/ngtcp2/ngtcp2.h
+++ b/lib/includes/ngtcp2/ngtcp2.h
@@ -1499,6 +1499,10 @@ typedef struct ngtcp2_conn_stat {
    * in byte per second.
    */
   uint64_t delivery_rate_sec;
+  /**
+   * :member:`app_limited` indicate current transmits rate limited by app.
+   */
+  uint64_t app_limited;
 } ngtcp2_conn_stat;
 
 /**
@@ -1515,6 +1519,10 @@ typedef enum ngtcp2_cc_algo {
    * :enum:`NGTCP2_CC_ALGO_CUBIC` represents Cubic.
    */
   NGTCP2_CC_ALGO_CUBIC = 0x01,
+  /**
+   * :enum:`NGTCP2_CC_ALGO_BBR` represents Bbr.
+   */
+  NGTCP2_CC_ALGO_BBR = 0x02,
   /**
    * :enum:`NGTCP2_CC_ALGO_CUSTOM` represents custom congestion
    * control algorithm.
@@ -1560,6 +1568,15 @@ typedef struct ngtcp2_cc_pkt {
    * :member:`ts_sent` is the timestamp when packet is sent.
    */
   ngtcp2_tstamp ts_sent;
+  /**
+   * :member:`delivered` is the bytes delivered when packet is sent.
+   */
+  uint64_t delivered;
+  /**
+   * :member:`is_app_limited` indicate current transmits rate limited by app
+   * when packet is sent.
+   */
+  uint64_t is_app_limited;
 } ngtcp2_cc_pkt;
 
 typedef struct ngtcp2_cc ngtcp2_cc;

--- a/lib/includes/ngtcp2/ngtcp2.h
+++ b/lib/includes/ngtcp2/ngtcp2.h
@@ -1495,6 +1495,11 @@ typedef struct ngtcp2_conn_stat {
    */
   size_t max_udp_payload_size;
   /**
+   * :member:`delivered` is the current delivered bytes measured
+   * in one sample rate round.
+   */
+  uint64_t delivered;
+  /**
    * :member:`delivery_rate_sec` is the current sending rate measured
    * in byte per second.
    */

--- a/lib/includes/ngtcp2/ngtcp2.h
+++ b/lib/includes/ngtcp2/ngtcp2.h
@@ -1685,6 +1685,14 @@ typedef void (*ngtcp2_cc_event)(ngtcp2_cc *cc, ngtcp2_conn_stat *cstat,
                                 ngtcp2_cc_event_type event, ngtcp2_tstamp ts);
 
 /**
+ * @functypedef
+ *
+ * :type:`conn_pace_time_to_send` is a callback function which is called
+ * when try to send packet pacing.
+ */
+typedef int (*ngtcp2_cc_on_pace_time_to_send)(ngtcp2_cc *cc, ngtcp2_tstamp ts);
+
+/**
  * @struct
  *
  * :type:`ngtcp2_cc` is congestion control algorithm interface to
@@ -1741,6 +1749,12 @@ typedef struct ngtcp2_cc {
    * specific event happens.
    */
   ngtcp2_cc_event event;
+
+  /**
+   * :member:`on_pace_time_to_send` is a callback function when try
+   * to send packet pacing.
+   */
+  ngtcp2_cc_on_pace_time_to_send on_pace_time_to_send;
 } ngtcp2_cc;
 
 /**

--- a/lib/ngtcp2_bbr.c
+++ b/lib/ngtcp2_bbr.c
@@ -38,12 +38,12 @@
 #define BBRGainCycleLen 8
 static const double pacing_gain_cycle[BBRGainCycleLen] = {5 / 4, 3 / 4, 1, 1,
                                                        1,     1,     1, 1};
-static const double BBRHighGain = 2.89;
-static const uint64_t ProbeRTTDuration = 200 * NGTCP2_MILLISECONDS;
-static const uint64_t RTpropFilterLen = 10 * NGTCP2_SECONDS;
-static const uint64_t MSS = 1500;
-static const uint64_t BBRMinPipeCwnd = 4 * MSS;
-static const uint64_t InitialCwnd = 10 * MSS;
+#define BBRHighGain 2.89
+#define ProbeRTTDuration (200*NGTCP2_MILLISECONDS)
+#define RTpropFilterLen (10*NGTCP2_SECONDS)
+#define MSS 1500
+#define BBRMinPipeCwnd (4*MSS)
+#define InitialCwnd (10*MSS)
 
 typedef enum {
   Startup = 0,

--- a/lib/ngtcp2_bbr.c
+++ b/lib/ngtcp2_bbr.c
@@ -1,0 +1,613 @@
+/*
+ * ngtcp2
+ *
+ * Copyright (c) 2018 ngtcp2 contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+#include "ngtcp2_bbr.h"
+
+#include <assert.h>
+
+#if defined(_MSC_VER)
+#  include <intrin.h>
+#endif
+
+#include "ngtcp2_log.h"
+#include "ngtcp2_macro.h"
+#include "ngtcp2_mem.h"
+#include "ngtcp2_rcvry.h"
+
+#define BBRGainCycleLen 8
+static const int pacing_gain_cycle[BBRGainCycleLen] = {5 / 4, 3 / 4, 1, 1,
+                                                       1,     1,     1, 1};
+static const double BBRHighGain = 2.8853900817779;
+static const uint64_t ProbeRTTDuration = 200 * NGTCP2_MILLISECONDS;
+static const uint64_t RTpropFilterLen = 10 * NGTCP2_SECONDS;
+static const uint64_t MSS = 1500;
+static const uint64_t BBRMinPipeCwnd = 4 * MSS;
+static const uint64_t InitialCwnd = 10 * MSS;
+
+typedef enum {
+  Startup = 0,
+  Drain = 1,
+  ProbeBW = 2,
+  ProbeRTT = 3,
+} BBRState;
+
+void BBROnConnectionInit(ngtcp2_bbr_cc *bbr_cc);
+void BBRUpdateOnACK(ngtcp2_bbr_cc *bbr_cc, ngtcp2_conn_stat *cstat,
+                    const ngtcp2_cc_pkt *pkt, ngtcp2_tstamp ts);
+void BBRUpdateModelAndState(ngtcp2_bbr_cc *bbr_cc, ngtcp2_conn_stat *cstat,
+                            const ngtcp2_cc_pkt *pkt, ngtcp2_tstamp ts);
+void BBRUpdateControlParameters(ngtcp2_bbr_cc *bbr_cc, ngtcp2_conn_stat *cstat);
+void BBROnTransmit(ngtcp2_bbr_cc *bbr_cc, ngtcp2_conn_stat *cstat);
+void BBRInitRoundCounting(ngtcp2_bbr_cc *bbr_cc);
+void BBRUpdateRound(ngtcp2_bbr_cc *bbr_cc, const ngtcp2_cc_pkt *pkt);
+void BBRUpdateBtlBw(ngtcp2_bbr_cc *bbr_cc, ngtcp2_conn_stat *cstat,
+                    const ngtcp2_cc_pkt *pkt);
+void BBRUpdateRTprop(ngtcp2_bbr_cc *bbr_cc, ngtcp2_conn_stat *cstat,
+                     ngtcp2_tstamp ts);
+void BBRInitPacingRate(ngtcp2_bbr_cc *bbr_cc);
+void BBRSetPacingRateWithGain(ngtcp2_bbr_cc *bbr_cc, uint64_t pacing_gain);
+void BBRSetPacingRate(ngtcp2_bbr_cc *bbr_cc);
+void BBRSetSendQuantum(ngtcp2_bbr_cc *bbr_cc);
+void BBRUpdateTargetCwnd(ngtcp2_bbr_cc *bbr_cc);
+void BBRModulateCwndForRecovery(ngtcp2_bbr_cc *bbr_cc, ngtcp2_conn_stat *cstat);
+void BBRRestoreCwnd(ngtcp2_bbr_cc *bbr_cc, ngtcp2_conn_stat *cstat);
+void BBRModulateCwndForProbeRTT(ngtcp2_bbr_cc *bbr_cc, ngtcp2_conn_stat *cstat);
+void BBRSetCwnd(ngtcp2_bbr_cc *bbr_cc, ngtcp2_conn_stat *cstat);
+void BBRInit(ngtcp2_bbr_cc *bbr_cc);
+void BBREnterStartup(ngtcp2_bbr_cc *bbr_cc);
+void BBRInitFullPipe(ngtcp2_bbr_cc *bbr_cc);
+void BBRCheckFullPipe(ngtcp2_bbr_cc *bbr_cc, ngtcp2_conn_stat *cstat,
+                      const ngtcp2_cc_pkt *pkt);
+void BBREnterDrain(ngtcp2_bbr_cc *bbr_cc);
+void BBRCheckDrain(ngtcp2_bbr_cc *bbr_cc, ngtcp2_conn_stat *cstat,
+                   ngtcp2_tstamp ts);
+void BBREnterProbeBW(ngtcp2_bbr_cc *bbr_cc, ngtcp2_tstamp ts);
+void BBRCheckCyclePhase(ngtcp2_bbr_cc *bbr_cc, ngtcp2_tstamp ts);
+void BBRAdvanceCyclePhase(ngtcp2_bbr_cc *bbr_cc, ngtcp2_tstamp ts);
+int BBRIsNextCyclePhase(ngtcp2_bbr_cc *bbr_cc, ngtcp2_tstamp ts);
+void BBRHandleRestartFromIdle(ngtcp2_bbr_cc *bbr_cc, ngtcp2_conn_stat *cstat);
+void BBRCheckProbeRTT(ngtcp2_bbr_cc *bbr_cc, ngtcp2_conn_stat *cstat,
+                      ngtcp2_tstamp ts);
+void BBREnterProbeRTT(ngtcp2_bbr_cc *bbr_cc);
+void BBRHandleProbeRTT(ngtcp2_bbr_cc *bbr_cc, ngtcp2_conn_stat *cstat,
+                       ngtcp2_tstamp ts);
+void BBRExitProbeRTT(ngtcp2_bbr_cc *bbr_cc, ngtcp2_tstamp ts);
+
+static void bbr_cc_reset(ngtcp2_bbr_cc *bbr_cc) { BBROnConnectionInit(bbr_cc); }
+
+void ngtcp2_bbr_cc_init(ngtcp2_bbr_cc *bbr_cc, ngtcp2_log *log) {
+  bbr_cc->ccb.log = log;
+  bbr_cc_reset(bbr_cc);
+}
+
+void ngtcp2_bbr_cc_free(ngtcp2_bbr_cc *bbr_cc) { (void)bbr_cc; }
+
+int ngtcp2_cc_bbr_cc_init(ngtcp2_cc *cc, ngtcp2_log *log,
+                          const ngtcp2_mem *mem) {
+  ngtcp2_bbr_cc *bbr_cc;
+
+  bbr_cc = ngtcp2_mem_calloc(mem, 1, sizeof(ngtcp2_bbr_cc));
+  if (bbr_cc == NULL) {
+    return NGTCP2_ERR_NOMEM;
+  }
+
+  ngtcp2_bbr_cc_init(bbr_cc, log);
+
+  cc->ccb = &bbr_cc->ccb;
+  cc->on_pkt_acked = ngtcp2_cc_bbr_cc_on_pkt_acked;
+  cc->congestion_event = ngtcp2_cc_bbr_cc_congestion_event;
+  cc->on_spurious_congestion = ngtcp2_cc_bbr_cc_on_spurious_congestion;
+  cc->on_persistent_congestion = ngtcp2_cc_bbr_cc_on_persistent_congestion;
+  cc->on_ack_recv = ngtcp2_cc_bbr_cc_on_ack_recv;
+  cc->on_pkt_sent = ngtcp2_cc_bbr_cc_on_pkt_sent;
+  cc->new_rtt_sample = ngtcp2_cc_bbr_cc_new_rtt_sample;
+  cc->reset = ngtcp2_cc_bbr_cc_reset;
+  cc->event = ngtcp2_cc_bbr_cc_event;
+
+  ngtcp2_log_info(bbr_cc->ccb.log, NGTCP2_LOG_EVENT_RCV, "bbr cc init");
+
+  return 0;
+}
+
+void ngtcp2_cc_bbr_cc_free(ngtcp2_cc *cc, const ngtcp2_mem *mem) {
+  ngtcp2_bbr_cc *bbr_cc = ngtcp2_struct_of(cc->ccb, ngtcp2_bbr_cc, ccb);
+
+  ngtcp2_bbr_cc_free(bbr_cc);
+  ngtcp2_mem_free(mem, bbr_cc);
+}
+
+void ngtcp2_cc_bbr_cc_on_pkt_acked(ngtcp2_cc *ccx, ngtcp2_conn_stat *cstat,
+                                   const ngtcp2_cc_pkt *pkt, ngtcp2_tstamp ts) {
+  ngtcp2_bbr_cc *bbr_cc = ngtcp2_struct_of(ccx->ccb, ngtcp2_bbr_cc, ccb);
+  bbr_cc->packets_delivered += pkt->pktlen;
+
+  ngtcp2_log_info(bbr_cc->ccb.log, NGTCP2_LOG_EVENT_RCV,
+                  "bbr cc pkn=%" PRId64 " acked, slow start cwnd=%" PRIu64,
+                  pkt->pkt_num, cstat->cwnd);
+
+  BBRUpdateOnACK(bbr_cc, cstat, pkt, ts);
+  bbr_cc->prior_inflight = ctsta->bytes_in_flight;
+}
+
+void ngtcp2_cc_bbr_cc_congestion_event(ngtcp2_cc *ccx, ngtcp2_conn_stat *cstat,
+                                       ngtcp2_tstamp ts_sent,
+                                       ngtcp2_tstamp ts) {
+  ngtcp2_bbr_cc *bbr_cc = ngtcp2_struct_of(ccx->ccb, ngtcp2_bbr_cc, ccb);
+}
+
+void ngtcp2_cc_bbr_cc_on_spurious_congestion(ngtcp2_cc *ccx,
+                                             ngtcp2_conn_stat *cstat,
+                                             ngtcp2_tstamp ts) {
+  ngtcp2_bbr_cc *bbr_cc = ngtcp2_struct_of(ccx->ccb, ngtcp2_bbr_cc, ccb);
+}
+
+void ngtcp2_cc_bbr_cc_on_persistent_congestion(ngtcp2_cc *ccx,
+                                               ngtcp2_conn_stat *cstat,
+                                               ngtcp2_tstamp ts) {}
+
+void ngtcp2_cc_bbr_cc_on_ack_recv(ngtcp2_cc *ccx, ngtcp2_conn_stat *cstat,
+                                  ngtcp2_tstamp ts) {
+  ngtcp2_bbr_cc *bbr_cc = ngtcp2_struct_of(ccx->ccb, ngtcp2_bbr_cc, ccb);
+}
+
+void ngtcp2_cc_bbr_cc_on_pkt_sent(ngtcp2_cc *ccx, ngtcp2_conn_stat *cstat,
+                                  const ngtcp2_cc_pkt *pkt) {
+  ngtcp2_bbr_cc *bbr_cc = ngtcp2_struct_of(ccx->ccb, ngtcp2_bbr_cc, ccb);
+  BBROnTransmit(bbr_cc, cstat);
+}
+
+void ngtcp2_cc_bbr_cc_new_rtt_sample(ngtcp2_cc *ccx, ngtcp2_conn_stat *cstat,
+                                     ngtcp2_tstamp ts) {
+  ngtcp2_bbr_cc *bbr_cc = ngtcp2_struct_of(ccx->ccb, ngtcp2_bbr_cc, ccb);
+}
+
+void ngtcp2_cc_bbr_cc_reset(ngtcp2_cc *ccx) {
+  ngtcp2_bbr_cc *bbr_cc = ngtcp2_struct_of(ccx->ccb, ngtcp2_bbr_cc, ccb);
+  bbr_cc_reset(bbr_cc);
+}
+
+void ngtcp2_cc_bbr_cc_event(ngtcp2_cc *ccx, ngtcp2_conn_stat *cstat,
+                            ngtcp2_cc_event_type event, ngtcp2_tstamp ts) {
+  ngtcp2_bbr_cc *bbr_cc = ngtcp2_struct_of(ccx->ccb, ngtcp2_bbr_cc, ccb);
+}
+
+void BBROnConnectionInit(ngtcp2_bbr_cc *bbr_cc) {
+  ngtcp2_log_info(bbr_cc->ccb.log, NGTCP2_LOG_EVENT_NONE, "BBR Trace # %s:%d",
+                  __func__, __LINE__);
+  BBRInit(bbr_cc);
+}
+
+void BBRUpdateOnACK(ngtcp2_bbr_cc *bbr_cc, ngtcp2_conn_stat *cstat,
+                    const ngtcp2_cc_pkt *pkt, ngtcp2_tstamp ts) {
+  ngtcp2_log_info(bbr_cc->ccb.log, NGTCP2_LOG_EVENT_NONE, "BBR Trace # %s:%d",
+                  __func__, __LINE__);
+  BBRUpdateModelAndState(bbr_cc, cstat, pkt, ts);
+  BBRUpdateControlParameters(bbr_cc, cstat);
+}
+
+void BBRUpdateModelAndState(ngtcp2_bbr_cc *bbr_cc, ngtcp2_conn_stat *cstat,
+                            const ngtcp2_cc_pkt *pkt, ngtcp2_tstamp ts) {
+  ngtcp2_log_info(bbr_cc->ccb.log, NGTCP2_LOG_EVENT_NONE, "BBR Trace # %s:%d",
+                  __func__, __LINE__);
+  BBRUpdateBtlBw(bbr_cc, cstat, pkt);
+  BBRCheckCyclePhase(bbr_cc, ts);
+  BBRCheckFullPipe(bbr_cc, cstat, pkt);
+  BBRCheckDrain(bbr_cc, cstat, ts);
+  BBRUpdateRTprop(bbr_cc, cstat, ts);
+  BBRCheckProbeRTT(bbr_cc, cstat, ts);
+}
+
+void BBRUpdateControlParameters(ngtcp2_bbr_cc *bbr_cc,
+                                ngtcp2_conn_stat *cstat) {
+  ngtcp2_log_info(bbr_cc->ccb.log, NGTCP2_LOG_EVENT_NONE, "BBR Trace # %s:%d",
+                  __func__, __LINE__);
+  BBRSetPacingRate(bbr_cc);
+  BBRSetSendQuantum(bbr_cc);
+  BBRSetCwnd(bbr_cc, cstat);
+}
+
+void BBROnTransmit(ngtcp2_bbr_cc *bbr_cc, ngtcp2_conn_stat *cstat) {
+  ngtcp2_log_info(bbr_cc->ccb.log, NGTCP2_LOG_EVENT_NONE, "BBR Trace # %s:%d",
+                  __func__, __LINE__);
+  BBRHandleRestartFromIdle(bbr_cc, cstat);
+}
+
+void BBRInitRoundCounting(ngtcp2_bbr_cc *bbr_cc) {
+  ngtcp2_log_info(bbr_cc->ccb.log, NGTCP2_LOG_EVENT_NONE, "BBR Trace # %s:%d",
+                  __func__, __LINE__);
+  bbr_cc->BBR.next_round_delivered = 0;
+  bbr_cc->BBR.round_start = 0;
+  bbr_cc->BBR.round_count = 0;
+}
+
+void BBRUpdateRound(ngtcp2_bbr_cc *bbr_cc, const ngtcp2_cc_pkt *pkt) {
+  ngtcp2_log_info(bbr_cc->ccb.log, NGTCP2_LOG_EVENT_NONE, "BBR Trace # %s:%d",
+                  __func__, __LINE__);
+  bbr_cc->BBR.delivered += pkt->pktlen;
+  if (pkt->delivered >= bbr_cc->BBR.next_round_delivered) {
+    bbr_cc->BBR.next_round_delivered = bbr_cc->BBR.delivered;
+    bbr_cc->BBR.round_count++;
+    bbr_cc->BBR.round_start = 1;
+  } else {
+    bbr_cc->BBR.round_start = 0;
+  }
+}
+
+void BBRUpdateBtlBw(ngtcp2_bbr_cc *bbr_cc, ngtcp2_conn_stat *cstat,
+                    const ngtcp2_cc_pkt *pkt) {
+  ngtcp2_log_info(bbr_cc->ccb.log, NGTCP2_LOG_EVENT_NONE, "BBR Trace # %s:%d",
+                  __func__, __LINE__);
+  BBRUpdateRound(bbr_cc, pkt);
+  if (cstat->delivery_rate_sec >= bbr_cc->BBR.BtlBw || !pkt->is_app_limited) {
+    int i;
+    for (i = 0; i < BtlBwFilterLen - 1; ++i) {
+      double bw = bbr_cc->BBR.BtlBwFilter[i];
+      bbr_cc->BBR.BtlBwFilter[i + 1] = bw;
+      bbr_cc->BBR.BtlBw = ngtcp2_max(bw, bbr_cc->BBR.BtlBw);
+    }
+    bbr_cc->BBR.BtlBwFilter[0] = cstat->delivery_rate_sec;
+    bbr_cc->BBR.BtlBw = ngtcp2_max(cstat->delivery_rate_sec, bbr_cc->BBR.BtlBw);
+    printf("btlbw=%lu, delivery_rate_sec=%lu\n", bbr_cc->BBR.BtlBw,
+           cstat->delivery_rate_sec);
+  }
+}
+
+void BBRUpdateRTprop(ngtcp2_bbr_cc *bbr_cc, ngtcp2_conn_stat *cstat,
+                     ngtcp2_tstamp ts) {
+  ngtcp2_log_info(bbr_cc->ccb.log, NGTCP2_LOG_EVENT_NONE, "BBR Trace # %s:%d",
+                  __func__, __LINE__);
+  bbr_cc->BBR.rtprop_expired = ts > bbr_cc->BBR.rtprop_stamp + RTpropFilterLen;
+  if (cstat->latest_rtt >= 0 &&
+      (cstat->latest_rtt <= bbr_cc->BBR.RTprop || bbr_cc->BBR.rtprop_expired)) {
+    bbr_cc->BBR.RTprop = cstat->latest_rtt;
+    ngtcp2_log_info(bbr_cc->ccb.log, NGTCP2_LOG_EVENT_NONE,
+                    "BBR Trace # RTprop=%lu", bbr_cc->BBR.RTprop);
+    bbr_cc->BBR.rtprop_stamp = ts;
+  }
+}
+
+void BBRInitPacingRate(ngtcp2_bbr_cc *bbr_cc) {
+  ngtcp2_log_info(bbr_cc->ccb.log, NGTCP2_LOG_EVENT_NONE, "BBR Trace # %s:%d",
+                  __func__, __LINE__);
+  uint64_t nominal_bandwidth = InitialCwnd / (1 * NGTCP2_MILLISECONDS);
+  bbr_cc->BBR.pacing_rate = bbr_cc->BBR.pacing_gain * nominal_bandwidth;
+}
+
+void BBRSetPacingRateWithGain(ngtcp2_bbr_cc *bbr_cc, uint64_t pacing_gain) {
+  ngtcp2_log_info(bbr_cc->ccb.log, NGTCP2_LOG_EVENT_NONE, "BBR Trace # %s:%d",
+                  __func__, __LINE__);
+  uint64_t rate = pacing_gain * bbr_cc->BBR.BtlBw;
+  if (bbr_cc->BBR.filled_pipe || rate > bbr_cc->BBR.pacing_rate) {
+    bbr_cc->BBR.pacing_rate = rate;
+  }
+}
+
+void BBRSetPacingRate(ngtcp2_bbr_cc *bbr_cc) {
+  ngtcp2_log_info(bbr_cc->ccb.log, NGTCP2_LOG_EVENT_NONE, "BBR Trace # %s:%d",
+                  __func__, __LINE__);
+  BBRSetPacingRateWithGain(bbr_cc, bbr_cc->BBR.pacing_gain);
+}
+
+void BBRSetSendQuantum(ngtcp2_bbr_cc *bbr_cc) {
+  ngtcp2_log_info(bbr_cc->ccb.log, NGTCP2_LOG_EVENT_NONE, "BBR Trace # %s:%d",
+                  __func__, __LINE__);
+  if (bbr_cc->BBR.pacing_rate < 1.2 * 1024 * 1024) {
+    bbr_cc->BBR.send_quantum = 1 * MSS;
+  } else if (bbr_cc->BBR.pacing_rate < 24 * 1024 * 1024) {
+    bbr_cc->BBR.send_quantum = 2 * MSS;
+  } else {
+    bbr_cc->BBR.send_quantum = ngtcp2_min(
+        bbr_cc->BBR.pacing_rate * 1 * NGTCP2_MILLISECONDS, 64 * 1024 * 8);
+  }
+}
+
+uint64_t BBRInflight(ngtcp2_bbr_cc *bbr_cc, uint64_t gain) {
+  ngtcp2_log_info(bbr_cc->ccb.log, NGTCP2_LOG_EVENT_NONE, "BBR Trace # %s:%d",
+                  __func__, __LINE__);
+  if (bbr_cc->BBR.RTprop == UINT64_MAX) {
+    return InitialCwnd; /* no valid RTT samples yet */
+  }
+  uint64_t quanta = 3 * bbr_cc->BBR.send_quantum;
+  uint64_t estimated_bdp =
+      bbr_cc->BBR.BtlBw * bbr_cc->BBR.RTprop / NGTCP2_SECONDS;
+  ngtcp2_log_info(bbr_cc->ccb.log, NGTCP2_LOG_EVENT_NONE,
+                  "BBR Trace # send_quantum=%lu, BtlBw=%lu, RTprop=%lu, "
+                  "gain=%u, estimated_bdp=%u",
+                  bbr_cc->BBR.send_quantum, bbr_cc->BBR.BtlBw,
+                  bbr_cc->BBR.RTprop, gain, estimated_bdp);
+  return gain * estimated_bdp + quanta;
+}
+
+void BBRUpdateTargetCwnd(ngtcp2_bbr_cc *bbr_cc) {
+  ngtcp2_log_info(bbr_cc->ccb.log, NGTCP2_LOG_EVENT_NONE, "BBR Trace # %s:%d",
+                  __func__, __LINE__);
+  bbr_cc->BBR.target_cwnd = BBRInflight(bbr_cc, bbr_cc->BBR.cwnd_gain);
+  ngtcp2_log_info(bbr_cc->ccb.log, NGTCP2_LOG_EVENT_NONE,
+                  "BBR Trace # target_cwnd=%lu", bbr_cc->BBR.target_cwnd);
+  printf("BBR Trace # target_cwnd=%lu\n", bbr_cc->BBR.target_cwnd);
+}
+
+void BBRModulateCwndForRecovery(ngtcp2_bbr_cc *bbr_cc,
+                                ngtcp2_conn_stat *cstat) {
+  ngtcp2_log_info(bbr_cc->ccb.log, NGTCP2_LOG_EVENT_NONE, "BBR Trace # %s:%d",
+                  __func__, __LINE__);
+  if (bbr_cc->packets_lost > 0) {
+    cstat->cwnd = ngtcp2_max(cstat->cwnd - bbr_cc->packets_lost, 1);
+  }
+
+  if (bbr_cc->BBR.packet_conservation) {
+    cstat->cwnd = ngtcp2_max(cstat->cwnd, cstat->bytes_in_flight +
+                                              bbr_cc->packets_delivered);
+  }
+}
+
+uint64_t BBRSaveCwnd(ngtcp2_bbr_cc *bbr_cc, ngtcp2_conn_stat *cstat) {
+  ngtcp2_log_info(bbr_cc->ccb.log, NGTCP2_LOG_EVENT_NONE, "BBR Trace # %s:%d",
+                  __func__, __LINE__);
+#if defined(TODO)
+  if (!InLossRecovery() && bbr_cc->BBR.state != ProbeRTT) {
+#else
+  if (bbr_cc->BBR.state != ProbeRTT) {
+#endif
+    return cstat->cwnd;
+  } else {
+    return ngtcp2_max(bbr_cc->BBR.prior_cwnd, cstat->cwnd);
+  }
+}
+void BBRRestoreCwnd(ngtcp2_bbr_cc *bbr_cc, ngtcp2_conn_stat *cstat) {
+  ngtcp2_log_info(bbr_cc->ccb.log, NGTCP2_LOG_EVENT_NONE, "BBR Trace # %s:%d",
+                  __func__, __LINE__);
+  cstat->cwnd = ngtcp2_max(cstat->cwnd, bbr_cc->BBR.prior_cwnd);
+}
+
+void BBRModulateCwndForProbeRTT(ngtcp2_bbr_cc *bbr_cc,
+                                ngtcp2_conn_stat *cstat) {
+  ngtcp2_log_info(bbr_cc->ccb.log, NGTCP2_LOG_EVENT_NONE, "BBR Trace # %s:%d",
+                  __func__, __LINE__);
+  if (bbr_cc->BBR.state == ProbeRTT) {
+    cstat->cwnd = ngtcp2_min(cstat->cwnd, BBRMinPipeCwnd);
+  }
+}
+
+void BBRSetCwnd(ngtcp2_bbr_cc *bbr_cc, ngtcp2_conn_stat *cstat) {
+  ngtcp2_log_info(bbr_cc->ccb.log, NGTCP2_LOG_EVENT_NONE, "BBR Trace # %s:%d",
+                  __func__, __LINE__);
+  BBRUpdateTargetCwnd(bbr_cc);
+  BBRModulateCwndForRecovery(bbr_cc, cstat);
+  if (!bbr_cc->BBR.packet_conservation) {
+    if (bbr_cc->BBR.filled_pipe) {
+      cstat->cwnd = ngtcp2_min(cstat->cwnd + bbr_cc->packets_delivered,
+                               bbr_cc->BBR.target_cwnd);
+      ngtcp2_log_info(bbr_cc->ccb.log, NGTCP2_LOG_EVENT_NONE,
+                      "BBR Trace # %s:%d", __func__, __LINE__);
+    } else if (cstat->cwnd < bbr_cc->BBR.target_cwnd ||
+               bbr_cc->BBR.delivered < InitialCwnd) {
+      cstat->cwnd = cstat->cwnd + bbr_cc->packets_delivered;
+      ngtcp2_log_info(bbr_cc->ccb.log, NGTCP2_LOG_EVENT_NONE,
+                      "BBR Trace # %s:%d", __func__, __LINE__);
+    }
+
+    ngtcp2_log_info(bbr_cc->ccb.log, NGTCP2_LOG_EVENT_NONE,
+                    "BBR Trace # cwnd=%u", cstat->cwnd);
+    cstat->cwnd = ngtcp2_max(cstat->cwnd, BBRMinPipeCwnd);
+  }
+  BBRModulateCwndForProbeRTT(bbr_cc, cstat);
+}
+
+void BBRInit(ngtcp2_bbr_cc *bbr_cc) {
+  ngtcp2_log_info(bbr_cc->ccb.log, NGTCP2_LOG_EVENT_NONE, "BBR Trace # %s:%d",
+                  __func__, __LINE__);
+  int i;
+  for (i = 0; i < BtlBwFilterLen; ++i) {
+    bbr_cc->BBR.BtlBwFilter[i] = 0;
+  }
+  bbr_cc->BBR.RTprop = UINT64_MAX;
+#if defined(TODO)
+  bbr_cc->BBR.rtprop_stamp = ts;
+#else
+  bbr_cc->BBR.rtprop_stamp = 0;
+#endif
+  bbr_cc->BBR.probe_rtt_done_stamp = 0;
+  bbr_cc->BBR.probe_rtt_round_done = 0;
+  bbr_cc->BBR.packet_conservation = 0;
+  bbr_cc->BBR.prior_cwnd = 0;
+  bbr_cc->BBR.idle_restart = 0;
+
+  bbr_cc->packets_delivered = 0;
+  bbr_cc->packets_lost = 0;
+  bbr_cc->prior_inflight = 0;
+
+  BBRInitRoundCounting(bbr_cc);
+  BBRInitFullPipe(bbr_cc);
+  BBRInitPacingRate(bbr_cc);
+  BBREnterStartup(bbr_cc);
+}
+
+void BBREnterStartup(ngtcp2_bbr_cc *bbr_cc) {
+  ngtcp2_log_info(bbr_cc->ccb.log, NGTCP2_LOG_EVENT_NONE, "BBR Trace # %s:%d",
+                  __func__, __LINE__);
+  bbr_cc->BBR.state = Startup;
+  bbr_cc->BBR.pacing_gain = BBRHighGain;
+  bbr_cc->BBR.cwnd_gain = BBRHighGain;
+}
+
+void BBRInitFullPipe(ngtcp2_bbr_cc *bbr_cc) {
+  ngtcp2_log_info(bbr_cc->ccb.log, NGTCP2_LOG_EVENT_NONE, "BBR Trace # %s:%d",
+                  __func__, __LINE__);
+  bbr_cc->BBR.filled_pipe = 0;
+  bbr_cc->BBR.full_bw = 0;
+  bbr_cc->BBR.full_bw_count = 0;
+}
+
+void BBRCheckFullPipe(ngtcp2_bbr_cc *bbr_cc, ngtcp2_conn_stat *cstat,
+                      const ngtcp2_cc_pkt *pkt) {
+  ngtcp2_log_info(bbr_cc->ccb.log, NGTCP2_LOG_EVENT_NONE, "BBR Trace # %s:%d",
+                  __func__, __LINE__);
+  if (bbr_cc->BBR.filled_pipe || !bbr_cc->BBR.round_start ||
+      pkt->is_app_limited) {
+    return; // no need to check for a full pipe now
+  }
+  if (bbr_cc->BBR.BtlBw >=
+      bbr_cc->BBR.full_bw * 1.25) {          // bbr_cc->BBR.BtlBw still growing?
+    bbr_cc->BBR.full_bw = bbr_cc->BBR.BtlBw; // record new baseline level
+    bbr_cc->BBR.full_bw_count = 0;
+    return;
+  }
+  bbr_cc->BBR.full_bw_count++; // another round w/o much growth
+  if (bbr_cc->BBR.full_bw_count >= 3) {
+    bbr_cc->BBR.filled_pipe = 1;
+  }
+}
+
+void BBREnterDrain(ngtcp2_bbr_cc *bbr_cc) {
+  ngtcp2_log_info(bbr_cc->ccb.log, NGTCP2_LOG_EVENT_NONE, "BBR Trace # %s:%d",
+                  __func__, __LINE__);
+  bbr_cc->BBR.state = Drain;
+  bbr_cc->BBR.pacing_gain = 1 / BBRHighGain; // pace slowly
+  bbr_cc->BBR.cwnd_gain = BBRHighGain;       // maintain cwnd
+}
+
+void BBRCheckDrain(ngtcp2_bbr_cc *bbr_cc, ngtcp2_conn_stat *cstat,
+                   ngtcp2_tstamp ts) {
+  ngtcp2_log_info(bbr_cc->ccb.log, NGTCP2_LOG_EVENT_NONE, "BBR Trace # %s:%d",
+                  __func__, __LINE__);
+  if (bbr_cc->BBR.state == Startup && bbr_cc->BBR.filled_pipe) {
+    BBREnterDrain(bbr_cc);
+  }
+
+  if (bbr_cc->BBR.state == Drain &&
+      cstat->bytes_in_flight <= BBRInflight(bbr_cc, 1.0)) {
+    BBREnterProbeBW(bbr_cc, ts); // we estimate queue is drained
+  }
+}
+
+void BBREnterProbeBW(ngtcp2_bbr_cc *bbr_cc, ngtcp2_tstamp ts) {
+  ngtcp2_log_info(bbr_cc->ccb.log, NGTCP2_LOG_EVENT_NONE, "BBR Trace # %s:%d",
+                  __func__, __LINE__);
+  bbr_cc->BBR.state = ProbeBW;
+  bbr_cc->BBR.pacing_gain = 1;
+  bbr_cc->BBR.cwnd_gain = 2;
+  bbr_cc->BBR.cycle_index = BBRGainCycleLen - 1 - (random() % 7);
+  BBRAdvanceCyclePhase(bbr_cc, ts);
+}
+
+void BBRCheckCyclePhase(ngtcp2_bbr_cc *bbr_cc, ngtcp2_tstamp ts) {
+  ngtcp2_log_info(bbr_cc->ccb.log, NGTCP2_LOG_EVENT_NONE, "BBR Trace # %s:%d",
+                  __func__, __LINE__);
+  if (bbr_cc->BBR.state == ProbeBW && BBRIsNextCyclePhase(bbr_cc, ts)) {
+    BBRAdvanceCyclePhase(bbr_cc, ts);
+  }
+}
+
+void BBRAdvanceCyclePhase(ngtcp2_bbr_cc *bbr_cc, ngtcp2_tstamp ts) {
+  ngtcp2_log_info(bbr_cc->ccb.log, NGTCP2_LOG_EVENT_NONE, "BBR Trace # %s:%d",
+                  __func__, __LINE__);
+  bbr_cc->BBR.cycle_stamp = ts;
+  bbr_cc->BBR.cycle_index = (bbr_cc->BBR.cycle_index + 1) % BBRGainCycleLen;
+  bbr_cc->BBR.pacing_gain = pacing_gain_cycle[bbr_cc->BBR.cycle_index];
+}
+
+int BBRIsNextCyclePhase(ngtcp2_bbr_cc *bbr_cc, ngtcp2_tstamp ts) {
+  ngtcp2_log_info(bbr_cc->ccb.log, NGTCP2_LOG_EVENT_NONE, "BBR Trace # %s:%d",
+                  __func__, __LINE__);
+  int is_full_length = (ts - bbr_cc->BBR.cycle_stamp) > bbr_cc->BBR.RTprop;
+  if (bbr_cc->BBR.pacing_gain == 1) {
+    return is_full_length;
+  }
+  if (bbr_cc->BBR.pacing_gain > 1) {
+    return is_full_length && (bbr_cc->packets_lost > 0 ||
+                              bbr_cc->prior_inflight >=
+                                  BBRInflight(bbr_cc, bbr_cc->BBR.pacing_gain));
+  } else {
+    return is_full_length || bbr_cc->prior_inflight <= BBRInflight(bbr_cc, 1);
+  }
+}
+
+void BBRHandleRestartFromIdle(ngtcp2_bbr_cc *bbr_cc, ngtcp2_conn_stat *cstat) {
+  ngtcp2_log_info(bbr_cc->ccb.log, NGTCP2_LOG_EVENT_NONE, "BBR Trace # %s:%d",
+                  __func__, __LINE__);
+  if (cstat->bytes_in_flight == 0 && cstat->app_limited) {
+    bbr_cc->BBR.idle_start = 1;
+    if (bbr_cc->BBR.state == ProbeBW) {
+      BBRSetPacingRateWithGain(bbr_cc, 1);
+    }
+  }
+}
+
+void BBRCheckProbeRTT(ngtcp2_bbr_cc *bbr_cc, ngtcp2_conn_stat *cstat,
+                      ngtcp2_tstamp ts) {
+  ngtcp2_log_info(bbr_cc->ccb.log, NGTCP2_LOG_EVENT_NONE, "BBR Trace # %s:%d",
+                  __func__, __LINE__);
+  if (bbr_cc->BBR.state != ProbeRTT && bbr_cc->BBR.rtprop_expired &&
+      !bbr_cc->BBR.idle_restart) {
+    BBREnterProbeRTT(bbr_cc);
+    BBRSaveCwnd(bbr_cc, cstat);
+    bbr_cc->BBR.probe_rtt_done_stamp = 0;
+  }
+  if (bbr_cc->BBR.state == ProbeRTT) {
+    BBRHandleProbeRTT(bbr_cc, cstat, ts);
+  }
+  bbr_cc->BBR.idle_restart = 0;
+}
+
+void BBREnterProbeRTT(ngtcp2_bbr_cc *bbr_cc) {
+  ngtcp2_log_info(bbr_cc->ccb.log, NGTCP2_LOG_EVENT_NONE, "BBR Trace # %s:%d",
+                  __func__, __LINE__);
+  bbr_cc->BBR.state = ProbeRTT;
+  bbr_cc->BBR.pacing_gain = 1;
+  bbr_cc->BBR.cwnd_gain = 1;
+}
+
+void BBRHandleProbeRTT(ngtcp2_bbr_cc *bbr_cc, ngtcp2_conn_stat *cstat,
+                       ngtcp2_tstamp ts) {
+  ngtcp2_log_info(bbr_cc->ccb.log, NGTCP2_LOG_EVENT_NONE, "BBR Trace # %s:%d",
+                  __func__, __LINE__);
+  /* Ignore low rate samples during ProbeRTT: */
+  if (bbr_cc->BBR.probe_rtt_done_stamp == 0 &&
+      cstat->bytes_in_flight <= BBRMinPipeCwnd) {
+    bbr_cc->BBR.probe_rtt_done_stamp = ts + ProbeRTTDuration;
+    bbr_cc->BBR.probe_rtt_round_done = 0;
+    bbr_cc->BBR.next_round_delivered = bbr_cc->BBR.delivered;
+  } else if (bbr_cc->BBR.probe_rtt_done_stamp != 0) {
+    if (bbr_cc->BBR.round_start) {
+      bbr_cc->BBR.probe_rtt_round_done = 1;
+    }
+    if (bbr_cc->BBR.probe_rtt_round_done &&
+        ts > bbr_cc->BBR.probe_rtt_done_stamp) {
+      bbr_cc->BBR.rtprop_stamp = ts;
+      BBRRestoreCwnd(bbr_cc, cstat);
+      BBRExitProbeRTT(bbr_cc, ts);
+    }
+  }
+}
+
+void BBRExitProbeRTT(ngtcp2_bbr_cc *bbr_cc, ngtcp2_tstamp ts) {
+  ngtcp2_log_info(bbr_cc->ccb.log, NGTCP2_LOG_EVENT_NONE, "BBR Trace # %s:%d",
+                  __func__, __LINE__);
+  if (bbr_cc->BBR.filled_pipe) {
+    BBREnterProbeBW(bbr_cc, ts);
+  } else {
+    BBREnterStartup(bbr_cc);
+  }
+}

--- a/lib/ngtcp2_bbr.h
+++ b/lib/ngtcp2_bbr.h
@@ -1,0 +1,110 @@
+/*
+ * ngtcp2
+ *
+ * Copyright (c) 2018 ngtcp2 contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+#ifndef NGTCP2_BBR_H
+#define NGTCP2_BBR_H
+
+#ifdef HAVE_CONFIG_H
+#  include <config.h>
+#endif /* HAVE_CONFIG_H */
+
+#include <ngtcp2/ngtcp2.h>
+
+#define BtlBwFilterLen 10
+
+/* ngtcp2_bbr_cc is BBR congestion controller. */
+typedef struct ngtcp2_bbr_cc {
+  ngtcp2_cc_base ccb;
+
+  struct {
+    uint64_t BtlBw;
+    uint64_t BtlBwFilter[BtlBwFilterLen];
+    uint64_t RTprop;
+    uint64_t cwnd_gain;
+    uint64_t cycle_index;
+    uint64_t cycle_stamp;
+    uint64_t filled_pipe;
+    uint64_t full_bw;
+    uint64_t full_bw_count;
+    uint64_t idle_restart;
+    uint64_t idle_start;
+    uint64_t delivered;
+    uint64_t next_round_delivered;
+    double pacing_gain;
+    uint64_t pacing_rate;
+    uint64_t packet_conservation;
+    uint64_t prior_cwnd;
+    uint64_t probe_rtt_done_stamp;
+    uint64_t probe_rtt_round_done;
+    uint64_t round_count;
+    uint64_t round_start;
+    uint64_t rtprop_expired;
+    uint64_t rtprop_stamp;
+    uint64_t send_quantum;
+    uint64_t state;
+    uint64_t target_cwnd;
+  } BBR;
+  uint64_t packets_delivered;
+  uint64_t packets_lost;
+  uint64_t prior_inflight;
+} ngtcp2_bbr_cc;
+
+int ngtcp2_cc_bbr_cc_init(ngtcp2_cc *cc, ngtcp2_log *log,
+                          const ngtcp2_mem *mem);
+
+void ngtcp2_cc_bbr_cc_free(ngtcp2_cc *cc, const ngtcp2_mem *mem);
+
+void ngtcp2_bbr_cc_init(ngtcp2_bbr_cc *cc, ngtcp2_log *log);
+
+void ngtcp2_bbr_cc_free(ngtcp2_bbr_cc *cc);
+
+void ngtcp2_cc_bbr_cc_on_pkt_acked(ngtcp2_cc *cc, ngtcp2_conn_stat *cstat,
+                                   const ngtcp2_cc_pkt *pkt, ngtcp2_tstamp ts);
+
+void ngtcp2_cc_bbr_cc_congestion_event(ngtcp2_cc *cc, ngtcp2_conn_stat *cstat,
+                                       ngtcp2_tstamp ts_sent, ngtcp2_tstamp ts);
+
+void ngtcp2_cc_bbr_cc_on_spurious_congestion(ngtcp2_cc *ccx,
+                                             ngtcp2_conn_stat *cstat,
+                                             ngtcp2_tstamp ts);
+
+void ngtcp2_cc_bbr_cc_on_persistent_congestion(ngtcp2_cc *cc,
+                                               ngtcp2_conn_stat *cstat,
+                                               ngtcp2_tstamp ts);
+
+void ngtcp2_cc_bbr_cc_on_ack_recv(ngtcp2_cc *cc, ngtcp2_conn_stat *cstat,
+                                  ngtcp2_tstamp ts);
+
+void ngtcp2_cc_bbr_cc_on_pkt_sent(ngtcp2_cc *cc, ngtcp2_conn_stat *cstat,
+                                  const ngtcp2_cc_pkt *pkt);
+
+void ngtcp2_cc_bbr_cc_new_rtt_sample(ngtcp2_cc *cc, ngtcp2_conn_stat *cstat,
+                                     ngtcp2_tstamp ts);
+
+void ngtcp2_cc_bbr_cc_reset(ngtcp2_cc *cc);
+
+void ngtcp2_cc_bbr_cc_event(ngtcp2_cc *cc, ngtcp2_conn_stat *cstat,
+                            ngtcp2_cc_event_type event, ngtcp2_tstamp ts);
+
+#endif /* NGTCP2_CC_H */

--- a/lib/ngtcp2_bbr.h
+++ b/lib/ngtcp2_bbr.h
@@ -31,17 +31,17 @@
 
 #include <ngtcp2/ngtcp2.h>
 
-#define BtlBwFilterLen 10
+#define BBR_BTL_BW_FILTER_LEN 10
 
 /* ngtcp2_bbr_cc is BBR congestion controller. */
 typedef struct ngtcp2_bbr_cc {
   ngtcp2_cc_base ccb;
 
   struct {
-    uint64_t BtlBw;
-    uint64_t BtlBwFilter[BtlBwFilterLen];
-    uint64_t RTprop;
-    uint64_t cwnd_gain;
+    uint64_t btl_bw;
+    uint64_t btl_bw_filter[BBR_BTL_BW_FILTER_LEN];
+    uint64_t rt_prop;
+    double cwnd_gain;
     uint64_t cycle_index;
     uint64_t cycle_stamp;
     uint64_t filled_pipe;
@@ -52,7 +52,7 @@ typedef struct ngtcp2_bbr_cc {
     uint64_t delivered;
     uint64_t next_round_delivered;
     double pacing_gain;
-    uint64_t pacing_rate;
+    double pacing_rate;
     uint64_t packet_conservation;
     uint64_t prior_cwnd;
     uint64_t probe_rtt_done_stamp;
@@ -64,8 +64,7 @@ typedef struct ngtcp2_bbr_cc {
     uint64_t send_quantum;
     uint64_t state;
     uint64_t target_cwnd;
-  } BBR;
-  uint64_t packets_delivered;
+  } bbr;
   uint64_t packets_lost;
   uint64_t prior_inflight;
 } ngtcp2_bbr_cc;

--- a/lib/ngtcp2_bbr.h
+++ b/lib/ngtcp2_bbr.h
@@ -33,40 +33,70 @@
 
 #define BBR_BTL_BW_FILTER_LEN 10
 
-/* ngtcp2_bbr_cc is BBR congestion controller. */
+/*
+ * ngtcp2_bbr_cc is BBR congestion controller, described in
+ * https://tools.ietf.org/html/draft-cardwell-iccrg-bbr-congestion-control-00
+ */
 typedef struct ngtcp2_bbr_cc {
   ngtcp2_cc_base ccb;
 
   struct {
+    /* BBR's estimated bottleneck bandwidth available to the
+       transport flow, estimated from the maximum delivery rate sample in a
+       sliding window. */
     uint64_t btl_bw;
+    /* The max filter used to estimate BBR.BtlBw. */
     uint64_t btl_bw_filter[BBR_BTL_BW_FILTER_LEN];
+    /* BBR's estimated two-way round-trip propagation delay of
+       the path, estimated from the windowed minimum recent round-trip delay
+       sample. */
     uint64_t rt_prop;
+    /* The dynamic gain factor used to scale the estimated BDP to produce a
+       congestion window (cwnd). */
     double cwnd_gain;
     uint64_t cycle_index;
     uint64_t cycle_stamp;
+    /* A boolean that records whether BBR estimates that it has ever fully
+       utilized its available bandwidth ("filled the pipe"). */
     uint64_t filled_pipe;
     uint64_t full_bw;
     uint64_t full_bw_count;
     uint64_t idle_restart;
     uint64_t idle_start;
+    /* TODO: FIXME: what's the usage of delivered? */
     uint64_t delivered;
+    /* packet.delivered value denoting the end of a packet-timed round trip. */
     uint64_t next_round_delivered;
+    /* The dynamic gain factor used to scale BBR.BtlBw to
+           produce BBR.pacing_rate. */
     double pacing_gain;
+    /* The current pacing rate for a BBR flow,
+       which controls inter-packet spacing. */
     double pacing_rate;
     uint64_t packet_conservation;
     uint64_t prior_cwnd;
     uint64_t probe_rtt_done_stamp;
     uint64_t probe_rtt_round_done;
+    /* Count of packet-timed round trips. */
     uint64_t round_count;
+    /* A boolean that BBR sets to true once per packet-timed round trip,
+       on ACKs that advance BBR.round_count. */
     uint64_t round_start;
     uint64_t rtprop_expired;
+    /* The wall clock time at which the current BBR.RTProp
+       sample was obtained. */
     uint64_t rtprop_stamp;
+    /* The maximum size of a data aggregate scheduled and
+       transmitted together. */
     uint64_t send_quantum;
     uint64_t state;
+    /* target_cwnd is the upper bound on the volume of data BBR
+       allows in flight. */
     uint64_t target_cwnd;
   } bbr;
   uint64_t packets_lost;
   uint64_t prior_inflight;
+  uint64_t next_send_time;
 } ngtcp2_bbr_cc;
 
 int ngtcp2_cc_bbr_cc_init(ngtcp2_cc *cc, ngtcp2_log *log,
@@ -106,5 +136,7 @@ void ngtcp2_cc_bbr_cc_reset(ngtcp2_cc *cc);
 
 void ngtcp2_cc_bbr_cc_event(ngtcp2_cc *cc, ngtcp2_conn_stat *cstat,
                             ngtcp2_cc_event_type event, ngtcp2_tstamp ts);
+
+int ngtcp2_cc_bbr_cc_on_pace_time_to_send(ngtcp2_cc *ccx, ngtcp2_tstamp ts);
 
 #endif /* NGTCP2_CC_H */

--- a/lib/ngtcp2_bbr.h
+++ b/lib/ngtcp2_bbr.h
@@ -71,11 +71,12 @@ typedef struct ngtcp2_bbr_cc {
 } ngtcp2_bbr_cc;
 
 int ngtcp2_cc_bbr_cc_init(ngtcp2_cc *cc, ngtcp2_log *log,
-                          const ngtcp2_mem *mem);
+                          ngtcp2_tstamp initial_ts, const ngtcp2_mem *mem);
 
 void ngtcp2_cc_bbr_cc_free(ngtcp2_cc *cc, const ngtcp2_mem *mem);
 
-void ngtcp2_bbr_cc_init(ngtcp2_bbr_cc *cc, ngtcp2_log *log);
+void ngtcp2_bbr_cc_init(ngtcp2_bbr_cc *bbr_cc, ngtcp2_tstamp initial_ts,
+                        ngtcp2_log *log);
 
 void ngtcp2_bbr_cc_free(ngtcp2_bbr_cc *cc);
 

--- a/lib/ngtcp2_cc.c
+++ b/lib/ngtcp2_cc.c
@@ -42,12 +42,16 @@ uint64_t ngtcp2_cc_compute_initcwnd(size_t max_udp_payload_size) {
 }
 
 ngtcp2_cc_pkt *ngtcp2_cc_pkt_init(ngtcp2_cc_pkt *pkt, int64_t pkt_num,
-                                  size_t pktlen, ngtcp2_pktns_id pktns_id,
+                                  size_t pktlen, uint64_t delivered,
+                                  uint64_t is_app_limited,
+                                  ngtcp2_pktns_id pktns_id,
                                   ngtcp2_tstamp ts_sent) {
   pkt->pkt_num = pkt_num;
   pkt->pktlen = pktlen;
   pkt->pktns_id = pktns_id;
   pkt->ts_sent = ts_sent;
+  pkt->delivered = delivered;
+  pkt->is_app_limited = is_app_limited;
 
   return pkt;
 }

--- a/lib/ngtcp2_cc.h
+++ b/lib/ngtcp2_cc.h
@@ -42,7 +42,9 @@ typedef struct ngtcp2_log ngtcp2_log;
 uint64_t ngtcp2_cc_compute_initcwnd(size_t max_packet_size);
 
 ngtcp2_cc_pkt *ngtcp2_cc_pkt_init(ngtcp2_cc_pkt *pkt, int64_t pkt_num,
-                                  size_t pktlen, ngtcp2_pktns_id pktns_id,
+                                  size_t pktlen, uint64_t delivered,
+                                  uint64_t is_app_limited,
+                                  ngtcp2_pktns_id pktns_id,
                                   ngtcp2_tstamp ts_sent);
 
 /* ngtcp2_reno_cc is the RENO congestion controller. */

--- a/lib/ngtcp2_conn.c
+++ b/lib/ngtcp2_conn.c
@@ -562,6 +562,7 @@ static void conn_reset_conn_stat_cc(ngtcp2_conn *conn,
   cstat->ssthresh = UINT64_MAX;
   cstat->congestion_recovery_start_ts = UINT64_MAX;
   cstat->bytes_in_flight = 0;
+  cstat->delivered = 0;
   cstat->delivery_rate_sec = 0;
   cstat->app_limited = 0;
 }

--- a/lib/ngtcp2_conn.c
+++ b/lib/ngtcp2_conn.c
@@ -860,7 +860,8 @@ static int conn_new(ngtcp2_conn **pconn, const ngtcp2_cid *dcid,
     }
     break;
   case NGTCP2_CC_ALGO_BBR:
-    rv = ngtcp2_cc_bbr_cc_init(&(*pconn)->cc, &(*pconn)->log, mem);
+    rv = ngtcp2_cc_bbr_cc_init(&(*pconn)->cc, &(*pconn)->log,
+                               settings->initial_ts, mem);
     if (rv != 0) {
       goto fail_cc_init;
     }

--- a/lib/ngtcp2_conn.h
+++ b/lib/ngtcp2_conn.h
@@ -42,6 +42,7 @@
 #include "ngtcp2_log.h"
 #include "ngtcp2_pq.h"
 #include "ngtcp2_cc.h"
+#include "ngtcp2_bbr.h"
 #include "ngtcp2_pv.h"
 #include "ngtcp2_cid.h"
 #include "ngtcp2_buf.h"

--- a/lib/ngtcp2_rst.c
+++ b/lib/ngtcp2_rst.c
@@ -79,6 +79,7 @@ int ngtcp2_rst_on_ack_recv(ngtcp2_rst *rst, ngtcp2_conn_stat *cstat) {
   }
 
   if (rs->interval) {
+    cstat->delivered = rs->delivered;
     cstat->delivery_rate_sec = rs->delivered * NGTCP2_SECONDS / rs->interval;
   }
 

--- a/lib/ngtcp2_rst.c
+++ b/lib/ngtcp2_rst.c
@@ -63,6 +63,8 @@ int ngtcp2_rst_on_ack_recv(ngtcp2_rst *rst, ngtcp2_conn_stat *cstat) {
     rst->app_limited = 0;
   }
 
+  cstat->app_limited = rst->app_limited;
+
   if (rs->prior_ts == 0) {
     return 0;
   }

--- a/lib/ngtcp2_rst.c
+++ b/lib/ngtcp2_rst.c
@@ -70,7 +70,6 @@ int ngtcp2_rst_on_ack_recv(ngtcp2_rst *rst, ngtcp2_conn_stat *cstat) {
   }
 
   rs->interval = ngtcp2_max(rs->send_elapsed, rs->ack_elapsed);
-
   rs->delivered = rst->delivered - rs->prior_delivered;
 
   if (rs->interval < cstat->min_rtt) {

--- a/lib/ngtcp2_rtb.c
+++ b/lib/ngtcp2_rtb.c
@@ -726,10 +726,11 @@ static void rtb_on_pkt_acked(ngtcp2_rtb *rtb, ngtcp2_rtb_entry *ent,
 
   ngtcp2_rst_update_rate_sample(rtb->rst, ent, ts);
 
-  cc->on_pkt_acked(cc, cstat,
-                   ngtcp2_cc_pkt_init(&pkt, ent->hd.pkt_num, ent->pktlen,
-                                      rtb->pktns_id, ent->ts),
-                   ts);
+  cc->on_pkt_acked(
+      cc, cstat,
+      ngtcp2_cc_pkt_init(&pkt, ent->hd.pkt_num, ent->pktlen, ent->rst.delivered,
+                         ent->rst.is_app_limited, rtb->pktns_id, ent->ts),
+      ts);
 
   if (!(ent->flags & NGTCP2_RTB_ENTRY_FLAG_PROBE) &&
       (ent->flags & NGTCP2_RTB_ENTRY_FLAG_ACK_ELICITING)) {


### PR DESCRIPTION
Hi, I'm the developer of [srs](https://github.com/ossrs/srs) , thanks to all the contributors of ngtcp2, it's an awesome project. I use ngtcp2 in my project [srs](https://github.com/ossrs/srs) to transport media streams between different servers. And cubic cc can't meet my needs when transmitting stream in a complex network(long RTT, high loss present), and I add BBR to make it good.
I implement the BBR algorithm described in [bbr](https://tools.ietf.org/html/draft-cardwell-iccrg-bbr-congestion-control-00), and test it uses a live media stream from the U.S. to China.

The picture blew is transmit live media stream using cubic cc.
![cubic](https://user-images.githubusercontent.com/8449258/121767763-020a7880-cb8d-11eb-9cc1-683f7e18da41.png)
This picture blew is transmit live media stream using BBR cc.
![bbr](https://user-images.githubusercontent.com/8449258/121767772-0fbffe00-cb8d-11eb-92db-718acb208ac1.png)

I hope you can help me to check the code, and make more test cases.