### PR TITLE
Make sure that a packet which elicits key update confirmation is sent

### DIFF
--- a/examples/client.cc
+++ b/examples/client.cc
@@ -1398,6 +1398,8 @@ int Client::initiate_key_update() {
     return -1;
   }
 
+  ev_io_start(loop_, &wev_);
+
   return 0;
 }
 

--- a/examples/h09client.cc
+++ b/examples/h09client.cc
@@ -1314,6 +1314,8 @@ int Client::initiate_key_update() {
     return -1;
   }
 
+  ev_io_start(loop_, &wev_);
+
   return 0;
 }
 

--- a/lib/ngtcp2_conn.h
+++ b/lib/ngtcp2_conn.h
@@ -206,6 +206,11 @@ void ngtcp2_path_challenge_entry_init(ngtcp2_path_challenge_entry *pcent,
    installed.  conn->early.ckm cannot be used for this purpose because
    it might be discarded when a certain condition is met. */
 #define NGTCP2_CONN_FLAG_EARLY_KEY_INSTALLED 0x8000
+/* NGTCP2_CONN_FLAG_KEY_UPDATE_CONFIRMATION_TIMER_CANCELLED is set
+   when a timer for outgoing packet which elicits key update
+   confirmation from the remote endpoint has been expired and
+   cancelled. */
+#define NGTCP2_CONN_FLAG_KEY_UPDATE_CONFIRMATION_TIMER_CANCELLED 0x10000
 
 typedef struct ngtcp2_crypto_data {
   ngtcp2_buf buf;
@@ -565,6 +570,11 @@ struct ngtcp2_conn {
          confirmed by the local endpoint last time.  UINT64_MAX means
          undefined value. */
       ngtcp2_tstamp confirmed_ts;
+      /* last_tx_confirm_ts is the time instant when the last key
+         update confirmation packet is sent.  The new key is confirmed
+         when this packet is acknowledged.  UINT64_MAX means no packet
+         has been sent for the new key. */
+      ngtcp2_tstamp last_tx_confirm_ts;
     } key_update;
 
     /* tls_native_handle is a native handle to TLS session object. */
@@ -626,7 +636,7 @@ struct ngtcp2_conn {
   void *user_data;
   uint32_t version;
   /* flags is bitwise OR of zero or more of NGTCP2_CONN_FLAG_*. */
-  uint16_t flags;
+  uint32_t flags;
   int server;
 };
 

--- a/lib/ngtcp2_rtb.c
+++ b/lib/ngtcp2_rtb.c
@@ -925,8 +925,11 @@ ngtcp2_ssize ngtcp2_rtb_recv_ack(ngtcp2_rtb *rtb, const ngtcp2_ack *fr,
 
   if (conn && (conn->flags & NGTCP2_CONN_FLAG_KEY_UPDATE_NOT_CONFIRMED) &&
       largest_ack >= conn->pktns.crypto.tx.ckm->pkt_num) {
-    conn->flags &= (uint16_t)~NGTCP2_CONN_FLAG_KEY_UPDATE_NOT_CONFIRMED;
+    conn->flags &=
+        (uint32_t) ~(NGTCP2_CONN_FLAG_KEY_UPDATE_NOT_CONFIRMED |
+                     NGTCP2_CONN_FLAG_KEY_UPDATE_CONFIRMATION_TIMER_CANCELLED);
     conn->crypto.key_update.confirmed_ts = ts;
+    conn->crypto.key_update.last_tx_confirm_ts = UINT64_MAX;
 
     ngtcp2_log_info(rtb->log, NGTCP2_LOG_EVENT_CRY, "key update confirmed");
   }


### PR DESCRIPTION
This change fixes the bug that a packet which elicits key update
confirmation from the remote endpoint might not be sent.  This might
lead to connection failure if the remote endpoint keeps changing keys
very frequently.  Changing keys in this frequency is unusual, but it
is allowed by the spec, and we should deal with it.