### PR TITLE
Rework error handling

### DIFF
--- a/examples/client.cc
+++ b/examples/client.cc
@@ -131,7 +131,8 @@ void timeoutcb(struct ev_loop *loop, ev_timer *w, int revents) {
 } // namespace
 
 void Client::idle_timeout() {
-  last_error_ = quic_err_idle_timeout();
+  ngtcp2_connection_close_error_set_transport_error_idle_close(&last_error_,
+                                                               nullptr, 0);
   disconnect();
 }
 
@@ -792,18 +793,20 @@ int Client::feed_data(const Endpoint &ep, const sockaddr *sa, socklen_t salen,
     case NGTCP2_ERR_TRANSPORT_PARAM:
     case NGTCP2_ERR_PROTO: // with failed TP validation, we get this.
       // If rv indicates transport_parameters related error, we should
-      // send TRANSPORT_PARAMETER_ERROR even if last_error_.code is
-      // already set.  This is because OpenSSL might set Alert.
-      last_error_ = quic_err_transport(rv);
+      // send TRANSPORT_PARAMETER_ERROR even if last_error_.error_code
+      // is already set.  This is because OpenSSL might set Alert.
+      ngtcp2_connection_close_error_set_transport_error_liberr(&last_error_, rv,
+                                                               nullptr, 0);
       break;
     case NGTCP2_ERR_CRYPTO:
-      if (!last_error_.code) {
+      if (!last_error_.error_code) {
         process_unhandled_tls_alert();
       }
       // fall through
     default:
-      if (!last_error_.code) {
-        last_error_ = quic_err_transport(rv);
+      if (!last_error_.error_code) {
+        ngtcp2_connection_close_error_set_transport_error_liberr(
+            &last_error_, rv, nullptr, 0);
       }
     }
     disconnect();
@@ -870,7 +873,8 @@ int Client::on_read(const Endpoint &ep) {
   }
 
   if (should_exit_) {
-    last_error_ = quic_err_app(0);
+    ngtcp2_connection_close_error_set_application_error(
+        &last_error_, nghttp3_err_infer_quic_app_error_code(0), nullptr, 0);
     disconnect();
     return -1;
   }
@@ -901,7 +905,8 @@ int Client::handle_expiry() {
   if (auto rv = ngtcp2_conn_handle_expiry(conn_, now); rv != 0) {
     std::cerr << "ngtcp2_conn_handle_expiry: " << ngtcp2_strerror(rv)
               << std::endl;
-    last_error_ = quic_err_transport(NGTCP2_ERR_INTERNAL);
+    ngtcp2_connection_close_error_set_transport_error_liberr(
+        &last_error_, NGTCP2_ERR_INTERNAL, nullptr, 0);
     disconnect();
     return -1;
   }
@@ -925,7 +930,8 @@ int Client::on_write() {
   }
 
   if (should_exit_) {
-    last_error_ = quic_err_app(0);
+    ngtcp2_connection_close_error_set_application_error(
+        &last_error_, nghttp3_err_infer_quic_app_error_code(0), nullptr, 0);
     disconnect();
     return -1;
   }
@@ -959,7 +965,9 @@ int Client::write_streams() {
       if (sveccnt < 0) {
         std::cerr << "nghttp3_conn_writev_stream: " << nghttp3_strerror(sveccnt)
                   << std::endl;
-        last_error_ = quic_err_app(sveccnt);
+        ngtcp2_connection_close_error_set_application_error(
+            &last_error_, nghttp3_err_infer_quic_app_error_code(sveccnt),
+            nullptr, 0);
         disconnect();
         return -1;
       }
@@ -987,7 +995,9 @@ int Client::write_streams() {
             rv != 0) {
           std::cerr << "nghttp3_conn_block_stream: " << nghttp3_strerror(rv)
                     << std::endl;
-          last_error_ = quic_err_app(rv);
+          ngtcp2_connection_close_error_set_application_error(
+              &last_error_, nghttp3_err_infer_quic_app_error_code(rv), nullptr,
+              0);
           disconnect();
           return -1;
         }
@@ -998,7 +1008,9 @@ int Client::write_streams() {
             rv != 0) {
           std::cerr << "nghttp3_conn_shutdown_stream_write: "
                     << nghttp3_strerror(rv) << std::endl;
-          last_error_ = quic_err_app(rv);
+          ngtcp2_connection_close_error_set_application_error(
+              &last_error_, nghttp3_err_infer_quic_app_error_code(rv), nullptr,
+              0);
           disconnect();
           return -1;
         }
@@ -1010,7 +1022,9 @@ int Client::write_streams() {
             rv != 0) {
           std::cerr << "nghttp3_conn_add_write_offset: " << nghttp3_strerror(rv)
                     << std::endl;
-          last_error_ = quic_err_app(rv);
+          ngtcp2_connection_close_error_set_application_error(
+              &last_error_, nghttp3_err_infer_quic_app_error_code(rv), nullptr,
+              0);
           disconnect();
           return -1;
         }
@@ -1021,7 +1035,8 @@ int Client::write_streams() {
 
       std::cerr << "ngtcp2_conn_write_stream: " << ngtcp2_strerror(nwrite)
                 << std::endl;
-      last_error_ = quic_err_transport(nwrite);
+      ngtcp2_connection_close_error_set_transport_error_liberr(
+          &last_error_, nwrite, nullptr, 0);
       disconnect();
       return -1;
     } else if (ndatalen >= 0) {
@@ -1030,7 +1045,9 @@ int Client::write_streams() {
           rv != 0) {
         std::cerr << "nghttp3_conn_add_write_offset: " << nghttp3_strerror(rv)
                   << std::endl;
-        last_error_ = quic_err_app(rv);
+        ngtcp2_connection_close_error_set_application_error(
+            &last_error_, nghttp3_err_infer_quic_app_error_code(rv), nullptr,
+            0);
         disconnect();
         return -1;
       }
@@ -1051,7 +1068,8 @@ int Client::write_streams() {
             send_packet(ep, ps.path.remote, pi.ecn, tx_.data.data(), nwrite);
         rv != NETWORK_ERR_OK) {
       if (rv != NETWORK_ERR_SEND_BLOCKED) {
-        last_error_ = quic_err_transport(NGTCP2_ERR_INTERNAL);
+        ngtcp2_connection_close_error_set_transport_error_liberr(
+            &last_error_, NGTCP2_ERR_INTERNAL, nullptr, 0);
         disconnect();
 
         return rv;
@@ -1503,7 +1521,8 @@ int Client::send_blocked_packet() {
       return 0;
     }
 
-    last_error_ = quic_err_transport(NGTCP2_ERR_INTERNAL);
+    ngtcp2_connection_close_error_set_transport_error_liberr(
+        &last_error_, NGTCP2_ERR_INTERNAL, nullptr, 0);
     disconnect();
 
     return rv;
@@ -1519,11 +1538,6 @@ int Client::handle_error() {
     return 0;
   }
 
-  if (last_error_.type == QUICErrorType::TransportVersionNegotiation ||
-      last_error_.type == QUICErrorType::TransportIdleTimeout) {
-    return 0;
-  }
-
   std::array<uint8_t, NGTCP2_MAX_UDP_PAYLOAD_SIZE> buf;
 
   ngtcp2_path_storage ps;
@@ -1531,25 +1545,18 @@ int Client::handle_error() {
   ngtcp2_path_storage_zero(&ps);
 
   ngtcp2_pkt_info pi;
-  ngtcp2_ssize nwrite;
-  if (last_error_.type == QUICErrorType::Transport) {
-    nwrite = ngtcp2_conn_write_connection_close(
-        conn_, &ps.path, &pi, buf.data(), buf.size(), last_error_.code, nullptr,
-        0, util::timestamp(loop_));
-    if (nwrite < 0) {
-      std::cerr << "ngtcp2_conn_write_connection_close: "
-                << ngtcp2_strerror(nwrite) << std::endl;
-      return -1;
-    }
-  } else {
-    nwrite = ngtcp2_conn_write_application_close(
-        conn_, &ps.path, &pi, buf.data(), buf.size(), last_error_.code, nullptr,
-        0, util::timestamp(loop_));
-    if (nwrite < 0) {
-      std::cerr << "ngtcp2_conn_write_application_close: "
-                << ngtcp2_strerror(nwrite) << std::endl;
-      return -1;
-    }
+
+  auto nwrite = ngtcp2_conn_write_connection_close2(
+      conn_, &ps.path, &pi, buf.data(), buf.size(), &last_error_,
+      util::timestamp(loop_));
+  if (nwrite < 0) {
+    std::cerr << "ngtcp2_conn_write_connection_close2: "
+              << ngtcp2_strerror(nwrite) << std::endl;
+    return -1;
+  }
+
+  if (nwrite == 0) {
+    return 0;
   }
 
   return send_packet(*static_cast<Endpoint *>(ps.path.user_data),
@@ -1577,7 +1584,8 @@ int Client::on_stream_close(int64_t stream_id, uint64_t app_error_code) {
     default:
       std::cerr << "nghttp3_conn_close_stream: " << nghttp3_strerror(rv)
                 << std::endl;
-      last_error_ = quic_err_app(rv);
+      ngtcp2_connection_close_error_set_application_error(
+          &last_error_, nghttp3_err_infer_quic_app_error_code(rv), nullptr, 0);
       return -1;
     }
   }
@@ -1706,7 +1714,9 @@ int Client::recv_stream_data(uint32_t flags, int64_t stream_id,
   if (nconsumed < 0) {
     std::cerr << "nghttp3_conn_read_stream: " << nghttp3_strerror(nconsumed)
               << std::endl;
-    last_error_ = quic_err_app(nconsumed);
+    ngtcp2_connection_close_error_set_application_error(
+        &last_error_, nghttp3_err_infer_quic_app_error_code(nconsumed), nullptr,
+        0);
     return -1;
   }
 

--- a/examples/client_base.cc
+++ b/examples/client_base.cc
@@ -39,10 +39,9 @@ using namespace ngtcp2;
 
 extern Config config;
 
-ClientBase::ClientBase()
-    : qlog_(nullptr),
-      conn_(nullptr),
-      last_error_{QUICErrorType::Transport, 0} {}
+ClientBase::ClientBase() : qlog_(nullptr), conn_(nullptr) {
+  ngtcp2_connection_close_error_default(&last_error_);
+}
 
 ClientBase::~ClientBase() {
   if (conn_) {
@@ -268,7 +267,8 @@ void ClientBase::write_client_handshake(ngtcp2_crypto_level level,
 }
 
 void ClientBase::set_tls_alert(uint8_t alert) {
-  last_error_ = quic_err_tls(alert);
+  ngtcp2_connection_close_error_set_transport_error_tls_alert(
+      &last_error_, alert, nullptr, 0);
 }
 
 ngtcp2_conn *ClientBase::conn() const { return conn_; }

--- a/examples/client_base.h
+++ b/examples/client_base.h
@@ -200,7 +200,7 @@ protected:
   TLSClientSession tls_session_;
   FILE *qlog_;
   ngtcp2_conn *conn_;
-  QUICError last_error_;
+  ngtcp2_connection_close_error last_error_;
   std::function<int()> application_rx_key_cb_;
 };
 

--- a/examples/server_base.cc
+++ b/examples/server_base.cc
@@ -40,8 +40,9 @@ Buffer::Buffer(const uint8_t *data, size_t datalen)
     : buf{data, data + datalen}, begin(buf.data()), tail(begin + datalen) {}
 Buffer::Buffer(size_t datalen) : buf(datalen), begin(buf.data()), tail(begin) {}
 
-HandlerBase::HandlerBase()
-    : conn_(nullptr), last_error_{QUICErrorType::Transport, 0} {}
+HandlerBase::HandlerBase() : conn_(nullptr) {
+  ngtcp2_connection_close_error_default(&last_error_);
+}
 
 HandlerBase::~HandlerBase() {
   if (conn_) {
@@ -122,7 +123,8 @@ void HandlerBase::write_server_handshake(ngtcp2_crypto_level level,
 }
 
 void HandlerBase::set_tls_alert(uint8_t alert) {
-  last_error_ = quic_err_tls(alert);
+  ngtcp2_connection_close_error_set_transport_error_tls_alert(
+      &last_error_, alert, nullptr, 0);
 }
 
 ngtcp2_conn *HandlerBase::conn() const { return conn_; }

--- a/examples/server_base.h
+++ b/examples/server_base.h
@@ -187,7 +187,7 @@ public:
 protected:
   TLSServerSession tls_session_;
   ngtcp2_conn *conn_;
-  QUICError last_error_;
+  ngtcp2_connection_close_error last_error_;
   std::function<int()> application_tx_key_cb_;
 };
 

--- a/examples/shared.cc
+++ b/examples/shared.cc
@@ -48,28 +48,6 @@
 
 namespace ngtcp2 {
 
-QUICError quic_err_transport(int liberr) {
-  if (liberr == NGTCP2_ERR_RECV_VERSION_NEGOTIATION) {
-    return {QUICErrorType::TransportVersionNegotiation, 0};
-  }
-  return {QUICErrorType::Transport,
-          ngtcp2_err_infer_quic_transport_error_code(liberr)};
-}
-
-QUICError quic_err_idle_timeout() {
-  return {QUICErrorType::TransportIdleTimeout, 0};
-}
-
-QUICError quic_err_tls(int alert) {
-  return {QUICErrorType::Transport,
-          static_cast<uint64_t>(NGTCP2_CRYPTO_ERROR | alert)};
-}
-
-QUICError quic_err_app(int liberr) {
-  return {QUICErrorType::Application,
-          nghttp3_err_infer_quic_app_error_code(liberr)};
-}
-
 unsigned int msghdr_get_ecn(msghdr *msg, int family) {
   switch (family) {
   case AF_INET:

--- a/examples/shared.h
+++ b/examples/shared.h
@@ -63,28 +63,6 @@ constexpr uint32_t QUIC_VER_DRAFT31 = 0xff00001fu;
 constexpr uint32_t QUIC_VER_DRAFT32 = 0xff000020u;
 constexpr uint32_t QUIC_VER_V1 = 0x00000001u;
 
-enum class QUICErrorType {
-  Application,
-  Transport,
-  TransportVersionNegotiation,
-  TransportIdleTimeout,
-};
-
-struct QUICError {
-  QUICError(QUICErrorType type, uint64_t code) : type(type), code(code) {}
-
-  QUICErrorType type;
-  uint64_t code;
-};
-
-QUICError quic_err_transport(int liberr);
-
-QUICError quic_err_idle_timeout();
-
-QUICError quic_err_tls(int alert);
-
-QUICError quic_err_app(int liberr);
-
 // msghdr_get_ecn gets ECN bits from |msg|.  |family| is the address
 // family from which packet is received.
 unsigned int msghdr_get_ecn(msghdr *msg, int family);

--- a/tests/ngtcp2_conn_test.c
+++ b/tests/ngtcp2_conn_test.c
@@ -6383,6 +6383,7 @@ void test_ngtcp2_conn_write_connection_close(void) {
   ngtcp2_crypto_aead_ctx aead_ctx = {0};
   ngtcp2_crypto_cipher_ctx hp_ctx = {0};
   ngtcp2_crypto_ctx crypto_ctx;
+  ngtcp2_connection_close_error ccerr;
 
   /* Client only Initial key */
   setup_handshake_client(&conn);
@@ -6391,9 +6392,11 @@ void test_ngtcp2_conn_write_connection_close(void) {
 
   CU_ASSERT(spktlen > 0);
 
-  spktlen = ngtcp2_conn_write_connection_close(conn, NULL, NULL, buf,
-                                               sizeof(buf), NGTCP2_NO_ERROR,
-                                               (const uint8_t *)"foo", 3, 0);
+  ngtcp2_connection_close_error_set_transport_error(&ccerr, NGTCP2_NO_ERROR,
+                                                    (const uint8_t *)"foo", 3);
+
+  spktlen = ngtcp2_conn_write_connection_close2(conn, NULL, NULL, buf,
+                                                sizeof(buf), &ccerr, 0);
 
   CU_ASSERT(spktlen > 0);
 
@@ -6418,8 +6421,10 @@ void test_ngtcp2_conn_write_connection_close(void) {
   ngtcp2_conn_install_tx_handshake_key(conn, &aead_ctx, null_iv,
                                        sizeof(null_iv), &hp_ctx);
 
-  spktlen = ngtcp2_conn_write_connection_close(
-      conn, NULL, NULL, buf, sizeof(buf), NGTCP2_NO_ERROR, NULL, 0, 0);
+  ngtcp2_connection_close_error_set_transport_error_liberr(&ccerr, 0, NULL, 0);
+
+  spktlen = ngtcp2_conn_write_connection_close2(conn, NULL, NULL, buf,
+                                                sizeof(buf), &ccerr, 0);
 
   CU_ASSERT(spktlen > 0);
 
@@ -6444,8 +6449,11 @@ void test_ngtcp2_conn_write_connection_close(void) {
 
   conn->state = NGTCP2_CS_POST_HANDSHAKE;
 
-  spktlen = ngtcp2_conn_write_connection_close(
-      conn, NULL, NULL, buf, sizeof(buf), NGTCP2_NO_ERROR, NULL, 0, 0);
+  ngtcp2_connection_close_error_set_transport_error(&ccerr, NGTCP2_NO_ERROR,
+                                                    NULL, 0);
+
+  spktlen = ngtcp2_conn_write_connection_close2(conn, NULL, NULL, buf,
+                                                sizeof(buf), &ccerr, 0);
 
   CU_ASSERT(spktlen > 0);
 
@@ -6469,8 +6477,11 @@ void test_ngtcp2_conn_write_connection_close(void) {
   /* Client has confirmed handshake */
   setup_default_client(&conn);
 
-  spktlen = ngtcp2_conn_write_connection_close(
-      conn, NULL, NULL, buf, sizeof(buf), NGTCP2_NO_ERROR, NULL, 0, 0);
+  ngtcp2_connection_close_error_set_transport_error(&ccerr, NGTCP2_NO_ERROR,
+                                                    NULL, 0);
+
+  spktlen = ngtcp2_conn_write_connection_close2(conn, NULL, NULL, buf,
+                                                sizeof(buf), &ccerr, 0);
 
   CU_ASSERT(spktlen > 0);
 
@@ -6497,8 +6508,11 @@ void test_ngtcp2_conn_write_connection_close(void) {
   ngtcp2_conn_install_tx_handshake_key(conn, &aead_ctx, null_iv,
                                        sizeof(null_iv), &hp_ctx);
 
-  spktlen = ngtcp2_conn_write_connection_close(
-      conn, NULL, NULL, buf, sizeof(buf), NGTCP2_NO_ERROR, NULL, 0, 0);
+  ngtcp2_connection_close_error_set_transport_error(&ccerr, NGTCP2_NO_ERROR,
+                                                    NULL, 0);
+
+  spktlen = ngtcp2_conn_write_connection_close2(conn, NULL, NULL, buf,
+                                                sizeof(buf), &ccerr, 0);
 
   CU_ASSERT(spktlen > 0);
 
@@ -6539,8 +6553,11 @@ void test_ngtcp2_conn_write_connection_close(void) {
 
   conn->state = NGTCP2_CS_POST_HANDSHAKE;
 
-  spktlen = ngtcp2_conn_write_connection_close(
-      conn, NULL, NULL, buf, sizeof(buf), NGTCP2_NO_ERROR, NULL, 0, 0);
+  ngtcp2_connection_close_error_set_transport_error(&ccerr, NGTCP2_NO_ERROR,
+                                                    NULL, 0);
+
+  spktlen = ngtcp2_conn_write_connection_close2(conn, NULL, NULL, buf,
+                                                sizeof(buf), &ccerr, 0);
 
   CU_ASSERT(spktlen > 0);
 
@@ -6573,8 +6590,11 @@ void test_ngtcp2_conn_write_connection_close(void) {
   /* Server has confirmed handshake */
   setup_default_server(&conn);
 
-  spktlen = ngtcp2_conn_write_connection_close(
-      conn, NULL, NULL, buf, sizeof(buf), NGTCP2_NO_ERROR, NULL, 0, 0);
+  ngtcp2_connection_close_error_set_transport_error(&ccerr, NGTCP2_NO_ERROR,
+                                                    NULL, 0);
+
+  spktlen = ngtcp2_conn_write_connection_close2(conn, NULL, NULL, buf,
+                                                sizeof(buf), &ccerr, 0);
 
   CU_ASSERT(spktlen > 0);
 
@@ -6597,6 +6617,7 @@ void test_ngtcp2_conn_write_application_close(void) {
   ngtcp2_crypto_cipher_ctx hp_ctx = {0};
   uint64_t app_err_code = 0;
   ngtcp2_crypto_ctx crypto_ctx;
+  ngtcp2_connection_close_error ccerr;
 
   /* Client only Initial key */
   setup_handshake_client(&conn);
@@ -6605,9 +6626,11 @@ void test_ngtcp2_conn_write_application_close(void) {
 
   CU_ASSERT(spktlen > 0);
 
-  spktlen = ngtcp2_conn_write_application_close(conn, NULL, NULL, buf,
-                                                sizeof(buf), app_err_code,
-                                                (const uint8_t *)"foo", 3, 0);
+  ngtcp2_connection_close_error_set_application_error(
+      &ccerr, app_err_code, (const uint8_t *)"foo", 3);
+
+  spktlen = ngtcp2_conn_write_connection_close2(conn, NULL, NULL, buf,
+                                                sizeof(buf), &ccerr, 0);
 
   CU_ASSERT(spktlen > 0);
 
@@ -6632,8 +6655,11 @@ void test_ngtcp2_conn_write_application_close(void) {
   ngtcp2_conn_install_tx_handshake_key(conn, &aead_ctx, null_iv,
                                        sizeof(null_iv), &hp_ctx);
 
-  spktlen = ngtcp2_conn_write_application_close(
-      conn, NULL, NULL, buf, sizeof(buf), app_err_code, NULL, 0, 0);
+  ngtcp2_connection_close_error_set_application_error(&ccerr, app_err_code,
+                                                      NULL, 0);
+
+  spktlen = ngtcp2_conn_write_connection_close2(conn, NULL, NULL, buf,
+                                                sizeof(buf), &ccerr, 0);
 
   CU_ASSERT(spktlen > 0);
 
@@ -6658,8 +6684,11 @@ void test_ngtcp2_conn_write_application_close(void) {
 
   conn->state = NGTCP2_CS_POST_HANDSHAKE;
 
-  spktlen = ngtcp2_conn_write_application_close(
-      conn, NULL, NULL, buf, sizeof(buf), app_err_code, NULL, 0, 0);
+  ngtcp2_connection_close_error_set_application_error(&ccerr, app_err_code,
+                                                      NULL, 0);
+
+  spktlen = ngtcp2_conn_write_connection_close2(conn, NULL, NULL, buf,
+                                                sizeof(buf), &ccerr, 0);
 
   CU_ASSERT(spktlen > 0);
 
@@ -6683,8 +6712,11 @@ void test_ngtcp2_conn_write_application_close(void) {
   /* Client has confirmed handshake */
   setup_default_client(&conn);
 
-  spktlen = ngtcp2_conn_write_application_close(
-      conn, NULL, NULL, buf, sizeof(buf), app_err_code, NULL, 0, 0);
+  ngtcp2_connection_close_error_set_application_error(&ccerr, app_err_code,
+                                                      NULL, 0);
+
+  spktlen = ngtcp2_conn_write_connection_close2(conn, NULL, NULL, buf,
+                                                sizeof(buf), &ccerr, 0);
 
   CU_ASSERT(spktlen > 0);
 
@@ -6711,8 +6743,11 @@ void test_ngtcp2_conn_write_application_close(void) {
   ngtcp2_conn_install_tx_handshake_key(conn, &aead_ctx, null_iv,
                                        sizeof(null_iv), &hp_ctx);
 
-  spktlen = ngtcp2_conn_write_application_close(
-      conn, NULL, NULL, buf, sizeof(buf), app_err_code, NULL, 0, 0);
+  ngtcp2_connection_close_error_set_application_error(&ccerr, app_err_code,
+                                                      NULL, 0);
+
+  spktlen = ngtcp2_conn_write_connection_close2(conn, NULL, NULL, buf,
+                                                sizeof(buf), &ccerr, 0);
 
   CU_ASSERT(spktlen > 0);
 
@@ -6751,8 +6786,11 @@ void test_ngtcp2_conn_write_application_close(void) {
   ngtcp2_conn_install_tx_key(conn, null_secret, sizeof(null_secret), &aead_ctx,
                              null_iv, sizeof(null_iv), &hp_ctx);
 
-  spktlen = ngtcp2_conn_write_application_close(
-      conn, NULL, NULL, buf, sizeof(buf), app_err_code, NULL, 0, 0);
+  ngtcp2_connection_close_error_set_application_error(&ccerr, app_err_code,
+                                                      NULL, 0);
+
+  spktlen = ngtcp2_conn_write_connection_close2(conn, NULL, NULL, buf,
+                                                sizeof(buf), &ccerr, 0);
 
   CU_ASSERT(spktlen > 0);
 
@@ -6785,8 +6823,11 @@ void test_ngtcp2_conn_write_application_close(void) {
   /* Server has confirmed handshake */
   setup_default_server(&conn);
 
-  spktlen = ngtcp2_conn_write_application_close(
-      conn, NULL, NULL, buf, sizeof(buf), app_err_code, NULL, 0, 0);
+  ngtcp2_connection_close_error_set_application_error(&ccerr, app_err_code,
+                                                      NULL, 0);
+
+  spktlen = ngtcp2_conn_write_connection_close2(conn, NULL, NULL, buf,
+                                                sizeof(buf), &ccerr, 0);
 
   CU_ASSERT(spktlen > 0);
 


### PR DESCRIPTION
ngtcp2_conn_write_connection_close2 is introduced, which replaces
ngtcp2_conn_write_connection_close and
ngtcp2_conn_write_application_close.
ngtcp2_conn_write_connection_close and
ngtcp2_conn_write_application_close are now deprecated, and removed in
the next release.  ngtcp2_conn_write_connection_close2 will be renamed
to ngtcp2_conn_write_connection_close.

Added helper functions to fill ngtcp2_connection_close_error object
for various types of errors.  In general, QUIC has 2 error code type:
transport and application.  ngtcp2 has 2 special subtypes of transport
error code type.  One indicates version negotiation and the other
indicates idle close.  These types should be recognized because we do
not send CONNECTION_CLOSE on these events.