### PR TITLE
Fix regex replace of compiler flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,7 +81,7 @@ include(CMakeOptions.txt)
 foreach(_build_type "Release" "MinSizeRel" "RelWithDebInfo")
   foreach(_lang C CXX)
     string(TOUPPER "CMAKE_${_lang}_FLAGS_${_build_type}" _var)
-    string(REGEX REPLACE "(^| )[/-]D *NDEBUG($| )" "" ${_var} "${${_var}}")
+    string(REGEX REPLACE "(^| )[/-]D *NDEBUG($| )" " " ${_var} "${${_var}}")
   endforeach()
 endforeach()
 


### PR DESCRIPTION
In MSVC the regex replace of compiler flags for a release build caused some flags to be fused together, `/Gy/Z7`, which resulted in the following error.

`cl : Command line error D8016 : '/O2' and '/GZ' command-line options are incompatible`

Took the same section from nghttp2's CMakeLists which contains a space to fix the issue.