### PR TITLE
Fix incorrect return value from ngtcp2_pkt_decode_datagram_frame()

### DIFF
--- a/lib/ngtcp2_pkt.c
+++ b/lib/ngtcp2_pkt.c
@@ -1428,7 +1428,7 @@ ngtcp2_ssize ngtcp2_pkt_decode_datagram_frame(ngtcp2_datagram *dest,
 
     vi = ngtcp2_get_varint(&n, p);
     if (payloadlen - len < vi) {
-      return NGTCP2_FRAME_ENCODING_ERROR;
+      return NGTCP2_ERR_FRAME_ENCODING;
     }
 
     datalen = (size_t)vi;


### PR DESCRIPTION
The value returned from ngtcp2_pkt_decode_datagram_frame() is later returned from ngtcp2_pkt_decode_frame(). According to its contract, ngtcp2_pkt_decode_frame() returns NGTCP2_ERR_FRAME_ENCODING when the payload is too short.