### PR TITLE
Add generic sockaddr types to support non-standard sockaddr platforms.

### DIFF
--- a/lib/includes/ngtcp2/ngtcp2.h
+++ b/lib/includes/ngtcp2/ngtcp2.h
@@ -50,10 +50,26 @@
 #include <stdarg.h>
 #include <stddef.h>
 
-#ifdef WIN32
-#  include <winsock2.h>
+#ifndef NGTCP2_USE_GENERIC_SOCKADDR
+#  ifdef WIN32
+#    include <ws2tcpip.h>
+#  else
+#    include <sys/socket.h>
+#    include <netinet/in.h>
+#  endif
+#endif
+
+#ifdef AF_INET
+#  define NGTCP2_AF_INET AF_INET
 #else
-#  include <sys/socket.h>
+#  define NGTCP2_AF_INET 2
+#endif
+
+#ifdef AF_INET6
+#  define NGTCP2_AF_INET6 AF_INET6
+#else
+#  define NGTCP2_AF_INET6 23
+#  define NGTCP2_USE_GENERIC_IPV6_SOCKADDR
 #endif
 
 #include <ngtcp2/version.h>
@@ -1733,6 +1749,46 @@ typedef struct ngtcp2_settings {
   ngtcp2_duration handshake_timeout;
 } ngtcp2_settings;
 
+#ifdef NGTCP2_USE_GENERIC_SOCKADDR
+typedef struct ngtcp2_sockaddr {
+  uint16_t sa_family;
+  uint8_t sa_data[14];
+} ngtcp2_sockaddr;
+
+typedef struct ngtcp2_sockaddr_in {
+  uint16_t sin_family;
+  uint16_t sin_port;
+  uint32_t sin_addr;
+  uint8_t sin_zero[8];
+} ngtcp2_sockaddr_in;
+
+typedef struct ngtcp2_sockaddr_storage {
+  uint16_t ss_family;
+  uint8_t ss_storage[30];
+} ngtcp2_sockaddr_storage;
+#else
+typedef struct sockaddr ngtcp2_sockaddr;
+typedef struct sockaddr_storage ngtcp2_sockaddr_storage;
+typedef struct sockaddr_in ngtcp2_sockaddr_in;
+#endif
+
+#if defined(NGTCP2_USE_GENERIC_SOCKADDR) || defined(NGTCP2_USE_GENERIC_IPV6_SOCKADDR)
+typedef struct ngtcp2_in6_addr
+{
+  uint8_t in6_addr[16];
+} ngtcp2_in6_addr;
+
+typedef struct ngtcp2_sockaddr_in6 {
+  uint16_t sin6_family;
+  uint16_t sin6_port;
+  uint32_t sin6_flowinfo;
+  ngtcp2_in6_addr sin6_addr;
+  uint32_t sin6_scope_id;
+} ngtcp2_sockaddr_in6;
+#else
+typedef struct sockaddr_in6 ngtcp2_sockaddr_in6;
+#endif
+
 /**
  * @struct
  *
@@ -1743,7 +1799,7 @@ typedef struct ngtcp2_addr {
    * :member:`addr` points to the buffer which contains endpoint
    * address.  It must not be ``NULL``.
    */
-  struct sockaddr *addr;
+  ngtcp2_sockaddr *addr;
   /**
    * :member:`addrlen` is the length of addr.
    */
@@ -1796,11 +1852,11 @@ typedef struct ngtcp2_path_storage {
   /**
    * :member:`local_addrbuf` is a buffer to store local address.
    */
-  struct sockaddr_storage local_addrbuf;
+  ngtcp2_sockaddr_storage local_addrbuf;
   /**
    * :member:`remote_addrbuf` is a buffer to store remote address.
    */
-  struct sockaddr_storage remote_addrbuf;
+  ngtcp2_sockaddr_storage remote_addrbuf;
 } ngtcp2_path_storage;
 
 /**
@@ -4824,7 +4880,7 @@ NGTCP2_EXTERN uint64_t ngtcp2_err_infer_quic_transport_error_code(int liberr);
  * returns |dest|.
  */
 NGTCP2_EXTERN ngtcp2_addr *ngtcp2_addr_init(ngtcp2_addr *dest,
-                                            const struct sockaddr *addr,
+                                            const ngtcp2_sockaddr *addr,
                                             size_t addrlen);
 
 /**
@@ -4838,7 +4894,7 @@ NGTCP2_EXTERN ngtcp2_addr *ngtcp2_addr_init(ngtcp2_addr *dest,
  * capacity to store the copy.
  */
 NGTCP2_EXTERN void ngtcp2_addr_copy_byte(ngtcp2_addr *dest,
-                                         const struct sockaddr *addr,
+                                         const ngtcp2_sockaddr *addr,
                                          size_t addrlen);
 
 /**
@@ -4848,9 +4904,9 @@ NGTCP2_EXTERN void ngtcp2_addr_copy_byte(ngtcp2_addr *dest,
  * arguments.  This function copies |local_addr| and |remote_addr|.
  */
 NGTCP2_EXTERN void ngtcp2_path_storage_init(ngtcp2_path_storage *ps,
-                                            const struct sockaddr *local_addr,
+                                            const ngtcp2_sockaddr *local_addr,
                                             size_t local_addrlen,
-                                            const struct sockaddr *remote_addr,
+                                            const ngtcp2_sockaddr *remote_addr,
                                             size_t remote_addrlen,
                                             void *user_data);
 

--- a/lib/ngtcp2_addr.c
+++ b/lib/ngtcp2_addr.c
@@ -27,22 +27,10 @@
 #include <string.h>
 #include <assert.h>
 
-#ifdef WIN32
-#  include <winsock2.h>
-#  include <ws2tcpip.h>
-#else
-#  include <sys/types.h>
-#  include <sys/socket.h>
-#  include <netinet/in.h>
-#  include <netinet/ip.h>
-#  include <netinet/tcp.h>
-#  include <arpa/inet.h>
-#endif
-
-ngtcp2_addr *ngtcp2_addr_init(ngtcp2_addr *dest, const struct sockaddr *addr,
+ngtcp2_addr *ngtcp2_addr_init(ngtcp2_addr *dest, const ngtcp2_sockaddr *addr,
                               size_t addrlen) {
   dest->addrlen = addrlen;
-  dest->addr = (struct sockaddr *)addr;
+  dest->addr = (ngtcp2_sockaddr *)addr;
   return dest;
 }
 
@@ -53,7 +41,7 @@ void ngtcp2_addr_copy(ngtcp2_addr *dest, const ngtcp2_addr *src) {
   }
 }
 
-void ngtcp2_addr_copy_byte(ngtcp2_addr *dest, const struct sockaddr *addr,
+void ngtcp2_addr_copy_byte(ngtcp2_addr *dest, const ngtcp2_sockaddr *addr,
                            size_t addrlen) {
   dest->addrlen = addrlen;
   if (addrlen) {
@@ -61,19 +49,19 @@ void ngtcp2_addr_copy_byte(ngtcp2_addr *dest, const struct sockaddr *addr,
   }
 }
 
-static int sockaddr_eq(const struct sockaddr *a, const struct sockaddr *b) {
+static int sockaddr_eq(const ngtcp2_sockaddr *a, const ngtcp2_sockaddr *b) {
   assert(a->sa_family == b->sa_family);
 
   switch (a->sa_family) {
-  case AF_INET: {
-    const struct sockaddr_in *ai = (const struct sockaddr_in *)(void *)a,
-                             *bi = (const struct sockaddr_in *)(void *)b;
+  case NGTCP2_AF_INET: {
+    const ngtcp2_sockaddr_in *ai = (const ngtcp2_sockaddr_in *)(void *)a,
+                             *bi = (const ngtcp2_sockaddr_in *)(void *)b;
     return ai->sin_port == bi->sin_port &&
            memcmp(&ai->sin_addr, &bi->sin_addr, sizeof(ai->sin_addr)) == 0;
   }
-  case AF_INET6: {
-    const struct sockaddr_in6 *ai = (const struct sockaddr_in6 *)(void *)a,
-                              *bi = (const struct sockaddr_in6 *)(void *)b;
+  case NGTCP2_AF_INET6: {
+    const ngtcp2_sockaddr_in6 *ai = (const ngtcp2_sockaddr_in6 *)(void *)a,
+                              *bi = (const ngtcp2_sockaddr_in6 *)(void *)b;
     return ai->sin6_port == bi->sin6_port &&
            memcmp(&ai->sin6_addr, &bi->sin6_addr, sizeof(ai->sin6_addr)) == 0;
   }
@@ -90,17 +78,17 @@ int ngtcp2_addr_eq(const ngtcp2_addr *a, const ngtcp2_addr *b) {
 
 uint32_t ngtcp2_addr_compare(const ngtcp2_addr *aa, const ngtcp2_addr *bb) {
   uint32_t flags = NGTCP2_ADDR_COMPARE_FLAG_NONE;
-  const struct sockaddr *a = aa->addr;
-  const struct sockaddr *b = bb->addr;
+  const ngtcp2_sockaddr *a = aa->addr;
+  const ngtcp2_sockaddr *b = bb->addr;
 
   if (a->sa_family != b->sa_family) {
     return NGTCP2_ADDR_COMPARE_FLAG_FAMILY;
   }
 
   switch (a->sa_family) {
-  case AF_INET: {
-    const struct sockaddr_in *ai = (const struct sockaddr_in *)(void *)a,
-                             *bi = (const struct sockaddr_in *)(void *)b;
+  case NGTCP2_AF_INET: {
+    const ngtcp2_sockaddr_in *ai = (const ngtcp2_sockaddr_in *)(void *)a,
+                             *bi = (const ngtcp2_sockaddr_in *)(void *)b;
     if (memcmp(&ai->sin_addr, &bi->sin_addr, sizeof(ai->sin_addr))) {
       flags |= NGTCP2_ADDR_COMPARE_FLAG_ADDR;
     }
@@ -109,9 +97,9 @@ uint32_t ngtcp2_addr_compare(const ngtcp2_addr *aa, const ngtcp2_addr *bb) {
     }
     return flags;
   }
-  case AF_INET6: {
-    const struct sockaddr_in6 *ai = (const struct sockaddr_in6 *)(void *)a,
-                              *bi = (const struct sockaddr_in6 *)(void *)b;
+  case NGTCP2_AF_INET6: {
+    const ngtcp2_sockaddr_in6 *ai = (const ngtcp2_sockaddr_in6 *)(void *)a,
+                              *bi = (const ngtcp2_sockaddr_in6 *)(void *)b;
     if (memcmp(&ai->sin6_addr, &bi->sin6_addr, sizeof(ai->sin6_addr))) {
       flags |= NGTCP2_ADDR_COMPARE_FLAG_ADDR;
     }

--- a/lib/ngtcp2_path.c
+++ b/lib/ngtcp2_path.c
@@ -46,14 +46,14 @@ int ngtcp2_path_eq(const ngtcp2_path *a, const ngtcp2_path *b) {
 }
 
 void ngtcp2_path_storage_init(ngtcp2_path_storage *ps,
-                              const struct sockaddr *local_addr,
+                              const ngtcp2_sockaddr *local_addr,
                               size_t local_addrlen,
-                              const struct sockaddr *remote_addr,
+                              const ngtcp2_sockaddr *remote_addr,
                               size_t remote_addrlen, void *user_data) {
-  ngtcp2_addr_init(&ps->path.local, (const struct sockaddr *)&ps->local_addrbuf,
+  ngtcp2_addr_init(&ps->path.local, (const ngtcp2_sockaddr *)&ps->local_addrbuf,
                    0);
   ngtcp2_addr_init(&ps->path.remote,
-                   (const struct sockaddr *)&ps->remote_addrbuf, 0);
+                   (const ngtcp2_sockaddr *)&ps->remote_addrbuf, 0);
 
   ngtcp2_addr_copy_byte(&ps->path.local, local_addr, local_addrlen);
   ngtcp2_addr_copy_byte(&ps->path.remote, remote_addr, remote_addrlen);
@@ -69,9 +69,9 @@ void ngtcp2_path_storage_init2(ngtcp2_path_storage *ps,
 }
 
 void ngtcp2_path_storage_zero(ngtcp2_path_storage *ps) {
-  ngtcp2_addr_init(&ps->path.local, (const struct sockaddr *)&ps->local_addrbuf,
+  ngtcp2_addr_init(&ps->path.local, (const ngtcp2_sockaddr *)&ps->local_addrbuf,
                    0);
   ngtcp2_addr_init(&ps->path.remote,
-                   (const struct sockaddr *)&ps->remote_addrbuf, 0);
+                   (const ngtcp2_sockaddr *)&ps->remote_addrbuf, 0);
   ps->path.user_data = NULL;
 }


### PR DESCRIPTION
This pull request address the following [issue](https://github.com/ngtcp2/ngtcp2/issues/276).
Some platforms have non-standard sockaddress types and ngtcp2 canot be ported as easily on these platforms.

To overcome this problem we have added new generic ngtcp2_sockaddr* structures that can be enabled using NGTCP2_USE_GENERIC_SOCKADDR or NGTCP2_USE_GENERIC_IPV6_SOCKADDR defines.

By default the new ngtcp2_sockaddr* are typedefs on the regular sockaddr* structures.

