### PR TITLE
Example 'simpleclient' with GnuTLS lib

### DIFF
--- a/examples/.gitignore
+++ b/examples/.gitignore
@@ -9,3 +9,4 @@ bsslclient
 bsslserver
 perfserver
 simpleclient
+gtlssimpleclient

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -21,134 +21,181 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-if(LIBEV_FOUND AND HAVE_OPENSSL AND LIBNGHTTP3_FOUND)
-  set(client_SOURCES
-    client.cc
-    client_base.cc
-    debug.cc
-    util.cc
-    shared.cc
-    tls_client_context_openssl.cc
-    tls_client_session_openssl.cc
-    tls_session_base_openssl.cc
-    util_openssl.cc
+if(LIBEV_FOUND AND HAVE_OPENSSL)
+  set(simpleclient_SOURCES
+    simpleclient.c
   )
 
-  set(server_SOURCES
-    server.cc
-    server_base.cc
-    debug.cc
-    util.cc
-    http.cc
-    shared.cc
-    tls_server_context_openssl.cc
-    tls_server_session_openssl.cc
-    tls_session_base_openssl.cc
-    util_openssl.cc util_aead_openssl.cc
-  )
-
-  set(ossl_INCLUDE_DIRS
+  set(simpleclient_INCLUDE_DIRS
     ${CMAKE_SOURCE_DIR}/lib/includes
     ${CMAKE_BINARY_DIR}/lib/includes
-    ${CMAKE_SOURCE_DIR}/third-party
     ${CMAKE_SOURCE_DIR}/crypto/includes
 
     ${OPENSSL_INCLUDE_DIRS}
     ${LIBEV_INCLUDE_DIRS}
-    ${LIBNGHTTP3_INCLUDE_DIRS}
   )
 
-  set(ossl_LIBS
-    ngtcp2_crypto_openssl
-    ngtcp2
-    ${OPENSSL_LIBRARIES}
-    ${LIBEV_LIBRARIES}
-    ${LIBNGHTTP3_LIBRARIES}
+  add_executable(simpleclient ${simpleclient_SOURCES})
+  set_target_properties(simpleclient PROPERTIES
+    COMPILE_FLAGS "-Wall -DENABLE_EXAMPLE_OPENSSL -DWITH_EXAMPLE_OPENSSL"
+    C_STANDARD 11
   )
+  target_include_directories(simpleclient PUBLIC ${simpleclient_INCLUDE_DIRS})
+  target_link_libraries(simpleclient ngtcp2_crypto_openssl ngtcp2 ${OPENSSL_LIBRARIES} ${LIBEV_LIBRARIES})
 
-  add_executable(client ${client_SOURCES} $<TARGET_OBJECTS:http-parser>)
-  add_executable(server ${server_SOURCES} $<TARGET_OBJECTS:http-parser>)
-  set_target_properties(client PROPERTIES
-    COMPILE_FLAGS "${WARNCXXFLAGS} -DENABLE_EXAMPLE_OPENSSL -DWITH_EXAMPLE_OPENSSL"
-    CXX_STANDARD 17
-    CXX_STANDARD_REQUIRED ON
-  )
-  set_target_properties(server PROPERTIES
-    COMPILE_FLAGS "${WARNCXXFLAGS} -DENABLE_EXAMPLE_OPENSSL -DWITH_EXAMPLE_OPENSSL"
-    CXX_STANDARD 17
-    CXX_STANDARD_REQUIRED ON
-  )
-  target_include_directories(client PUBLIC ${ossl_INCLUDE_DIRS})
-  target_include_directories(server PUBLIC ${ossl_INCLUDE_DIRS})
-  target_link_libraries(client ${ossl_LIBS})
-  target_link_libraries(server ${ossl_LIBS})
+  if(LIBNGHTTP3_FOUND)
+    set(client_SOURCES
+      client.cc
+      client_base.cc
+      debug.cc
+      util.cc
+      shared.cc
+      tls_client_context_openssl.cc
+      tls_client_session_openssl.cc
+      tls_session_base_openssl.cc
+      util_openssl.cc
+    )
 
-  # TODO prevent client and example servers from being installed?
+    set(server_SOURCES
+      server.cc
+      server_base.cc
+      debug.cc
+      util.cc
+      http.cc
+      shared.cc
+      tls_server_context_openssl.cc
+      tls_server_session_openssl.cc
+      tls_session_base_openssl.cc
+      util_openssl.cc util_aead_openssl.cc
+    )
+
+    set(ossl_INCLUDE_DIRS
+      ${CMAKE_SOURCE_DIR}/lib/includes
+      ${CMAKE_BINARY_DIR}/lib/includes
+      ${CMAKE_SOURCE_DIR}/third-party
+      ${CMAKE_SOURCE_DIR}/crypto/includes
+
+      ${OPENSSL_INCLUDE_DIRS}
+      ${LIBEV_INCLUDE_DIRS}
+      ${LIBNGHTTP3_INCLUDE_DIRS}
+    )
+
+    set(ossl_LIBS
+      ngtcp2_crypto_openssl
+      ngtcp2
+      ${OPENSSL_LIBRARIES}
+      ${LIBEV_LIBRARIES}
+      ${LIBNGHTTP3_LIBRARIES}
+    )
+
+    add_executable(client ${client_SOURCES} $<TARGET_OBJECTS:http-parser>)
+    add_executable(server ${server_SOURCES} $<TARGET_OBJECTS:http-parser>)
+    set_target_properties(client PROPERTIES
+      COMPILE_FLAGS "${WARNCXXFLAGS} -DENABLE_EXAMPLE_OPENSSL -DWITH_EXAMPLE_OPENSSL"
+      CXX_STANDARD 17
+      CXX_STANDARD_REQUIRED ON
+    )
+    set_target_properties(server PROPERTIES
+      COMPILE_FLAGS "${WARNCXXFLAGS} -DENABLE_EXAMPLE_OPENSSL -DWITH_EXAMPLE_OPENSSL"
+      CXX_STANDARD 17
+      CXX_STANDARD_REQUIRED ON
+    )
+    target_include_directories(client PUBLIC ${ossl_INCLUDE_DIRS})
+    target_include_directories(server PUBLIC ${ossl_INCLUDE_DIRS})
+    target_link_libraries(client ${ossl_LIBS})
+    target_link_libraries(server ${ossl_LIBS})
+
+    # TODO prevent client and example servers from being installed?
+  endif()
 endif()
 
-if(LIBEV_FOUND AND HAVE_GNUTLS AND LIBNGHTTP3_FOUND)
-  set(gtlsclient_SOURCES
-    client.cc
-    client_base.cc
-    debug.cc
-    util.cc
-    shared.cc
-    tls_client_context_gnutls.cc
-    tls_client_session_gnutls.cc
-    tls_session_base_gnutls.cc
-    util_gnutls.cc
+if(LIBEV_FOUND AND HAVE_GNUTLS)
+  set(gtlssimpleclient_SOURCES
+    simpleclient.c
   )
 
-  set(gtlsserver_SOURCES
-    server.cc
-    server_base.cc
-    debug.cc
-    util.cc
-    http.cc
-    shared.cc
-    tls_server_context_gnutls.cc
-    tls_server_session_gnutls.cc
-    tls_session_base_gnutls.cc
-    util_gnutls.cc
-  )
-
-  set(gtls_INCLUDE_DIRS
+  set(gtlssimpleclient_INCLUDE_DIRS
     ${CMAKE_SOURCE_DIR}/lib/includes
     ${CMAKE_BINARY_DIR}/lib/includes
-    ${CMAKE_SOURCE_DIR}/third-party
     ${CMAKE_SOURCE_DIR}/crypto/includes
 
     ${GNUTLS_INCLUDE_DIRS}
     ${LIBEV_INCLUDE_DIRS}
-    ${LIBNGHTTP3_INCLUDE_DIRS}
   )
 
-  set(gtls_LIBS
-    ngtcp2_crypto_gnutls
-    ngtcp2
-    ${GNUTLS_LIBRARIES}
-    ${LIBEV_LIBRARIES}
-    ${LIBNGHTTP3_LIBRARIES}
+  add_executable(gtlssimpleclient ${gtlssimpleclient_SOURCES})
+  set_target_properties(gtlssimpleclient PROPERTIES
+    COMPILE_FLAGS "-Wall -DENABLE_EXAMPLE_GNUTLS -DWITH_EXAMPLE_GNUTLS"
+    C_STANDARD 11
+    C_STANDARD_REQUIRED ON
   )
+  target_include_directories(gtlssimpleclient PUBLIC ${gtlssimpleclient_INCLUDE_DIRS})
+  target_link_libraries(gtlssimpleclient ngtcp2_crypto_gnutls ngtcp2 ${GNUTLS_LIBRARIES} ${LIBEV_LIBRARIES})
 
-  add_executable(gtlsclient ${gtlsclient_SOURCES} $<TARGET_OBJECTS:http-parser>)
-  add_executable(gtlsserver ${gtlsserver_SOURCES} $<TARGET_OBJECTS:http-parser>)
-  set_target_properties(gtlsclient PROPERTIES
-    COMPILE_FLAGS "${WARNCXXFLAGS} -DENABLE_EXAMPLE_GNUTLS -DWITH_EXAMPLE_GNUTLS"
-    CXX_STANDARD 17
-    CXX_STANDARD_REQUIRED ON
-  )
-  set_target_properties(gtlsserver PROPERTIES
-    COMPILE_FLAGS "${WARNCXXFLAGS} -DENABLE_EXAMPLE_GNUTLS -DWITH_EXAMPLE_GNUTLS"
-    CXX_STANDARD 17
-    CXX_STANDARD_REQUIRED ON
-  )
-  target_include_directories(gtlsclient PUBLIC ${gtls_INCLUDE_DIRS})
-  target_include_directories(gtlsserver PUBLIC ${gtls_INCLUDE_DIRS})
-  target_link_libraries(gtlsclient ${gtls_LIBS})
-  target_link_libraries(gtlsserver ${gtls_LIBS})
+  if(LIBNGHTTP3_FOUND)
+    set(gtlsclient_SOURCES
+      client.cc
+      client_base.cc
+      debug.cc
+      util.cc
+      shared.cc
+      tls_client_context_gnutls.cc
+      tls_client_session_gnutls.cc
+      tls_session_base_gnutls.cc
+      util_gnutls.cc
+    )
+
+    set(gtlsserver_SOURCES
+      server.cc
+      server_base.cc
+      debug.cc
+      util.cc
+      http.cc
+      shared.cc
+      tls_server_context_gnutls.cc
+      tls_server_session_gnutls.cc
+      tls_session_base_gnutls.cc
+      util_gnutls.cc
+    )
+
+    set(gtls_INCLUDE_DIRS
+      ${CMAKE_SOURCE_DIR}/lib/includes
+      ${CMAKE_BINARY_DIR}/lib/includes
+      ${CMAKE_SOURCE_DIR}/third-party
+      ${CMAKE_SOURCE_DIR}/crypto/includes
+
+      ${GNUTLS_INCLUDE_DIRS}
+      ${LIBEV_INCLUDE_DIRS}
+      ${LIBNGHTTP3_INCLUDE_DIRS}
+    )
+
+    set(gtls_LIBS
+      ngtcp2_crypto_gnutls
+      ngtcp2
+      ${GNUTLS_LIBRARIES}
+      ${LIBEV_LIBRARIES}
+      ${LIBNGHTTP3_LIBRARIES}
+    )
+
+    add_executable(gtlsclient ${gtlsclient_SOURCES} $<TARGET_OBJECTS:http-parser>)
+    add_executable(gtlsserver ${gtlsserver_SOURCES} $<TARGET_OBJECTS:http-parser>)
+    set_target_properties(gtlsclient PROPERTIES
+      COMPILE_FLAGS "${WARNCXXFLAGS} -DENABLE_EXAMPLE_GNUTLS -DWITH_EXAMPLE_GNUTLS"
+      CXX_STANDARD 17
+      CXX_STANDARD_REQUIRED ON
+    )
+    set_target_properties(gtlsserver PROPERTIES
+      COMPILE_FLAGS "${WARNCXXFLAGS} -DENABLE_EXAMPLE_GNUTLS -DWITH_EXAMPLE_GNUTLS"
+      CXX_STANDARD 17
+      CXX_STANDARD_REQUIRED ON
+    )
+    target_include_directories(gtlsclient PUBLIC ${gtls_INCLUDE_DIRS})
+    target_include_directories(gtlsserver PUBLIC ${gtls_INCLUDE_DIRS})
+    target_link_libraries(gtlsclient ${gtls_LIBS})
+    target_link_libraries(gtlsserver ${gtls_LIBS})
 
   # TODO prevent gtlsclient and example gtlsservers from being installed?
+  endif()
 endif()
 
 if(LIBEV_FOUND AND HAVE_BORINGSSL AND LIBNGHTTP3_FOUND)

--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -115,7 +115,16 @@ perfserver_SOURCES = perfserver.cc perfserver.h ${SERVER_SRCS} \
 endif # ENABLE_EXAMPLE_OPENSSL
 
 if ENABLE_EXAMPLE_GNUTLS
-noinst_PROGRAMS += gtlsclient gtlsserver
+# Missing 'h09client h09server perfserver' (??)
+noinst_PROGRAMS += gtlsclient gtlsserver gtlssimpleclient
+
+gtlssimpleclient_CPPFLAGS = ${AM_CPPFLAGS} \
+	@JEMALLOC_CFLAGS@ @GNUTLS_CFLAGS@ -DWITH_EXAMPLE_GNUTLS
+gtlssimpleclient_LDADD = ${LDADD} \
+	$(top_builddir)/crypto/gnutls/libngtcp2_crypto_gnutls.la \
+	@GNUTLS_LIBS@ \
+	@JEMALLOC_LIBS@
+gtlssimpleclient_SOURCES = simpleclient.c
 
 gtlsclient_CPPFLAGS = ${AM_CPPFLAGS} \
 	@JEMALLOC_CFLAGS@ @GNUTLS_CFLAGS@ -DWITH_EXAMPLE_GNUTLS


### PR DESCRIPTION
Port of simpleclient to GnuTLS.
As total newbie in `ngtcp2` i would like to ask to revisit my code before pull.
**Feature:**
- add build of `gtlssimpleclient` into `autotools` build script
- add build of whole simpleclient example into `cmake` build script
- expand code with gnutls library

**TODO:**
- [ ] I don't have the correct `openssl` installed, could someone test the retained functionality?
- [ ] Someone who understand autotools better than me, can you decide `noinst_PROGRAMS` of GnuTLS?
- [x] Are commented-out DEFAULT_CIPHERS and DEFAULT_GROUPS part of QUIC standard?
- [ ] Refactoring (and remove of optional options)