### PR TITLE
Suppress compiler warnings for NDEBUG

### DIFF
--- a/crypto/openssl/openssl.c
+++ b/crypto/openssl/openssl.c
@@ -53,6 +53,7 @@ static size_t crypto_aead_max_overhead(const EVP_CIPHER *aead) {
     return EVP_CCM_TLS_TAG_LEN;
   default:
     assert(0);
+    abort(); /* if NDEBUG is set */
   }
 }
 
@@ -630,6 +631,7 @@ ngtcp2_crypto_level ngtcp2_crypto_openssl_from_ossl_encryption_level(
     return NGTCP2_CRYPTO_LEVEL_APPLICATION;
   default:
     assert(0);
+    abort(); /* if NDEBUG is set */
   }
 }
 
@@ -647,6 +649,7 @@ ngtcp2_crypto_openssl_from_ngtcp2_crypto_level(
     return ssl_encryption_early_data;
   default:
     assert(0);
+    abort(); /* if NDEBUG is set */
   }
 }
 

--- a/crypto/shared.c
+++ b/crypto/shared.c
@@ -883,8 +883,8 @@ int ngtcp2_crypto_verify_retry_token(
 
 static size_t crypto_generate_regular_token_aad(uint8_t *dest,
                                                 const struct sockaddr *sa) {
-  const uint8_t *addr;
-  size_t addrlen;
+  const uint8_t *addr = NULL;
+  size_t addrlen = 0;
 
   switch (sa->sa_family) {
   case AF_INET:

--- a/lib/ngtcp2_map.c
+++ b/lib/ngtcp2_map.c
@@ -204,6 +204,7 @@ static int map_resize(ngtcp2_map *map, uint32_t new_tablelen,
                 bkt->data);
 
     assert(0 == rv);
+    (void)rv;
   }
 
   ngtcp2_mem_free(map->mem, map->table);

--- a/lib/ngtcp2_pkt.c
+++ b/lib/ngtcp2_pkt.c
@@ -1396,7 +1396,7 @@ ngtcp2_ssize ngtcp2_pkt_decode_datagram_frame(ngtcp2_datagram *dest,
   size_t len = 1;
   const uint8_t *p;
   uint8_t type;
-  size_t datalen;
+  size_t datalen = 0;
   size_t n;
   uint64_t vi;
 

--- a/lib/ngtcp2_rtb.c
+++ b/lib/ngtcp2_rtb.c
@@ -580,6 +580,7 @@ static void rtb_remove(ngtcp2_rtb *rtb, ngtcp2_ksl_it *it,
   int rv;
   rv = ngtcp2_ksl_remove_hint(&rtb->ents, it, it, &ent->hd.pkt_num);
   assert(0 == rv);
+  (void)rv;
   rtb_on_remove(rtb, ent, cstat);
 
   assert(ent->next == NULL);
@@ -624,7 +625,7 @@ static int rtb_process_acked_pkt(ngtcp2_rtb *rtb, ngtcp2_rtb_entry *ent,
   int rv;
   uint64_t datalen;
   ngtcp2_strm *crypto = rtb->crypto;
-  ngtcp2_pktns *pktns;
+  ngtcp2_pktns *pktns = NULL;
 
   for (frc = ent->frc; frc; frc = frc->next) {
     if (frc->binder) {
@@ -1196,6 +1197,7 @@ void ngtcp2_rtb_remove_excessive_lost_pkt(ngtcp2_rtb *rtb, size_t n) {
     --rtb->num_lost_pkts;
     rv = ngtcp2_ksl_remove_hint(&rtb->ents, &it, &it, &ent->hd.pkt_num);
     assert(0 == rv);
+    (void)rv;
     ngtcp2_rtb_entry_del(ent, rtb->mem);
   }
 }
@@ -1229,6 +1231,7 @@ void ngtcp2_rtb_remove_expired_lost_pkt(ngtcp2_rtb *rtb, ngtcp2_duration pto,
     --rtb->num_lost_pkts;
     rv = ngtcp2_ksl_remove_hint(&rtb->ents, &it, &it, &ent->hd.pkt_num);
     assert(0 == rv);
+    (void)rv;
     ngtcp2_rtb_entry_del(ent, rtb->mem);
 
     if (ngtcp2_ksl_len(&rtb->ents) == 0) {
@@ -1418,6 +1421,7 @@ void ngtcp2_rtb_remove_early_data(ngtcp2_rtb *rtb, ngtcp2_conn_stat *cstat) {
     rtb_on_remove(rtb, ent, cstat);
     rv = ngtcp2_ksl_remove_hint(&rtb->ents, &it, &it, &ent->hd.pkt_num);
     assert(0 == rv);
+    (void)rv;
 
     ngtcp2_rtb_entry_del(ent, rtb->mem);
   }

--- a/tests/ngtcp2_conn_test.c
+++ b/tests/ngtcp2_conn_test.c
@@ -320,6 +320,7 @@ static int update_key(ngtcp2_conn *conn, uint8_t *rx_secret, uint8_t *tx_secret,
   (void)current_rx_secret;
   (void)current_tx_secret;
   (void)user_data;
+  (void)secretlen;
 
   assert(sizeof(null_secret) == secretlen);
 
@@ -549,6 +550,7 @@ static void conn_set_scid_used(ngtcp2_conn *conn) {
   rv = ngtcp2_pq_push(&conn->scid.used, &scid->pe);
 
   assert(0 == rv);
+  (void)rv;
 }
 
 static void setup_default_server(ngtcp2_conn **pconn) {

--- a/tests/ngtcp2_test_helper.c
+++ b/tests/ngtcp2_test_helper.c
@@ -140,6 +140,7 @@ size_t write_single_frame_pkt_flags(uint8_t *out, size_t outlen, uint8_t flags,
   assert(0 == rv);
   rv = ngtcp2_ppe_encode_frame(&ppe, fr);
   assert(0 == rv);
+  (void)rv;
   n = ngtcp2_ppe_final(&ppe, NULL);
   assert(n > 0);
 
@@ -175,6 +176,7 @@ size_t write_pkt_flags(uint8_t *out, size_t outlen, uint8_t flags,
   ngtcp2_ppe_init(&ppe, out, outlen, &cc);
   rv = ngtcp2_ppe_encode_hd(&ppe, &hd);
   assert(0 == rv);
+  (void)rv;
 
   for (i = 0; i < frlen; ++i, ++fr) {
     rv = ngtcp2_ppe_encode_frame(&ppe, fr);
@@ -212,6 +214,7 @@ size_t write_single_frame_pkt_without_conn_id(uint8_t *out, size_t outlen,
   assert(0 == rv);
   n = ngtcp2_ppe_final(&ppe, NULL);
   assert(n > 0);
+  (void)rv;
   return (size_t)n;
 }
 
@@ -255,6 +258,7 @@ static size_t write_single_frame_handshake_pkt_generic(
   assert(0 == rv);
   n = ngtcp2_ppe_final(&ppe, NULL);
   assert(n > 0);
+  (void)rv;
   return (size_t)n;
 }
 
@@ -323,6 +327,7 @@ size_t write_handshake_pkt(uint8_t *out, size_t outlen, uint8_t pkt_type,
   ngtcp2_ppe_init(&ppe, out, outlen, &cc);
   rv = ngtcp2_ppe_encode_hd(&ppe, &hd);
   assert(0 == rv);
+  (void)rv;
 
   for (i = 0; i < frlen; ++i) {
     fr = &fra[i];
@@ -344,6 +349,7 @@ ngtcp2_strm *open_stream(ngtcp2_conn *conn, int64_t stream_id) {
 
   rv = ngtcp2_conn_init_stream(conn, strm, stream_id, NULL);
   assert(0 == rv);
+  (void)rv;
 
   return strm;
 }


### PR DESCRIPTION
Currently when configuring using the following options there are a
number of compiler warnings generated:
```console
$ env CFLAGS='-DNDEBUG -O3' ./configure --enable-debug=no --disable-silent-rules --enable-werror PKG_CONFIG_PATH=$PWD/../openssl/build/lib/pkgconfig:$PWD/../nghttp3/build/lib/pkgconfig LDFLAGS="-Wl,-rpath,$PWD/../openssl/build/lib"
```
This commit contains suggestions to suppress these warnings.