### PR TITLE
configure.ac: fix have_openssl_quic detection

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -253,7 +253,7 @@ if test "x${request_openssl}" != "xno"; then
     CFLAGS="$save_CFLAGS"
     LIBS="$save_LIBS"
 
-    if test "x${have_openssl_quic}" = "no"; then
+    if test "x${have_openssl_quic}" = "xno"; then
       AC_MSG_NOTICE([openssl does not have QUIC interface, disabling it])
       have_openssl=no
       OPENSSL_LIBS=


### PR DESCRIPTION
Prior to this change OpenSSL >= 1.1.1 without QUIC was not properly
disabled. make would attempt to build libngtcp2_crypto_openssl anyway
and fail.

Bug: https://github.com/curl/curl/pull/8485
Reported-by: Michał Antoniak

Closes #xxxx
