### PR TITLE
Make NGTCP2_PKT_* type QUIC version independent

### DIFF
--- a/doc/source/programmers-guide.rst
+++ b/doc/source/programmers-guide.rst
@@ -207,10 +207,8 @@ connection, pass the UDP datagram to `ngtcp2_conn_read_pkt()`.  If it
 does not belong to any existing connection, it should be passed to
 `ngtcp2_accept()`.  If it returns :macro:`NGTCP2_ERR_RETRY`, the
 server should send Retry packet (use `ngtcp2_crypto_write_retry()` to
-create Retry packet).  If it returns
-:macro:`NGTCP2_ERR_VERSION_NEGOTIATION`, the server should send
-Version Negotiation packet.  If it returns an other negative error
-code, just drop the packet to the floor and take no action, or send
+create Retry packet).  If it returns an other negative error code,
+just drop the packet to the floor and take no action, or send
 Stateless Reset packet (use `ngtcp2_pkt_write_stateless_reset()` to
 create Stateless Reset packet).  Otherwise, the UDP datagram is
 acceptable as a new connection.  Create :type:`ngtcp2_conn` object and

--- a/examples/h09server.cc
+++ b/examples/h09server.cc
@@ -1824,15 +1824,6 @@ int Server::on_read(Endpoint &ep) {
       case NGTCP2_ERR_RETRY:
         send_retry(&hd, ep, *local_addr, &su.sa, msg.msg_namelen, nread * 3);
         continue;
-      case NGTCP2_ERR_VERSION_NEGOTIATION:
-        if (!config.quiet) {
-          std::cerr << "Unsupported version: Send Version Negotiation"
-                    << std::endl;
-        }
-        send_version_negotiation(hd.version, hd.scid.data, hd.scid.datalen,
-                                 hd.dcid.data, hd.dcid.datalen, ep, *local_addr,
-                                 &su.sa, msg.msg_namelen);
-        continue;
       default:
         if (!config.quiet) {
           std::cerr << "Unexpected packet received: length=" << nread

--- a/examples/server.cc
+++ b/examples/server.cc
@@ -2494,15 +2494,6 @@ int Server::on_read(Endpoint &ep) {
       case NGTCP2_ERR_RETRY:
         send_retry(&hd, ep, *local_addr, &su.sa, msg.msg_namelen, nread * 3);
         continue;
-      case NGTCP2_ERR_VERSION_NEGOTIATION:
-        if (!config.quiet) {
-          std::cerr << "Unsupported version: Send Version Negotiation"
-                    << std::endl;
-        }
-        send_version_negotiation(hd.version, hd.scid.data, hd.scid.datalen,
-                                 hd.dcid.data, hd.dcid.datalen, ep, *local_addr,
-                                 &su.sa, msg.msg_namelen);
-        continue;
       default:
         if (!config.quiet) {
           std::cerr << "Unexpected packet received: length=" << nread

--- a/lib/includes/ngtcp2/ngtcp2.h
+++ b/lib/includes/ngtcp2/ngtcp2.h
@@ -801,7 +801,8 @@ typedef struct NGTCP2_ALIGN(8) ngtcp2_pkt_info {
 /**
  * @enum
  *
- * :type:`ngtcp2_pkt_type` defines QUIC packet types.
+ * :type:`ngtcp2_pkt_type` defines QUIC version-independent QUIC
+ * packet types.
  */
 typedef enum ngtcp2_pkt_type {
   /**
@@ -817,19 +818,19 @@ typedef enum ngtcp2_pkt_type {
   /**
    * :enum:`NGTCP2_PKT_INITIAL` indicates Initial packet.
    */
-  NGTCP2_PKT_INITIAL = 0x0,
+  NGTCP2_PKT_INITIAL = 0x10,
   /**
    * :enum:`NGTCP2_PKT_0RTT` indicates 0RTT packet.
    */
-  NGTCP2_PKT_0RTT = 0x1,
+  NGTCP2_PKT_0RTT = 0x11,
   /**
    * :enum:`NGTCP2_PKT_HANDSHAKE` indicates Handshake packet.
    */
-  NGTCP2_PKT_HANDSHAKE = 0x2,
+  NGTCP2_PKT_HANDSHAKE = 0x12,
   /**
    * :enum:`NGTCP2_PKT_RETRY` indicates Retry packet.
    */
-  NGTCP2_PKT_RETRY = 0x3,
+  NGTCP2_PKT_RETRY = 0x13,
   /**
    * :enum:`NGTCP2_PKT_SHORT` is defined by libngtcp2 for convenience.
    */
@@ -3313,18 +3314,15 @@ NGTCP2_EXTERN ngtcp2_ssize ngtcp2_pkt_write_retry(
  * whether packet |pkt| of length |pktlen| from client is acceptable
  * for the very initial packet to a connection.
  *
- * If |dest| is not ``NULL`` and the function returns 0,
- * :macro:`NGTCP2_ERR_RETRY`, or
- * :macro:`NGTCP2_ERR_VERSION_NEGOTIATION`, the decoded packet header
- * is stored to the object pointed by |dest|.
+ * If |dest| is not ``NULL`` and the function returns 0, or
+ * :macro:`NGTCP2_ERR_RETRY`, the decoded packet header is stored to
+ * the object pointed by |dest|.
  *
  * This function returns 0 if it succeeds, or one of the following
  * negative error codes:
  *
  * :macro:`NGTCP2_ERR_RETRY`
  *     Retry packet should be sent.
- * :macro:`NGTCP2_ERR_VERSION_NEGOTIATION`
- *     Version Negotiation packet should be sent.
  * :macro:`NGTCP2_ERR_INVALID_ARGUMENT`
  *     The packet is not acceptable for the very first packet to a new
  *     connection; or it failed to parse the packet header.

--- a/lib/ngtcp2_pkt.h
+++ b/lib/ngtcp2_pkt.h
@@ -111,6 +111,19 @@
    Length field in Long packet header. */
 #define NGTCP2_PKT_LENGTHLEN 4
 
+/* NGTCP2_PKT_TYPE_INITIAL_V1 is Initial long header packet type for
+   QUIC v1. */
+#define NGTCP2_PKT_TYPE_INITIAL_V1 0x0
+/* NGTCP2_PKT_TYPE_0RTT_V1 is 0RTT long header packet type for QUIC
+   v1. */
+#define NGTCP2_PKT_TYPE_0RTT_V1 0x1
+/* NGTCP2_PKT_TYPE_HANDSHAKE_V1 is Handshake long header packet type
+   for QUIC v1. */
+#define NGTCP2_PKT_TYPE_HANDSHAKE_V1 0x2
+/* NGTCP2_PKT_TYPE_RETRY_V1 is Retry long header packet type for QUIC
+   v1. */
+#define NGTCP2_PKT_TYPE_RETRY_V1 0x3
+
 typedef struct ngtcp2_pkt_retry {
   ngtcp2_cid odcid;
   ngtcp2_vec token;
@@ -1194,12 +1207,27 @@ int ngtcp2_pkt_verify_retry_tag(uint32_t version, const ngtcp2_pkt_retry *retry,
                                 const ngtcp2_crypto_aead *aead,
                                 const ngtcp2_crypto_aead_ctx *aead_ctx);
 
+/*
+ * ngtcp2_pkt_is_supported_version returns nonzero if the library
+ * supports QUIC version |version|.
+ */
+int ngtcp2_pkt_is_supported_version(uint32_t version);
+
+/*
+ * ngtcp2_pkt_versioned_type returns versioned packet type for a
+ * version |version| that corresponds to the version-independent
+ * |pkt_type|.
+ */
+uint8_t ngtcp2_pkt_versioned_type(uint32_t version, uint32_t pkt_type);
+
 /**
  * @function
  *
- * `ngtcp2_pkt_get_type_long` returns the long packet type.  |c| is
- * the first byte of Long packet header.
+ * `ngtcp2_pkt_get_type_long` returns the version-independent long
+ * packet type.  |version| is the QUIC version.  |c| is the first byte
+ * of Long packet header.  If |version| is not supported by the
+ * library, it returns 0.
  */
-uint8_t ngtcp2_pkt_get_type_long(uint8_t c);
+uint8_t ngtcp2_pkt_get_type_long(uint32_t version, uint8_t c);
 
 #endif /* NGTCP2_PKT_H */

--- a/tests/ngtcp2_conn_test.c
+++ b/tests/ngtcp2_conn_test.c
@@ -8133,7 +8133,10 @@ void test_ngtcp2_accept(void) {
 
   rv = ngtcp2_accept(&hd, buf, pktlen);
 
-  CU_ASSERT(NGTCP2_ERR_VERSION_NEGOTIATION == rv);
+  /* Unknown version should be filtered out by earlier call of
+     ngtcp2_pkt_decode_version_cid, that is, only supported versioned
+     packet should be passed to ngtcp2_accept. */
+  CU_ASSERT(NGTCP2_ERR_INVALID_ARGUMENT == rv);
 
   /* Unknown version and the UDP payload size is less than
      NGTCP2_MAX_UDP_PAYLOAD_SIZE. */

--- a/tests/ngtcp2_pkt_test.c
+++ b/tests/ngtcp2_pkt_test.c
@@ -238,7 +238,7 @@ void test_ngtcp2_pkt_decode_hd_long(void) {
 
   /* Handshake */
   ngtcp2_pkt_hd_init(&hd, NGTCP2_PKT_FLAG_LONG_FORM, NGTCP2_PKT_HANDSHAKE,
-                     &dcid, &scid, 0xe1e2e3e4u, 4, 0x000000ff, 16383);
+                     &dcid, &scid, 0xe1e2e3e4u, 4, NGTCP2_PROTO_VER_V1, 16383);
 
   rv = ngtcp2_pkt_encode_hd_long(buf, sizeof(buf), &hd);
 
@@ -261,7 +261,8 @@ void test_ngtcp2_pkt_decode_hd_long(void) {
   /* Handshake without Fixed Bit set */
   ngtcp2_pkt_hd_init(
       &hd, NGTCP2_PKT_FLAG_LONG_FORM | NGTCP2_PKT_FLAG_FIXED_BIT_CLEAR,
-      NGTCP2_PKT_HANDSHAKE, &dcid, &scid, 0xe1e2e3e4u, 4, 0x000000ff, 16383);
+      NGTCP2_PKT_HANDSHAKE, &dcid, &scid, 0xe1e2e3e4u, 4, NGTCP2_PROTO_VER_V1,
+      16383);
 
   rv = ngtcp2_pkt_encode_hd_long(buf, sizeof(buf), &hd);
 
@@ -284,9 +285,11 @@ void test_ngtcp2_pkt_decode_hd_long(void) {
   /* VN */
   /* Set random packet type */
   ngtcp2_pkt_hd_init(&hd, NGTCP2_PKT_FLAG_LONG_FORM, NGTCP2_PKT_HANDSHAKE,
-                     &dcid, &scid, 0, 4, 0, 0);
+                     &dcid, &scid, 0, 4, NGTCP2_PROTO_VER_V1, 0);
 
   rv = ngtcp2_pkt_encode_hd_long(buf, sizeof(buf), &hd);
+  /* Set version field to 0 */
+  memset(&buf[1], 0, 4);
 
   len = 1 + 4 + 1 + dcid.datalen + 1 + scid.datalen;
 
@@ -300,7 +303,7 @@ void test_ngtcp2_pkt_decode_hd_long(void) {
   CU_ASSERT(ngtcp2_cid_eq(&hd.dcid, &nhd.dcid));
   CU_ASSERT(ngtcp2_cid_eq(&hd.scid, &nhd.scid));
   CU_ASSERT(hd.pkt_num == nhd.pkt_num);
-  CU_ASSERT(hd.version == nhd.version);
+  CU_ASSERT(0 == nhd.version);
   CU_ASSERT(hd.len == nhd.len);
 }
 

--- a/tests/ngtcp2_test_helper.c
+++ b/tests/ngtcp2_test_helper.c
@@ -247,7 +247,7 @@ static size_t write_single_frame_handshake_pkt_generic(
   }
 
   ngtcp2_pkt_hd_init(&hd, NGTCP2_PKT_FLAG_LONG_FORM, pkt_type, dcid, scid,
-                     pkt_num, 4, version, 0);
+                     pkt_num, 4, NGTCP2_PROTO_VER_V1, 0);
 
   hd.token.base = (uint8_t *)token;
   hd.token.len = tokenlen;
@@ -255,6 +255,7 @@ static size_t write_single_frame_handshake_pkt_generic(
   ngtcp2_ppe_init(&ppe, out, outlen, &cc);
   rv = ngtcp2_ppe_encode_hd(&ppe, &hd);
   assert(0 == rv);
+  ngtcp2_put_uint32be(&out[1], version);
   rv = ngtcp2_ppe_encode_frame(&ppe, fr);
   assert(0 == rv);
   n = ngtcp2_ppe_final(&ppe, NULL);


### PR DESCRIPTION
Now ngtcp2_accept does not return NGTCP2_ERR_VERSION_NEGOTIATION.  It
should be handled by inspecting the return value of
ngtcp2_pkt_decode_version_cid.