### PR TITLE
Compatible version negotiation and QUIC v2

### DIFF
--- a/crypto/includes/ngtcp2/ngtcp2_crypto.h
+++ b/crypto/includes/ngtcp2/ngtcp2_crypto.h
@@ -836,6 +836,21 @@ NGTCP2_EXTERN int ngtcp2_crypto_get_path_challenge_data_cb(ngtcp2_conn *conn,
                                                            uint8_t *data,
                                                            void *user_data);
 
+/**
+ * @function
+ *
+ * `ngtcp2_crypto_version_negotiation_cb` installs Initial keys for
+ * |version| which is negotiated or being negotiated.  |client_dcid|
+ * is the destination connection ID in first Initial packet of client.
+ *
+ * This function can be directly passed to
+ * :member:`ngtcp2_callbacks.version_negotiation` field.
+ */
+NGTCP2_EXTERN int
+ngtcp2_crypto_version_negotiation_cb(ngtcp2_conn *conn, uint32_t version,
+                                     const ngtcp2_cid *client_dcid,
+                                     void *user_data);
+
 #ifdef __cplusplus
 }
 #endif

--- a/crypto/shared.c
+++ b/crypto/shared.c
@@ -85,10 +85,16 @@ int ngtcp2_crypto_derive_initial_secrets(uint32_t version, uint8_t *rx_secret,
 
   ngtcp2_crypto_ctx_initial(&ctx);
 
-  if (version == NGTCP2_PROTO_VER_V1) {
+  switch (version) {
+  case NGTCP2_PROTO_VER_V1:
     salt = (const uint8_t *)NGTCP2_INITIAL_SALT_V1;
     saltlen = sizeof(NGTCP2_INITIAL_SALT_V1) - 1;
-  } else {
+    break;
+  case NGTCP2_PROTO_VER_V2:
+    salt = (const uint8_t *)NGTCP2_INITIAL_SALT_V2;
+    saltlen = sizeof(NGTCP2_INITIAL_SALT_V2) - 1;
+    break;
+  default:
     salt = (const uint8_t *)NGTCP2_INITIAL_SALT_DRAFT;
     saltlen = sizeof(NGTCP2_INITIAL_SALT_DRAFT) - 1;
   }
@@ -129,26 +135,52 @@ int ngtcp2_crypto_derive_packet_protection_key(
     uint8_t *key, uint8_t *iv, uint8_t *hp_key, uint32_t version,
     const ngtcp2_crypto_aead *aead, const ngtcp2_crypto_md *md,
     const uint8_t *secret, size_t secretlen) {
-  static const uint8_t KEY_LABEL[] = "quic key";
-  static const uint8_t IV_LABEL[] = "quic iv";
-  static const uint8_t HP_KEY_LABEL[] = "quic hp";
+  static const uint8_t KEY_LABEL_V1[] = "quic key";
+  static const uint8_t IV_LABEL_V1[] = "quic iv";
+  static const uint8_t HP_KEY_LABEL_V1[] = "quic hp";
+  static const uint8_t KEY_LABEL_V2[] = "quicv2 key";
+  static const uint8_t IV_LABEL_V2[] = "quicv2 iv";
+  static const uint8_t HP_KEY_LABEL_V2[] = "quicv2 hp";
   size_t keylen = ngtcp2_crypto_aead_keylen(aead);
   size_t ivlen = ngtcp2_crypto_packet_protection_ivlen(aead);
-  (void)version;
+  const uint8_t *key_label;
+  size_t key_labellen;
+  const uint8_t *iv_label;
+  size_t iv_labellen;
+  const uint8_t *hp_key_label;
+  size_t hp_key_labellen;
+
+  switch (version) {
+  case NGTCP2_PROTO_VER_V2:
+    key_label = KEY_LABEL_V2;
+    key_labellen = sizeof(KEY_LABEL_V2) - 1;
+    iv_label = IV_LABEL_V2;
+    iv_labellen = sizeof(IV_LABEL_V2) - 1;
+    hp_key_label = HP_KEY_LABEL_V2;
+    hp_key_labellen = sizeof(HP_KEY_LABEL_V2) - 1;
+    break;
+  default:
+    key_label = KEY_LABEL_V1;
+    key_labellen = sizeof(KEY_LABEL_V1) - 1;
+    iv_label = IV_LABEL_V1;
+    iv_labellen = sizeof(IV_LABEL_V1) - 1;
+    hp_key_label = HP_KEY_LABEL_V1;
+    hp_key_labellen = sizeof(HP_KEY_LABEL_V1) - 1;
+  }
 
   if (ngtcp2_crypto_hkdf_expand_label(key, keylen, md, secret, secretlen,
-                                      KEY_LABEL, sizeof(KEY_LABEL) - 1) != 0) {
+                                      key_label, key_labellen) != 0) {
     return -1;
   }
 
   if (ngtcp2_crypto_hkdf_expand_label(iv, ivlen, md, secret, secretlen,
-                                      IV_LABEL, sizeof(IV_LABEL) - 1) != 0) {
+                                      iv_label, iv_labellen) != 0) {
     return -1;
   }
 
-  if (hp_key != NULL && ngtcp2_crypto_hkdf_expand_label(
-                            hp_key, keylen, md, secret, secretlen, HP_KEY_LABEL,
-                            sizeof(HP_KEY_LABEL) - 1) != 0) {
+  if (hp_key != NULL &&
+      ngtcp2_crypto_hkdf_expand_label(hp_key, keylen, md, secret, secretlen,
+                                      hp_key_label, hp_key_labellen) != 0) {
     return -1;
   }
 
@@ -200,11 +232,22 @@ int ngtcp2_crypto_derive_and_install_rx_key(ngtcp2_conn *conn, uint8_t *key,
     hp_key = hp_keybuf;
   }
 
-  if (level == NGTCP2_CRYPTO_LEVEL_EARLY) {
+  switch (level) {
+  case NGTCP2_CRYPTO_LEVEL_EARLY:
     ngtcp2_crypto_ctx_tls_early(&cctx, tls);
     ngtcp2_conn_set_early_crypto_ctx(conn, &cctx);
     ctx = ngtcp2_conn_get_early_crypto_ctx(conn);
-  } else {
+    break;
+  case NGTCP2_CRYPTO_LEVEL_HANDSHAKE:
+    if (ngtcp2_conn_is_server(conn) &&
+        !ngtcp2_conn_get_negotiated_version(conn)) {
+      rv = ngtcp2_crypto_set_remote_transport_params(conn, tls);
+      if (rv != 0) {
+        return -1;
+      }
+    }
+    /* fall through */
+  default:
     ctx = ngtcp2_conn_get_crypto_ctx(conn);
 
     if (!ctx->aead.native_handle) {
@@ -335,11 +378,22 @@ int ngtcp2_crypto_derive_and_install_tx_key(ngtcp2_conn *conn, uint8_t *key,
     hp_key = hp_keybuf;
   }
 
-  if (level == NGTCP2_CRYPTO_LEVEL_EARLY) {
+  switch (level) {
+  case NGTCP2_CRYPTO_LEVEL_EARLY:
     ngtcp2_crypto_ctx_tls_early(&cctx, tls);
     ngtcp2_conn_set_early_crypto_ctx(conn, &cctx);
     ctx = ngtcp2_conn_get_early_crypto_ctx(conn);
-  } else {
+    break;
+  case NGTCP2_CRYPTO_LEVEL_HANDSHAKE:
+    if (ngtcp2_conn_is_server(conn) &&
+        !ngtcp2_conn_get_negotiated_version(conn)) {
+      rv = ngtcp2_crypto_set_remote_transport_params(conn, tls);
+      if (rv != 0) {
+        return -1;
+      }
+    }
+    /* fall through */
+  default:
     ctx = ngtcp2_conn_get_crypto_ctx(conn);
 
     if (!ctx->aead.native_handle) {
@@ -382,15 +436,9 @@ int ngtcp2_crypto_derive_and_install_tx_key(ngtcp2_conn *conn, uint8_t *key,
       goto fail;
     }
 
-    if (ngtcp2_conn_is_server(conn)) {
-      rv = ngtcp2_crypto_set_remote_transport_params(conn, tls);
-      if (rv != 0) {
-        return rv;
-      }
-
-      if (crypto_set_local_transport_params(conn, tls) != 0) {
-        return rv;
-      }
+    if (ngtcp2_conn_is_server(conn) &&
+        crypto_set_local_transport_params(conn, tls) != 0) {
+      goto fail;
     }
 
     break;
@@ -516,10 +564,16 @@ int ngtcp2_crypto_derive_and_install_initial_key(
   if (!server && !ngtcp2_conn_after_retry(conn)) {
     ngtcp2_crypto_aead_retry(&retry_aead);
 
-    if (version == NGTCP2_PROTO_VER_V1) {
+    switch (version) {
+    case NGTCP2_PROTO_VER_V1:
       retry_key = (const uint8_t *)NGTCP2_RETRY_KEY_V1;
       retry_noncelen = sizeof(NGTCP2_RETRY_NONCE_V1) - 1;
-    } else {
+      break;
+    case NGTCP2_PROTO_VER_V2:
+      retry_key = (const uint8_t *)NGTCP2_RETRY_KEY_V2;
+      retry_noncelen = sizeof(NGTCP2_RETRY_NONCE_V2) - 1;
+      break;
+    default:
       retry_key = (const uint8_t *)NGTCP2_RETRY_KEY_DRAFT;
       retry_noncelen = sizeof(NGTCP2_RETRY_NONCE_DRAFT) - 1;
     }
@@ -545,6 +599,114 @@ int ngtcp2_crypto_derive_and_install_initial_key(
 
 fail:
   ngtcp2_crypto_aead_ctx_free(&retry_aead_ctx);
+  ngtcp2_crypto_cipher_ctx_free(&tx_hp_ctx);
+  ngtcp2_crypto_aead_ctx_free(&tx_aead_ctx);
+  ngtcp2_crypto_cipher_ctx_free(&rx_hp_ctx);
+  ngtcp2_crypto_aead_ctx_free(&rx_aead_ctx);
+
+  return -1;
+}
+
+int ngtcp2_crypto_derive_and_install_vneg_initial_key(
+    ngtcp2_conn *conn, uint8_t *rx_secret, uint8_t *tx_secret,
+    uint8_t *initial_secret, uint8_t *rx_key, uint8_t *rx_iv,
+    uint8_t *rx_hp_key, uint8_t *tx_key, uint8_t *tx_iv, uint8_t *tx_hp_key,
+    uint32_t version, const ngtcp2_cid *client_dcid) {
+  uint8_t rx_secretbuf[NGTCP2_CRYPTO_INITIAL_SECRETLEN];
+  uint8_t tx_secretbuf[NGTCP2_CRYPTO_INITIAL_SECRETLEN];
+  uint8_t initial_secretbuf[NGTCP2_CRYPTO_INITIAL_SECRETLEN];
+  uint8_t rx_keybuf[NGTCP2_CRYPTO_INITIAL_KEYLEN];
+  uint8_t rx_ivbuf[NGTCP2_CRYPTO_INITIAL_IVLEN];
+  uint8_t rx_hp_keybuf[NGTCP2_CRYPTO_INITIAL_KEYLEN];
+  uint8_t tx_keybuf[NGTCP2_CRYPTO_INITIAL_KEYLEN];
+  uint8_t tx_ivbuf[NGTCP2_CRYPTO_INITIAL_IVLEN];
+  uint8_t tx_hp_keybuf[NGTCP2_CRYPTO_INITIAL_KEYLEN];
+  const ngtcp2_crypto_ctx *ctx = ngtcp2_conn_get_initial_crypto_ctx(conn);
+  ngtcp2_crypto_aead_ctx rx_aead_ctx = {0};
+  ngtcp2_crypto_cipher_ctx rx_hp_ctx = {0};
+  ngtcp2_crypto_aead_ctx tx_aead_ctx = {0};
+  ngtcp2_crypto_cipher_ctx tx_hp_ctx = {0};
+  int rv;
+  int server = ngtcp2_conn_is_server(conn);
+
+  if (!rx_secret) {
+    rx_secret = rx_secretbuf;
+  }
+  if (!tx_secret) {
+    tx_secret = tx_secretbuf;
+  }
+  if (!initial_secret) {
+    initial_secret = initial_secretbuf;
+  }
+
+  if (!rx_key) {
+    rx_key = rx_keybuf;
+  }
+  if (!rx_iv) {
+    rx_iv = rx_ivbuf;
+  }
+  if (!rx_hp_key) {
+    rx_hp_key = rx_hp_keybuf;
+  }
+  if (!tx_key) {
+    tx_key = tx_keybuf;
+  }
+  if (!tx_iv) {
+    tx_iv = tx_ivbuf;
+  }
+  if (!tx_hp_key) {
+    tx_hp_key = tx_hp_keybuf;
+  }
+
+  if (ngtcp2_crypto_derive_initial_secrets(
+          version, rx_secret, tx_secret, initial_secret, client_dcid,
+          server ? NGTCP2_CRYPTO_SIDE_SERVER : NGTCP2_CRYPTO_SIDE_CLIENT) !=
+      0) {
+    return -1;
+  }
+
+  if (ngtcp2_crypto_derive_packet_protection_key(
+          rx_key, rx_iv, rx_hp_key, version, &ctx->aead, &ctx->md, rx_secret,
+          NGTCP2_CRYPTO_INITIAL_SECRETLEN) != 0) {
+    return -1;
+  }
+
+  if (ngtcp2_crypto_derive_packet_protection_key(
+          tx_key, tx_iv, tx_hp_key, version, &ctx->aead, &ctx->md, tx_secret,
+          NGTCP2_CRYPTO_INITIAL_SECRETLEN) != 0) {
+    return -1;
+  }
+
+  if (ngtcp2_crypto_aead_ctx_decrypt_init(&rx_aead_ctx, &ctx->aead, rx_key,
+                                          NGTCP2_CRYPTO_INITIAL_IVLEN) != 0) {
+    goto fail;
+  }
+
+  if (ngtcp2_crypto_cipher_ctx_encrypt_init(&rx_hp_ctx, &ctx->hp, rx_hp_key) !=
+      0) {
+    goto fail;
+  }
+
+  if (ngtcp2_crypto_aead_ctx_encrypt_init(&tx_aead_ctx, &ctx->aead, tx_key,
+                                          NGTCP2_CRYPTO_INITIAL_IVLEN) != 0) {
+    goto fail;
+  }
+
+  if (ngtcp2_crypto_cipher_ctx_encrypt_init(&tx_hp_ctx, &ctx->hp, tx_hp_key) !=
+      0) {
+    goto fail;
+  }
+
+  rv = ngtcp2_conn_install_vneg_initial_key(
+      conn, version, &rx_aead_ctx, rx_iv, &rx_hp_ctx, &tx_aead_ctx, tx_iv,
+      &tx_hp_ctx, NGTCP2_CRYPTO_INITIAL_IVLEN);
+  if (rv != 0) {
+    goto fail;
+  }
+
+  return 0;
+
+fail:
   ngtcp2_crypto_cipher_ctx_free(&tx_hp_ctx);
   ngtcp2_crypto_aead_ctx_free(&tx_aead_ctx);
   ngtcp2_crypto_cipher_ctx_free(&rx_hp_ctx);
@@ -1190,6 +1352,20 @@ int ngtcp2_crypto_recv_client_initial_cb(ngtcp2_conn *conn,
   if (ngtcp2_crypto_derive_and_install_initial_key(
           conn, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
           ngtcp2_conn_get_original_version(conn), dcid) != 0) {
+    return NGTCP2_ERR_CALLBACK_FAILURE;
+  }
+
+  return 0;
+}
+
+int ngtcp2_crypto_version_negotiation_cb(ngtcp2_conn *conn, uint32_t version,
+                                         const ngtcp2_cid *client_dcid,
+                                         void *user_data) {
+  (void)user_data;
+
+  if (ngtcp2_crypto_derive_and_install_vneg_initial_key(
+          conn, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, version,
+          client_dcid) != 0) {
     return NGTCP2_ERR_CALLBACK_FAILURE;
   }
 

--- a/crypto/shared.h
+++ b/crypto/shared.h
@@ -51,6 +51,16 @@
   "\x38\x76\x2c\xf7\xf5\x59\x34\xb3\x4d\x17\x9a\xe6\xa4\xc8\x0c\xad\xcc\xbb"   \
   "\x7f\x0a"
 
+/**
+ * @macro
+ *
+ * :macro:`NGTCP2_INITIAL_SALT_V2` is a salt value which is used to
+ * derive initial secret.  It is used for QUIC v2.
+ */
+#define NGTCP2_INITIAL_SALT_V2                                                 \
+  "\xa7\x07\xc2\x03\xa5\x9b\x47\x18\x4a\x1d\x62\xca\x57\x04\x06\xea\x7a\xe3"   \
+  "\xe5\xd3"
+
 /* Maximum key usage (encryption) limits */
 #define NGTCP2_CRYPTO_MAX_ENCRYPTION_AES_GCM (1ULL << 23)
 #define NGTCP2_CRYPTO_MAX_ENCRYPTION_CHACHA20_POLY1305 (1ULL << 62)
@@ -243,6 +253,57 @@ int ngtcp2_crypto_set_remote_transport_params(ngtcp2_conn *conn, void *tls);
  * This function returns 0 if it succeeds, or -1.
  */
 int ngtcp2_crypto_derive_and_install_initial_key(
+    ngtcp2_conn *conn, uint8_t *rx_secret, uint8_t *tx_secret,
+    uint8_t *initial_secret, uint8_t *rx_key, uint8_t *rx_iv, uint8_t *rx_hp,
+    uint8_t *tx_key, uint8_t *tx_iv, uint8_t *tx_hp, uint32_t version,
+    const ngtcp2_cid *client_dcid);
+
+/**
+ * @function
+ *
+ * `ngtcp2_crypto_derive_and_install_vneg_initial_key` derives initial
+ * keying materials and installs keys to |conn|.  This function is
+ * dedicated to install keys for |version| which is negotiated, or
+ * being negotiated.
+ *
+ * If |rx_secret| is not NULL, the secret for decryption is written to
+ * the buffer pointed by |rx_secret|.  The length of secret is 32
+ * bytes, and |rx_secret| must point to the buffer which has enough
+ * capacity.
+ *
+ * If |tx_secret| is not NULL, the secret for encryption is written to
+ * the buffer pointed by |tx_secret|.  The length of secret is 32
+ * bytes, and |tx_secret| must point to the buffer which has enough
+ * capacity.
+ *
+ * If |initial_secret| is not NULL, the initial secret is written to
+ * the buffer pointed by |initial_secret|.  The length of secret is 32
+ * bytes, and |initial_secret| must point to the buffer which has
+ * enough capacity.
+ *
+ * |client_dcid| is the destination connection ID in first Initial
+ * packet of client.
+ *
+ * If |rx_key| is not NULL, the derived packet protection key for
+ * decryption is written to the buffer pointed by |rx_key|.  If
+ * |rx_iv| is not NULL, the derived packet protection IV for
+ * decryption is written to the buffer pointed by |rx_iv|.  If |rx_hp|
+ * is not NULL, the derived header protection key for decryption is
+ * written to the buffer pointed by |rx_hp|.
+ *
+ * If |tx_key| is not NULL, the derived packet protection key for
+ * encryption is written to the buffer pointed by |tx_key|.  If
+ * |tx_iv| is not NULL, the derived packet protection IV for
+ * encryption is written to the buffer pointed by |tx_iv|.  If |tx_hp|
+ * is not NULL, the derived header protection key for encryption is
+ * written to the buffer pointed by |tx_hp|.
+ *
+ * The length of packet protection key and header protection key is 16
+ * bytes long.  The length of packet protection IV is 12 bytes long.
+ *
+ * This function returns 0 if it succeeds, or -1.
+ */
+int ngtcp2_crypto_derive_and_install_vneg_initial_key(
     ngtcp2_conn *conn, uint8_t *rx_secret, uint8_t *tx_secret,
     uint8_t *initial_secret, uint8_t *rx_key, uint8_t *rx_iv, uint8_t *rx_hp,
     uint8_t *tx_key, uint8_t *tx_iv, uint8_t *tx_hp, uint32_t version,

--- a/doc/source/programmers-guide.rst
+++ b/doc/source/programmers-guide.rst
@@ -67,6 +67,9 @@ callback functions must be set:
   directly.
 * :member:`get_path_challenge_data <ngtcp2_get_path_challenge_data>`:
   `ngtcp2_crypto_get_path_challenge_data_cb()` can be passed directly.
+* :member:`version_negotiation
+  <ngtcp2_callbacks.version_negotiation>`:
+  `ngtcp2_crypto_version_negotiation_cb()` can be passed directly.
 
 For server application, the following callback functions must be set:
 
@@ -95,6 +98,9 @@ For server application, the following callback functions must be set:
   directly.
 * :member:`get_path_challenge_data <ngtcp2_get_path_challenge_data>`:
   `ngtcp2_crypto_get_path_challenge_data_cb()` can be passed directly.
+* :member:`version_negotiation
+  <ngtcp2_callbacks.version_negotiation>`:
+  `ngtcp2_crypto_version_negotiation_cb()` can be passed directly.
 
 ``ngtcp2_crypto_*`` functions are a part of :doc:`ngtcp2 crypto API
 <crypto_apiref>` which provides easy integration with the supported

--- a/examples/client.cc
+++ b/examples/client.cc
@@ -642,6 +642,7 @@ int Client::init(int fd, const Address &local_addr, const Address &remote_addr,
       nullptr, // lost_datagram
       ngtcp2_crypto_get_path_challenge_data_cb,
       stream_stop_sending,
+      ngtcp2_crypto_version_negotiation_cb,
   };
 
   ngtcp2_cid scid, dcid;

--- a/examples/gtlssimpleclient.c
+++ b/examples/gtlssimpleclient.c
@@ -481,6 +481,7 @@ static int client_quic_init(struct client *c,
       NULL, /* lost_datagram */
       ngtcp2_crypto_get_path_challenge_data_cb,
       NULL, /* stream_stop_sending */
+      ngtcp2_crypto_version_negotiation_cb,
   };
   ngtcp2_cid dcid, scid;
   ngtcp2_settings settings;

--- a/examples/h09client.cc
+++ b/examples/h09client.cc
@@ -604,6 +604,8 @@ int Client::init(int fd, const Address &local_addr, const Address &remote_addr,
       nullptr, // ack_datagram
       nullptr, // lost_datagram
       ngtcp2_crypto_get_path_challenge_data_cb,
+      nullptr, // stream_stop_sending
+      ngtcp2_crypto_version_negotiation_cb,
   };
 
   ngtcp2_cid scid, dcid;

--- a/examples/h09server.cc
+++ b/examples/h09server.cc
@@ -710,6 +710,8 @@ int Handler::init(const Endpoint &ep, const Address &local_addr,
       nullptr, // ack_datagram
       nullptr, // lost_datagram
       ngtcp2_crypto_get_path_challenge_data_cb,
+      nullptr, // stream_stop_sending
+      ngtcp2_crypto_version_negotiation_cb,
   };
 
   scid_.datalen = NGTCP2_SV_SCIDLEN;

--- a/examples/server.cc
+++ b/examples/server.cc
@@ -1383,6 +1383,7 @@ int Handler::init(const Endpoint &ep, const Address &local_addr,
       nullptr, // lost_datagram
       ngtcp2_crypto_get_path_challenge_data_cb,
       stream_stop_sending,
+      ngtcp2_crypto_version_negotiation_cb,
   };
 
   scid_.datalen = NGTCP2_SV_SCIDLEN;

--- a/examples/shared.h
+++ b/examples/shared.h
@@ -62,6 +62,7 @@ constexpr uint32_t QUIC_VER_DRAFT30 = 0xff00001eu;
 constexpr uint32_t QUIC_VER_DRAFT31 = 0xff00001fu;
 constexpr uint32_t QUIC_VER_DRAFT32 = 0xff000020u;
 constexpr uint32_t QUIC_VER_V1 = 0x00000001u;
+constexpr uint32_t QUIC_VER_V2 = NGTCP2_PROTO_VER_V2;
 
 // msghdr_get_ecn gets ECN bits from |msg|.  |family| is the address
 // family from which packet is received.

--- a/examples/simpleclient.c
+++ b/examples/simpleclient.c
@@ -378,6 +378,7 @@ static int client_quic_init(struct client *c,
       NULL, /* lost_datagram */
       ngtcp2_crypto_get_path_challenge_data_cb,
       NULL, /* stream_stop_sending */
+      ngtcp2_crypto_version_negotiation_cb,
   };
   ngtcp2_cid dcid, scid;
   ngtcp2_settings settings;

--- a/examples/tls_client_session_boringssl.cc
+++ b/examples/tls_client_session_boringssl.cc
@@ -56,7 +56,7 @@ int TLSClientSession::init(bool &early_data_enabled,
   SSL_set_app_data(ssl_, client);
   SSL_set_connect_state(ssl_);
 
-  if (quic_version & 0xff000000) {
+  if ((quic_version & 0xff000000) == 0xff000000) {
     SSL_set_quic_use_legacy_codepoint(ssl_, 1);
   } else {
     SSL_set_quic_use_legacy_codepoint(ssl_, 0);

--- a/examples/tls_client_session_gnutls.cc
+++ b/examples/tls_client_session_gnutls.cc
@@ -181,7 +181,7 @@ int append_local_transport_params(const ClientBase *client,
   ngtcp2_transport_params params;
   ngtcp2_conn_get_local_transport_params(conn, &params);
 
-  std::array<uint8_t, 64> buf;
+  std::array<uint8_t, 256> buf;
 
   auto nwrite = ngtcp2_encode_transport_params(
       buf.data(), buf.size(), NGTCP2_TRANSPORT_PARAMS_TYPE_CLIENT_HELLO,
@@ -247,7 +247,7 @@ int TLSClientSession::init(bool &early_data_enabled,
 
   if (auto rv = gnutls_session_ext_register(
           session_, "QUIC Transport Parameters",
-          (quic_version & 0xff000000)
+          (quic_version & 0xff000000) == 0xff000000
               ? NGTCP2_TLSEXT_QUIC_TRANSPORT_PARAMETERS_DRAFT
               : NGTCP2_TLSEXT_QUIC_TRANSPORT_PARAMETERS_V1,
           GNUTLS_EXT_TLS, tp_recv_func, tp_send_func, nullptr, nullptr, nullptr,

--- a/examples/tls_client_session_openssl.cc
+++ b/examples/tls_client_session_openssl.cc
@@ -58,7 +58,7 @@ int TLSClientSession::init(bool &early_data_enabled,
   SSL_set_app_data(ssl_, client);
   SSL_set_connect_state(ssl_);
 
-  if (quic_version & 0xff000000) {
+  if ((quic_version & 0xff000000) == 0xff000000) {
     SSL_set_quic_use_legacy_codepoint(ssl_, 1);
   } else {
     SSL_set_quic_use_legacy_codepoint(ssl_, 0);

--- a/examples/tls_client_session_picotls.cc
+++ b/examples/tls_client_session_picotls.cc
@@ -58,7 +58,7 @@ int set_additional_extensions(ptls_handshake_properties_t &hsprops,
 
   ngtcp2_conn_get_local_transport_params(conn, &params);
 
-  constexpr size_t paramsbuflen = 64;
+  constexpr size_t paramsbuflen = 256;
   auto paramsbuf = std::make_unique<uint8_t[]>(paramsbuflen);
 
   auto nwrite = ngtcp2_encode_transport_params(

--- a/examples/tls_server_context_boringssl.cc
+++ b/examples/tls_server_context_boringssl.cc
@@ -53,7 +53,9 @@ int alpn_select_proto_h3_cb(SSL *ssl, const unsigned char **out,
   auto h = static_cast<HandlerBase *>(SSL_get_app_data(ssl));
   const uint8_t *alpn;
   size_t alpnlen;
-  auto version = ngtcp2_conn_get_negotiated_version(h->conn());
+  // This should be the negotiated version, but we have not set the
+  // negotiated version when this callback is called.
+  auto version = ngtcp2_conn_get_original_version(h->conn());
 
   switch (version) {
   case QUIC_VER_DRAFT29:
@@ -73,6 +75,7 @@ int alpn_select_proto_h3_cb(SSL *ssl, const unsigned char **out,
     alpnlen = str_size(H3_ALPN_DRAFT32);
     break;
   case QUIC_VER_V1:
+  case QUIC_VER_V2:
     alpn = reinterpret_cast<const uint8_t *>(H3_ALPN_V1);
     alpnlen = str_size(H3_ALPN_V1);
     break;
@@ -107,7 +110,9 @@ int alpn_select_proto_hq_cb(SSL *ssl, const unsigned char **out,
   auto h = static_cast<HandlerBase *>(SSL_get_app_data(ssl));
   const uint8_t *alpn;
   size_t alpnlen;
-  auto version = ngtcp2_conn_get_negotiated_version(h->conn());
+  // This should be the negotiated version, but we have not set the
+  // negotiated version when this callback is called.
+  auto version = ngtcp2_conn_get_original_version(h->conn());
 
   switch (version) {
   case QUIC_VER_DRAFT29:
@@ -127,6 +132,7 @@ int alpn_select_proto_hq_cb(SSL *ssl, const unsigned char **out,
     alpnlen = str_size(HQ_ALPN_DRAFT32);
     break;
   case QUIC_VER_V1:
+  case QUIC_VER_V2:
     alpn = reinterpret_cast<const uint8_t *>(HQ_ALPN_V1);
     alpnlen = str_size(HQ_ALPN_V1);
     break;

--- a/examples/tls_server_context_openssl.cc
+++ b/examples/tls_server_context_openssl.cc
@@ -54,7 +54,9 @@ int alpn_select_proto_h3_cb(SSL *ssl, const unsigned char **out,
   auto h = static_cast<HandlerBase *>(SSL_get_app_data(ssl));
   const uint8_t *alpn;
   size_t alpnlen;
-  auto version = ngtcp2_conn_get_negotiated_version(h->conn());
+  // This should be the negotiated version, but we have not set the
+  // negotiated version when this callback is called.
+  auto version = ngtcp2_conn_get_original_version(h->conn());
 
   switch (version) {
   case QUIC_VER_DRAFT29:
@@ -74,6 +76,7 @@ int alpn_select_proto_h3_cb(SSL *ssl, const unsigned char **out,
     alpnlen = str_size(H3_ALPN_DRAFT32);
     break;
   case QUIC_VER_V1:
+  case QUIC_VER_V2:
     alpn = reinterpret_cast<const uint8_t *>(H3_ALPN_V1);
     alpnlen = str_size(H3_ALPN_V1);
     break;
@@ -108,7 +111,9 @@ int alpn_select_proto_hq_cb(SSL *ssl, const unsigned char **out,
   auto h = static_cast<HandlerBase *>(SSL_get_app_data(ssl));
   const uint8_t *alpn;
   size_t alpnlen;
-  auto version = ngtcp2_conn_get_negotiated_version(h->conn());
+  // This should be the negotiated version, but we have not set the
+  // negotiated version when this callback is called.
+  auto version = ngtcp2_conn_get_original_version(h->conn());
 
   switch (version) {
   case QUIC_VER_DRAFT29:
@@ -128,6 +133,7 @@ int alpn_select_proto_hq_cb(SSL *ssl, const unsigned char **out,
     alpnlen = str_size(HQ_ALPN_DRAFT32);
     break;
   case QUIC_VER_V1:
+  case QUIC_VER_V2:
     alpn = reinterpret_cast<const uint8_t *>(HQ_ALPN_V1);
     alpnlen = str_size(HQ_ALPN_V1);
     break;

--- a/lib/ngtcp2_conn.h
+++ b/lib/ngtcp2_conn.h
@@ -625,6 +625,25 @@ struct ngtcp2_conn {
     ngtcp2_duration timeout;
   } keep_alive;
 
+  struct {
+    /* Initial keys for negotiated version.  If original version ==
+       negotiated version, these fields are not used. */
+    struct {
+      ngtcp2_crypto_km *ckm;
+      ngtcp2_crypto_cipher_ctx hp_ctx;
+    } rx;
+    struct {
+      ngtcp2_crypto_km *ckm;
+      ngtcp2_crypto_cipher_ctx hp_ctx;
+    } tx;
+    /* version is QUIC version that the above Initial keys are created
+       for. */
+    uint32_t version;
+    /* other_versions is the versions that the local endpoint sends in
+       version_information transport parameter. */
+    uint8_t other_versions[sizeof(uint32_t) * 2];
+  } vneg;
+
   ngtcp2_map strms;
   ngtcp2_conn_stat cstat;
   ngtcp2_pv *pv;
@@ -637,7 +656,8 @@ struct ngtcp2_conn {
   /* idle_ts is the time instant when idle timer started. */
   ngtcp2_tstamp idle_ts;
   void *user_data;
-  uint32_t version;
+  uint32_t original_version;
+  uint32_t negotiated_version;
   /* flags is bitwise OR of zero or more of NGTCP2_CONN_FLAG_*. */
   uint32_t flags;
   int server;

--- a/lib/ngtcp2_crypto.c
+++ b/lib/ngtcp2_crypto.c
@@ -157,6 +157,7 @@ ngtcp2_ssize ngtcp2_encode_transport_params_versioned(
   size_t len = 0;
   /* For some reason, gcc 7.3.0 requires this initialization. */
   size_t preferred_addrlen = 0;
+  size_t version_infolen = 0;
   (void)transport_params_version;
 
   switch (exttype) {
@@ -257,6 +258,11 @@ ngtcp2_ssize ngtcp2_encode_transport_params_versioned(
   if (params->grease_quic_bit) {
     len += ngtcp2_put_varint_len(NGTCP2_TRANSPORT_PARAM_GREASE_QUIC_BIT) +
            ngtcp2_put_varint_len(0);
+  }
+  if (params->version_info_present) {
+    version_infolen = sizeof(uint32_t) + params->version_info.other_versionslen;
+    len += ngtcp2_put_varint_len(NGTCP2_TRANSPORT_PARAM_VERSION_INFORMATION) +
+           ngtcp2_put_varint_len(version_infolen) + version_infolen;
   }
 
   if (destlen < len) {
@@ -392,6 +398,14 @@ ngtcp2_ssize ngtcp2_encode_transport_params_versioned(
   if (params->grease_quic_bit) {
     p = ngtcp2_put_varint(p, NGTCP2_TRANSPORT_PARAM_GREASE_QUIC_BIT);
     p = ngtcp2_put_varint(p, 0);
+  }
+
+  if (params->version_info_present) {
+    p = ngtcp2_put_varint(p, NGTCP2_TRANSPORT_PARAM_VERSION_INFORMATION);
+    p = ngtcp2_put_varint(p, version_infolen);
+    p = ngtcp2_put_uint32be(p, params->version_info.chosen_version);
+    p = ngtcp2_cpymem(p, params->version_info.other_versions,
+                      params->version_info.other_versionslen);
   }
 
   assert((size_t)(p - dest) == len);
@@ -531,6 +545,7 @@ int ngtcp2_decode_transport_params_versioned(
   memset(&params->retry_scid, 0, sizeof(params->retry_scid));
   memset(&params->initial_scid, 0, sizeof(params->initial_scid));
   memset(&params->original_dcid, 0, sizeof(params->original_dcid));
+  params->version_info_present = 0;
 
   p = data;
   end = data + datalen;
@@ -767,6 +782,27 @@ int ngtcp2_decode_transport_params_versioned(
       }
       p += nread;
       params->grease_quic_bit = 1;
+      break;
+    case NGTCP2_TRANSPORT_PARAM_VERSION_INFORMATION:
+      nread = decode_varint(&valuelen, p, end);
+      if (nread < 0) {
+        return NGTCP2_ERR_MALFORMED_TRANSPORT_PARAM;
+      }
+      p += nread;
+      if ((size_t)(end - p) < valuelen) {
+        return NGTCP2_ERR_MALFORMED_TRANSPORT_PARAM;
+      }
+      if (valuelen < sizeof(uint32_t) || (valuelen & 0x3)) {
+        return NGTCP2_ERR_MALFORMED_TRANSPORT_PARAM;
+      }
+      params->version_info.chosen_version = ngtcp2_get_uint32(p);
+      p += sizeof(uint32_t);
+      if (valuelen > sizeof(uint32_t)) {
+        params->version_info.other_versions = (uint8_t *)p;
+        params->version_info.other_versionslen = valuelen - sizeof(uint32_t);
+        p += valuelen - sizeof(uint32_t);
+      }
+      params->version_info_present = 1;
       break;
     default:
       /* Ignore unknown parameter */

--- a/lib/ngtcp2_crypto.h
+++ b/lib/ngtcp2_crypto.h
@@ -63,6 +63,8 @@ typedef enum ngtcp2_transport_param_id {
   NGTCP2_TRANSPORT_PARAM_RETRY_SOURCE_CONNECTION_ID = 0x0010,
   NGTCP2_TRANSPORT_PARAM_MAX_DATAGRAM_FRAME_SIZE = 0x0020,
   NGTCP2_TRANSPORT_PARAM_GREASE_QUIC_BIT = 0x2ab2,
+  /* https://quicwg.org/quic-v2/draft-ietf-quic-v2.html */
+  NGTCP2_TRANSPORT_PARAM_VERSION_INFORMATION = 0xff73db,
 } ngtcp2_transport_param_id;
 
 /* NGTCP2_CRYPTO_KM_FLAG_NONE indicates that no flag is set. */

--- a/lib/ngtcp2_err.c
+++ b/lib/ngtcp2_err.c
@@ -104,6 +104,8 @@ const char *ngtcp2_strerror(int liberr) {
     return "ERR_VERSION_NEGOTIATION";
   case NGTCP2_ERR_HANDSHAKE_TIMEOUT:
     return "ERR_HANDSHAKE_TIMEOUT";
+  case NGTCP2_ERR_VERSION_NEGOTIATION_FAILURE:
+    return "ERR_VERSION_NEGOTIATION_FAILURE";
   default:
     return "(unknown)";
   }
@@ -142,6 +144,8 @@ uint64_t ngtcp2_err_infer_quic_transport_error_code(int liberr) {
     return NGTCP2_AEAD_LIMIT_REACHED;
   case NGTCP2_ERR_NO_VIABLE_PATH:
     return NGTCP2_NO_VIABLE_PATH;
+  case NGTCP2_ERR_VERSION_NEGOTIATION_FAILURE:
+    return NGTCP2_VERSION_NEGOTIATION_ERROR;
   default:
     return NGTCP2_PROTOCOL_VIOLATION;
   }

--- a/lib/ngtcp2_pkt.h
+++ b/lib/ngtcp2_pkt.h
@@ -124,6 +124,19 @@
    v1. */
 #define NGTCP2_PKT_TYPE_RETRY_V1 0x3
 
+/* NGTCP2_PKT_TYPE_INITIAL_V2 is Initial long header packet type for
+   QUIC v2. */
+#define NGTCP2_PKT_TYPE_INITIAL_V2 0x1
+/* NGTCP2_PKT_TYPE_0RTT_V2 is 0RTT long header packet type for QUIC
+   v2. */
+#define NGTCP2_PKT_TYPE_0RTT_V2 0x2
+/* NGTCP2_PKT_TYPE_HANDSHAKE_V2 is Handshake long header packet type
+   for QUIC v2. */
+#define NGTCP2_PKT_TYPE_HANDSHAKE_V2 0x3
+/* NGTCP2_PKT_TYPE_RETRY_V2 is Retry long header packet type for QUIC
+   v2. */
+#define NGTCP2_PKT_TYPE_RETRY_V2 0x0
+
 typedef struct ngtcp2_pkt_retry {
   ngtcp2_cid odcid;
   ngtcp2_vec token;

--- a/tests/main.c
+++ b/tests/main.c
@@ -294,6 +294,8 @@ int main(void) {
                    test_ngtcp2_conn_handshake_timeout) ||
       !CU_add_test(pSuite, "conn_get_connection_close_error",
                    test_ngtcp2_conn_get_connection_close_error) ||
+      !CU_add_test(pSuite, "conn_version_negotiation",
+                   test_ngtcp2_conn_version_negotiation) ||
       !CU_add_test(pSuite, "accept", test_ngtcp2_accept) ||
       !CU_add_test(pSuite, "pkt_write_connection_close",
                    test_ngtcp2_pkt_write_connection_close) ||

--- a/tests/ngtcp2_conn_test.h
+++ b/tests/ngtcp2_conn_test.h
@@ -91,6 +91,7 @@ void test_ngtcp2_conn_stream_close(void);
 void test_ngtcp2_conn_buffer_pkt(void);
 void test_ngtcp2_conn_handshake_timeout(void);
 void test_ngtcp2_conn_get_connection_close_error(void);
+void test_ngtcp2_conn_version_negotiation(void);
 void test_ngtcp2_accept(void);
 void test_ngtcp2_pkt_write_connection_close(void);
 

--- a/tests/ngtcp2_pkt_test.c
+++ b/tests/ngtcp2_pkt_test.c
@@ -67,7 +67,7 @@ void test_ngtcp2_pkt_decode_version_cid(void) {
   /* Supported QUIC version */
   p = buf;
   *p++ = NGTCP2_HEADER_FORM_BIT;
-  p = ngtcp2_put_uint32be(p, NGTCP2_PROTO_VER_MAX);
+  p = ngtcp2_put_uint32be(p, NGTCP2_PROTO_VER_V1);
   *p++ = NGTCP2_MAX_CIDLEN;
   p = ngtcp2_setmem(p, 0xf1, NGTCP2_MAX_CIDLEN);
   *p++ = NGTCP2_MAX_CIDLEN - 1;
@@ -77,7 +77,7 @@ void test_ngtcp2_pkt_decode_version_cid(void) {
                                      buf, (size_t)(p - buf), 0);
 
   CU_ASSERT(0 == rv);
-  CU_ASSERT(NGTCP2_PROTO_VER_MAX == version);
+  CU_ASSERT(NGTCP2_PROTO_VER_V1 == version);
   CU_ASSERT(NGTCP2_MAX_CIDLEN == dcidlen);
   CU_ASSERT(&buf[6] == dcid);
   CU_ASSERT(NGTCP2_MAX_CIDLEN - 1 == scidlen);
@@ -120,7 +120,7 @@ void test_ngtcp2_pkt_decode_version_cid(void) {
   /* Supported QUIC version with long CID */
   p = buf;
   *p++ = NGTCP2_HEADER_FORM_BIT;
-  p = ngtcp2_put_uint32be(p, NGTCP2_PROTO_VER_MAX);
+  p = ngtcp2_put_uint32be(p, NGTCP2_PROTO_VER_V1);
   *p++ = NGTCP2_MAX_CIDLEN + 1;
   p = ngtcp2_setmem(p, 0xf1, NGTCP2_MAX_CIDLEN + 1);
   *p++ = NGTCP2_MAX_CIDLEN;
@@ -182,12 +182,17 @@ void test_ngtcp2_pkt_decode_version_cid(void) {
   rv = ngtcp2_pkt_decode_version_cid(&version, &dcid, &dcidlen, &scid, &scidlen,
                                      buf, (size_t)(p - buf), 0);
 
-  CU_ASSERT(NGTCP2_ERR_INVALID_ARGUMENT == rv);
+  CU_ASSERT(0 == rv);
+  CU_ASSERT(0 == version);
+  CU_ASSERT(NGTCP2_MAX_CIDLEN + 1 == dcidlen);
+  CU_ASSERT(&buf[6] == dcid);
+  CU_ASSERT(NGTCP2_MAX_CIDLEN == scidlen);
+  CU_ASSERT(&buf[6 + NGTCP2_MAX_CIDLEN + 1 + 1] == scid);
 
   /* Malformed Long packet */
   p = buf;
   *p++ = NGTCP2_HEADER_FORM_BIT;
-  p = ngtcp2_put_uint32be(p, NGTCP2_PROTO_VER_MAX);
+  p = ngtcp2_put_uint32be(p, NGTCP2_PROTO_VER_V1);
   *p++ = NGTCP2_MAX_CIDLEN;
   p = ngtcp2_setmem(p, 0xf1, NGTCP2_MAX_CIDLEN);
   *p++ = NGTCP2_MAX_CIDLEN - 1;
@@ -1508,8 +1513,8 @@ void test_ngtcp2_pkt_write_retry(void) {
     token[i] = (uint8_t)i;
   }
 
-  spktlen = ngtcp2_pkt_write_retry(buf, sizeof(buf), NGTCP2_PROTO_VER_MAX,
-                                   &dcid, &scid, &odcid, token, sizeof(token),
+  spktlen = ngtcp2_pkt_write_retry(buf, sizeof(buf), NGTCP2_PROTO_VER_V1, &dcid,
+                                   &scid, &odcid, token, sizeof(token),
                                    null_retry_encrypt, &aead, &aead_ctx);
 
   CU_ASSERT(spktlen > 0);
@@ -1520,7 +1525,7 @@ void test_ngtcp2_pkt_write_retry(void) {
 
   CU_ASSERT(nread > 0);
   CU_ASSERT(NGTCP2_PKT_RETRY == nhd.type);
-  CU_ASSERT(NGTCP2_PROTO_VER_MAX == nhd.version);
+  CU_ASSERT(NGTCP2_PROTO_VER_V1 == nhd.version);
   CU_ASSERT(ngtcp2_cid_eq(&dcid, &nhd.dcid));
   CU_ASSERT(ngtcp2_cid_eq(&scid, &nhd.scid));
 

--- a/tests/ngtcp2_rtb_test.c
+++ b/tests/ngtcp2_rtb_test.c
@@ -69,7 +69,7 @@ void test_ngtcp2_rtb_add(void) {
                   &rtb_entry_objalloc, &frc_objalloc, mem);
 
   ngtcp2_pkt_hd_init(&hd, NGTCP2_PKT_FLAG_NONE, NGTCP2_PKT_SHORT, &dcid, NULL,
-                     1000000007, 1, NGTCP2_PROTO_VER_MAX, 0);
+                     1000000007, 1, NGTCP2_PROTO_VER_V1, 0);
 
   rv = ngtcp2_rtb_entry_objalloc_new(
       &ent, &hd, NULL, 10, 0, NGTCP2_RTB_ENTRY_FLAG_NONE, &rtb_entry_objalloc);
@@ -79,7 +79,7 @@ void test_ngtcp2_rtb_add(void) {
   ngtcp2_rtb_add(&rtb, ent, &cstat);
 
   ngtcp2_pkt_hd_init(&hd, NGTCP2_PKT_FLAG_NONE, NGTCP2_PKT_SHORT, &dcid, NULL,
-                     1000000008, 2, NGTCP2_PROTO_VER_MAX, 0);
+                     1000000008, 2, NGTCP2_PROTO_VER_V1, 0);
 
   rv = ngtcp2_rtb_entry_objalloc_new(
       &ent, &hd, NULL, 9, 0, NGTCP2_RTB_ENTRY_FLAG_NONE, &rtb_entry_objalloc);
@@ -89,7 +89,7 @@ void test_ngtcp2_rtb_add(void) {
   ngtcp2_rtb_add(&rtb, ent, &cstat);
 
   ngtcp2_pkt_hd_init(&hd, NGTCP2_PKT_FLAG_NONE, NGTCP2_PKT_SHORT, &dcid, NULL,
-                     1000000009, 4, NGTCP2_PROTO_VER_MAX, 0);
+                     1000000009, 4, NGTCP2_PROTO_VER_V1, 0);
 
   rv = ngtcp2_rtb_entry_objalloc_new(
       &ent, &hd, NULL, 11, 0, NGTCP2_RTB_ENTRY_FLAG_NONE, &rtb_entry_objalloc);
@@ -138,7 +138,7 @@ static void add_rtb_entry_range(ngtcp2_rtb *rtb, int64_t base_pkt_num,
 
   for (i = 0; i < len; ++i) {
     ngtcp2_pkt_hd_init(&hd, NGTCP2_PKT_FLAG_NONE, NGTCP2_PKT_SHORT, &dcid, NULL,
-                       base_pkt_num + (int64_t)i, 1, NGTCP2_PROTO_VER_MAX, 0);
+                       base_pkt_num + (int64_t)i, 1, NGTCP2_PROTO_VER_V1, 0);
     ngtcp2_rtb_entry_objalloc_new(&ent, &hd, NULL, 0, 0,
                                   NGTCP2_RTB_ENTRY_FLAG_NONE, objalloc);
     ngtcp2_rtb_add(rtb, ent, cstat);
@@ -189,7 +189,7 @@ void test_ngtcp2_rtb_recv_ack(void) {
                    mem);
   ngtcp2_log_init(&log, NULL, NULL, 0, NULL);
   ngtcp2_pkt_hd_init(&hd, NGTCP2_PKT_FLAG_NONE, NGTCP2_PKT_SHORT, NULL, NULL, 0,
-                     1, NGTCP2_PROTO_VER_MAX, 0);
+                     1, NGTCP2_PROTO_VER_V1, 0);
 
   /* no ack block */
   conn_stat_init(&cstat);


### PR DESCRIPTION
This commit adds compatible version negotiation and QUIC v2 support.
Now most ngtcp2 functions other than ngtcp2_pkt_decode_version_cid
require the supported QUIC version.  ngtcp2_accept now does not return
NGTCP2_ERR_VERSION_NEGOTIATION.  It should be handled by
ngtcp2_pkt_decode_version_cid.