### PR TITLE
Fix the non-standard alignment specifier for C++

### DIFF
--- a/lib/includes/ngtcp2/ngtcp2.h
+++ b/lib/includes/ngtcp2/ngtcp2.h
@@ -32,6 +32,11 @@
 #  define WIN32
 #endif
 
+#ifdef WIN32
+#  pragma warning(push)
+#  pragma warning(disable : 4324)
+#endif
+
 #include <stdlib.h>
 #if defined(_MSC_VER) && (_MSC_VER < 1800)
 /* MSVC < 2013 does not have inttypes.h because it is not C99
@@ -70,11 +75,9 @@
 #endif   /* !defined(WIN32) */
 
 #ifdef WIN32
-#  define NGTCP2_ALIGN_BEFORE(N) __declspec(align(N))
-#  define NGTCP2_ALIGN_AFTER(N)
+#  define NGTCP2_ALIGN(N) __declspec(align(N))
 #else /* !WIN32 */
-#  define NGTCP2_ALIGN_BEFORE(N)
-#  define NGTCP2_ALIGN_AFTER(N) __attribute__((aligned(N)))
+#  define NGTCP2_ALIGN(N) __attribute__((aligned(N)))
 #endif /* !WIN32 */
 
 #ifdef __cplusplus
@@ -456,7 +459,7 @@ typedef struct ngtcp2_mem {
  *
  * :type:`ngtcp2_pkt_info` is a packet metadata.
  */
-typedef NGTCP2_ALIGN_BEFORE(8) struct NGTCP2_ALIGN_AFTER(8) ngtcp2_pkt_info {
+typedef struct NGTCP2_ALIGN(8) ngtcp2_pkt_info {
   /**
    * :member:`ecn` is ECN marking and when passing
    * `ngtcp2_conn_read_pkt()`, and it should be either
@@ -5172,6 +5175,10 @@ NGTCP2_EXTERN int ngtcp2_path_eq(const ngtcp2_path *a, const ngtcp2_path *b);
  */
 #define ngtcp2_settings_default(SETTINGS)                                      \
   ngtcp2_settings_default_versioned(NGTCP2_SETTINGS_VERSION, (SETTINGS))
+
+#ifdef WIN32
+#  pragma warning(pop)
+#endif
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This is an additional fix for https://github.com/ngtcp2/ngtcp2/issues/337, but this one for MSVC.

----

Microsoft introduced the C5029 warning with Visual Studio 2015. This warning only applies to C++ mode, but it does not seem to be language specific (i.e. ngtcp2 will trigger it when included from C++, even if it is within an extern C block). Basically, C5029 will be raised when an alignment specified is added to an alias and not the original type, because this is a non-standard extension (see [this page](https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warnings-c4800-through-c4999?view=msvc-170)).

```
typedef __declspec(align(8)) struct ngtcp2_pkt_info {
  // ...
} ngtcp2_pkt_info;
```

In the code you had previously, the `ngtcp2_pkt_info` structure was aligned with natural alignment, while the `ngtcp2_pkt_info` alias was overaligned to 8 bytes. This behavior is documented [here](https://docs.microsoft.com/en-us/cpp/cpp/align-cpp?view=msvc-170#vclrf_declspecaligntypedef).

As clearly there is no intent to have the alias and the type with different alignments (as you've already fixed for GCC and Clang), I did the same change for MSVC.

----

This MR also disable the [C4324](https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4324?view=msvc-170) warning for Windows platforms. As you are overaligning the structure, padding will be added. It is fine by itself, but as it is part of the public header, it is best if this warning is disabled to avoid the users do it.