### PR TITLE
Simple Path MTU Discovery

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,13 +8,13 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-10.15]
+        os: [ubuntu-20.04, macos-11]
         compiler: [gcc, clang]
         buildtool: [autotools, distcheck, cmake]
         openssl: [openssl1, openssl3]
         sockaddr: [native-sockaddr, generic-sockaddr]
         exclude:
-        - os: macos-10.15
+        - os: macos-11
           buildtool: distcheck
         - compiler: gcc
           buildtool: distcheck
@@ -28,9 +28,9 @@ jobs:
           sockaddr: generic-sockaddr
         - buildtool: cmake
           sockaddr: generic-sockaddr
-        - os: macos-10.15
+        - os: macos-11
           compiler: gcc
-        - os: macos-10.15
+        - os: macos-11
           openssl: openssl3
 
     steps:

--- a/doc/source/programmers-guide.rst
+++ b/doc/source/programmers-guide.rst
@@ -181,7 +181,8 @@ Read and write packets
 
 `ngtcp2_conn_read_pkt()` processes the incoming QUIC packets.  In
 order to write QUIC packets, call `ngtcp2_conn_writev_stream()` or
-`ngtcp2_conn_write_pkt()`.
+`ngtcp2_conn_write_pkt()`.  The *destlen* parameter must be at least
+the value returned from `ngtcp2_conn_get_max_udp_payload_size()`.
 
 In order to send stream data, the application has to first open a
 stream.  Use `ngtcp2_conn_open_bidi_stream()` to open bidirectional

--- a/examples/client.cc
+++ b/examples/client.cc
@@ -693,8 +693,8 @@ int Client::init(int fd, const Address &local_addr, const Address &remote_addr,
   settings.max_window = config.max_window;
   settings.max_stream_window = config.max_stream_window;
   settings.max_udp_payload_size = config.max_udp_payload_size;
-  settings.no_udp_payload_size_shaping = 1;
   settings.handshake_timeout = config.handshake_timeout;
+  settings.no_pmtud = config.no_pmtud;
 
   std::string token;
 
@@ -950,7 +950,7 @@ int Client::write_streams() {
   std::array<nghttp3_vec, 16> vec;
   ngtcp2_path_storage ps;
   size_t pktcnt = 0;
-  auto max_udp_payload_size = ngtcp2_conn_get_path_max_udp_payload_size(conn_);
+  auto max_udp_payload_size = ngtcp2_conn_get_max_udp_payload_size(conn_);
   size_t max_pktcnt =
       (config.cc_algo == NGTCP2_CC_ALGO_BBR ||
        config.cc_algo == NGTCP2_CC_ALGO_BBR2)
@@ -1200,6 +1200,8 @@ int udp_sock(int family) {
   }
 
   fd_set_recv_ecn(fd, family);
+  fd_set_ip_mtu_discover(fd, family);
+  fd_set_ip_dontfrag(fd, family);
 
   return fd;
 }
@@ -1463,6 +1465,9 @@ int Client::send_packet(const Endpoint &ep, const ngtcp2_addr &remote_addr,
       return NETWORK_ERR_SEND_BLOCKED;
     }
     std::cerr << "sendmsg: " << strerror(errno) << std::endl;
+    if (errno == EMSGSIZE) {
+      return 0;
+    }
     return NETWORK_ERR_FATAL;
   }
 
@@ -2402,6 +2407,7 @@ Options:
               Set the QUIC handshake timeout.
               Default: )"
             << util::format_duration(config.handshake_timeout) << R"(
+  --no-pmtud  Disables Path MTU Discovery.
   -h, --help  Display this help and exit.
 
 ---
@@ -2472,6 +2478,7 @@ int main(int argc, char **argv) {
         {"max-udp-payload-size", required_argument, &flag, 35},
         {"handshake-timeout", required_argument, &flag, 36},
         {"other-versions", required_argument, &flag, 37},
+        {"no-pmtud", no_argument, &flag, 38},
         {nullptr, 0, nullptr, 0},
     };
 
@@ -2814,6 +2821,10 @@ int main(int argc, char **argv) {
         }
         break;
       }
+      case 38:
+        // --no-pmtud
+        config.no_pmtud = true;
+        break;
       }
       break;
     default:

--- a/examples/client_base.h
+++ b/examples/client_base.h
@@ -172,6 +172,8 @@ struct Config {
   // other_versions includes QUIC versions that are sent in
   // other_versions field of version_information transport_parameter.
   std::vector<uint32_t> other_versions;
+  // no_pmtud disables Path MTU Discovery.
+  bool no_pmtud;
 };
 
 class ClientBase {

--- a/examples/server.cc
+++ b/examples/server.cc
@@ -1402,12 +1402,12 @@ int Handler::init(const Endpoint &ep, const Address &local_addr,
   settings.max_window = config.max_window;
   settings.max_stream_window = config.max_stream_window;
   settings.handshake_timeout = config.handshake_timeout;
+  settings.no_pmtud = config.no_pmtud;
   if (config.max_udp_payload_size) {
     settings.max_udp_payload_size = config.max_udp_payload_size;
     settings.no_udp_payload_size_shaping = 1;
   } else {
     settings.max_udp_payload_size = server_max_udp_payload_size;
-    settings.assume_symmetric_path = 1;
   }
   if (!config.qlog_dir.empty()) {
     auto path = std::string{config.qlog_dir};
@@ -1654,7 +1654,7 @@ int Handler::write_streams() {
   ngtcp2_path_storage ps, prev_ps;
   uint32_t prev_ecn = 0;
   size_t pktcnt = 0;
-  auto max_udp_payload_size = ngtcp2_conn_get_path_max_udp_payload_size(conn_);
+  auto max_udp_payload_size = ngtcp2_conn_get_max_udp_payload_size(conn_);
   size_t max_pktcnt =
       std::min(static_cast<size_t>(64_k), ngtcp2_conn_get_send_quantum(conn_)) /
       max_udp_payload_size;
@@ -2270,6 +2270,8 @@ int create_sock(Address &local_addr, const char *addr, const char *port,
     }
 
     fd_set_recv_ecn(fd, rp->ai_family);
+    fd_set_ip_mtu_discover(fd, rp->ai_family);
+    fd_set_ip_dontfrag(fd, family);
 
     if (bind(fd, rp->ai_addr, rp->ai_addrlen) != -1) {
       break;
@@ -2353,6 +2355,8 @@ int add_endpoint(std::vector<Endpoint> &endpoints, const Address &addr) {
   }
 
   fd_set_recv_ecn(fd, addr.su.sa.sa_family);
+  fd_set_ip_mtu_discover(fd, addr.su.sa.sa_family);
+  fd_set_ip_dontfrag(fd, addr.su.sa.sa_family);
 
   if (bind(fd, &addr.su.sa, addr.len) == -1) {
     std::cerr << "bind: " << strerror(errno) << std::endl;
@@ -3275,6 +3279,7 @@ Options:
               string,  there  are   special  aliases  available:  "v1"
               indicates  QUIC  v1,  and "v2draft"  indicates  QUIC  v2
               draft.
+  --no-pmtud  Disables Path MTU Discovery.
   -h, --help  Display this help and exit.
 
 ---
@@ -3333,6 +3338,7 @@ int main(int argc, char **argv) {
         {"handshake-timeout", required_argument, &flag, 26},
         {"preferred-versions", required_argument, &flag, 27},
         {"other-versions", required_argument, &flag, 28},
+        {"no-pmtud", no_argument, &flag, 29},
         {nullptr, 0, nullptr, 0}};
 
     auto optidx = 0;
@@ -3629,6 +3635,10 @@ int main(int argc, char **argv) {
         }
         break;
       }
+      case 29:
+        // --no-pmtud
+        config.no_pmtud = true;
+        break;
       }
       break;
     default:

--- a/examples/server_base.h
+++ b/examples/server_base.h
@@ -145,6 +145,8 @@ struct Config {
   // other_versions includes QUIC versions that are sent in
   // other_versions field of version_information transport_parameter.
   std::vector<uint32_t> other_versions;
+  // no_pmtud disables Path MTU Discovery.
+  bool no_pmtud;
 };
 
 struct Buffer {

--- a/examples/shared.cc
+++ b/examples/shared.cc
@@ -106,6 +106,53 @@ void fd_set_recv_ecn(int fd, int family) {
   }
 }
 
+void fd_set_ip_mtu_discover(int fd, int family) {
+#if defined(IP_MTU_DISCOVER) && defined(IPV6_MTU_DISCOVER)
+  int val;
+
+  switch (family) {
+  case AF_INET:
+    val = IP_PMTUDISC_DO;
+    if (setsockopt(fd, IPPROTO_IP, IP_MTU_DISCOVER, &val,
+                   static_cast<socklen_t>(sizeof(val))) == -1) {
+      std::cerr << "setsockopt: IP_MTU_DISCOVER: " << strerror(errno)
+                << std::endl;
+    }
+    break;
+  case AF_INET6:
+    val = IPV6_PMTUDISC_DO;
+    if (setsockopt(fd, IPPROTO_IPV6, IPV6_MTU_DISCOVER, &val,
+                   static_cast<socklen_t>(sizeof(val))) == -1) {
+      std::cerr << "setsockopt: IPV6_MTU_DISCOVER: " << strerror(errno)
+                << std::endl;
+    }
+    break;
+  }
+#endif // defined(IP_MTU_DISCOVER) && defined(IPV6_MTU_DISCOVER)
+}
+
+void fd_set_ip_dontfrag(int fd, int family) {
+#if defined(IP_DONTFRAG) && defined(IPV6_DONTFRAG)
+  int val = 1;
+
+  switch (family) {
+  case AF_INET:
+    if (setsockopt(fd, IPPROTO_IP, IP_DONTFRAG, &val,
+                   static_cast<socklen_t>(sizeof(val))) == -1) {
+      std::cerr << "setsockopt: IP_DONTFRAG: " << strerror(errno) << std::endl;
+    }
+    break;
+  case AF_INET6:
+    if (setsockopt(fd, IPPROTO_IPV6, IPV6_DONTFRAG, &val,
+                   static_cast<socklen_t>(sizeof(val))) == -1) {
+      std::cerr << "setsockopt: IPV6_DONTFRAG: " << strerror(errno)
+                << std::endl;
+    }
+    break;
+  }
+#endif // defined(IP_DONTFRAG) && defined(IPV6_DONTFRAG)
+}
+
 std::optional<Address> msghdr_get_local_addr(msghdr *msg, int family) {
   switch (family) {
   case AF_INET:

--- a/examples/shared.h
+++ b/examples/shared.h
@@ -74,6 +74,13 @@ void fd_set_ecn(int fd, int family, unsigned int ecn);
 // ECN bits.
 void fd_set_recv_ecn(int fd, int family);
 
+// fd_set_ip_mtu_discover sets IP(V6)_MTU_DISCOVER socket option to
+// |fd|.
+void fd_set_ip_mtu_discover(int fd, int family);
+
+// fd_set_ip_dontfrag sets IP(V6)_DONTFRAG socket option to |fd|.
+void fd_set_ip_dontfrag(int fd, int family);
+
 std::optional<Address> msghdr_get_local_addr(msghdr *msg, int family);
 
 void set_port(Address &dst, Address &src);

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -57,6 +57,7 @@ set(ngtcp2_SOURCES
   ngtcp2_addr.c
   ngtcp2_path.c
   ngtcp2_pv.c
+  ngtcp2_pmtud.c
   ngtcp2_version.c
   ngtcp2_rst.c
   ngtcp2_window_filter.c

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -65,6 +65,7 @@ OBJECTS = \
 	ngtcp2_addr.c \
 	ngtcp2_path.c \
 	ngtcp2_pv.c \
+	ngtcp2_pmtud.c \
 	ngtcp2_version.c \
 	ngtcp2_rst.c \
 	ngtcp2_window_filter.c \
@@ -103,6 +104,7 @@ HFILES = \
 	ngtcp2_addr.h \
 	ngtcp2_path.h \
 	ngtcp2_pv.h \
+	ngtcp2_pmtud.h \
 	ngtcp2_macro.h \
 	ngtcp2_rst.h \
 	ngtcp2_window_filter.h \

--- a/lib/ngtcp2_conn.h
+++ b/lib/ngtcp2_conn.h
@@ -45,6 +45,7 @@
 #include "ngtcp2_bbr.h"
 #include "ngtcp2_bbr2.h"
 #include "ngtcp2_pv.h"
+#include "ngtcp2_pmtud.h"
 #include "ngtcp2_cid.h"
 #include "ngtcp2_buf.h"
 #include "ngtcp2_ppe.h"
@@ -661,6 +662,7 @@ struct ngtcp2_conn {
   ngtcp2_map strms;
   ngtcp2_conn_stat cstat;
   ngtcp2_pv *pv;
+  ngtcp2_pmtud *pmtud;
   ngtcp2_log log;
   ngtcp2_qlog qlog;
   ngtcp2_rst rst;
@@ -1060,5 +1062,7 @@ ngtcp2_ssize ngtcp2_conn_write_application_close_pkt(
     ngtcp2_conn *conn, ngtcp2_path *path, ngtcp2_pkt_info *pi, uint8_t *dest,
     size_t destlen, uint64_t app_error_code, const uint8_t *reason,
     size_t reasonlen, ngtcp2_tstamp ts);
+
+void ngtcp2_conn_stop_pmtud(ngtcp2_conn *conn);
 
 #endif /* NGTCP2_CONN_H */

--- a/lib/ngtcp2_pmtud.c
+++ b/lib/ngtcp2_pmtud.c
@@ -1,0 +1,153 @@
+/*
+ * ngtcp2
+ *
+ * Copyright (c) 2022 ngtcp2 contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+#include "ngtcp2_pmtud.h"
+
+#include <assert.h>
+
+#include "ngtcp2_mem.h"
+#include "ngtcp2_macro.h"
+
+/* NGTCP2_PMTUD_PROBE_NUM_MAX is the maximum number of packets sent
+   for each probe. */
+#define NGTCP2_PMTUD_PROBE_NUM_MAX 3
+
+static size_t mtu_probes[] = {
+    1454 - 48, /* The well known MTU used by a domestic optic fiber
+                  service in Japan. */
+    1280 - 48, /* IPv6 minimum MTU */
+    1500 - 48, /* Standard Ethernet MTU */
+};
+
+static size_t mtu_probeslen = sizeof(mtu_probes) / sizeof(mtu_probes[0]);
+
+int ngtcp2_pmtud_new(ngtcp2_pmtud **ppmtud, size_t max_udp_payload_size,
+                     int64_t tx_pkt_num, const ngtcp2_mem *mem) {
+  ngtcp2_pmtud *pmtud = ngtcp2_mem_malloc(mem, sizeof(ngtcp2_pmtud));
+
+  if (pmtud == NULL) {
+    return NGTCP2_ERR_NOMEM;
+  }
+
+  pmtud->mem = mem;
+  pmtud->mtu_idx = 0;
+  pmtud->num_pkts_sent = 0;
+  pmtud->expiry = UINT64_MAX;
+  pmtud->tx_pkt_num = tx_pkt_num;
+  pmtud->max_udp_payload_size = max_udp_payload_size;
+  pmtud->min_fail_udp_payload_size = SIZE_MAX;
+
+  for (; pmtud->mtu_idx < mtu_probeslen; ++pmtud->mtu_idx) {
+    if (mtu_probes[pmtud->mtu_idx] > pmtud->max_udp_payload_size) {
+      break;
+    }
+  }
+
+  *ppmtud = pmtud;
+
+  return 0;
+}
+
+void ngtcp2_pmtud_del(ngtcp2_pmtud *pmtud) {
+  if (!pmtud) {
+    return;
+  }
+
+  ngtcp2_mem_free(pmtud->mem, pmtud);
+}
+
+size_t ngtcp2_pmtud_probelen(ngtcp2_pmtud *pmtud) {
+  assert(pmtud->mtu_idx < mtu_probeslen);
+
+  return mtu_probes[pmtud->mtu_idx];
+}
+
+void ngtcp2_pmtud_probe_sent(ngtcp2_pmtud *pmtud, ngtcp2_duration pto,
+                             ngtcp2_tstamp ts) {
+  ngtcp2_tstamp timeout;
+
+  if (++pmtud->num_pkts_sent < NGTCP2_PMTUD_PROBE_NUM_MAX) {
+    timeout = pto;
+  } else {
+    timeout = 3 * pto;
+  }
+
+  pmtud->expiry = ts + timeout;
+}
+
+int ngtcp2_pmtud_require_probe(ngtcp2_pmtud *pmtud) {
+  return pmtud->expiry == UINT64_MAX;
+}
+
+static void pmtud_next_probe(ngtcp2_pmtud *pmtud) {
+  assert(pmtud->mtu_idx < mtu_probeslen);
+
+  ++pmtud->mtu_idx;
+  pmtud->num_pkts_sent = 0;
+  pmtud->expiry = UINT64_MAX;
+
+  for (; pmtud->mtu_idx < mtu_probeslen; ++pmtud->mtu_idx) {
+    if (mtu_probes[pmtud->mtu_idx] <= pmtud->max_udp_payload_size) {
+      continue;
+    }
+
+    if (mtu_probes[pmtud->mtu_idx] < pmtud->min_fail_udp_payload_size) {
+      break;
+    }
+  }
+}
+
+void ngtcp2_pmtud_probe_success(ngtcp2_pmtud *pmtud, size_t payloadlen) {
+  pmtud->max_udp_payload_size =
+      ngtcp2_max(pmtud->max_udp_payload_size, payloadlen);
+
+  assert(pmtud->mtu_idx < mtu_probeslen);
+
+  if (mtu_probes[pmtud->mtu_idx] > pmtud->max_udp_payload_size) {
+    return;
+  }
+
+  pmtud_next_probe(pmtud);
+}
+
+void ngtcp2_pmtud_handle_expiry(ngtcp2_pmtud *pmtud, ngtcp2_tstamp ts) {
+  if (ts < pmtud->expiry) {
+    return;
+  }
+
+  pmtud->expiry = UINT64_MAX;
+
+  if (pmtud->num_pkts_sent < NGTCP2_PMTUD_PROBE_NUM_MAX) {
+    return;
+  }
+
+  pmtud->min_fail_udp_payload_size =
+      ngtcp2_min(pmtud->min_fail_udp_payload_size, mtu_probes[pmtud->mtu_idx]);
+
+  pmtud_next_probe(pmtud);
+}
+
+int ngtcp2_pmtud_finished(ngtcp2_pmtud *pmtud) {
+  return pmtud->mtu_idx >= mtu_probeslen;
+}

--- a/lib/ngtcp2_pmtud.h
+++ b/lib/ngtcp2_pmtud.h
@@ -1,0 +1,119 @@
+/*
+ * ngtcp2
+ *
+ * Copyright (c) 2022 ngtcp2 contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+#ifndef NGTCP2_PMTUD_H
+#define NGTCP2_PMTUD_H
+
+#ifdef HAVE_CONFIG_H
+#  include <config.h>
+#endif /* HAVE_CONFIG_H */
+
+#include <ngtcp2/ngtcp2.h>
+
+typedef struct ngtcp2_pmtud {
+  const ngtcp2_mem *mem;
+  /* mtu_idx is the index of UDP payload size candidates to try
+     out. */
+  size_t mtu_idx;
+  /* num_pkts_sent is the number of mtu_idx sized UDP datagram payload
+     sent */
+  size_t num_pkts_sent;
+  /* expiry is the expired, if it is reached, send out the next UDP
+     datagram.  UINT64_MAX means no expiry, or expiration is canceled.
+     In either case, new probe packet should be sent unless we have
+     done all attempts. */
+  ngtcp2_tstamp expiry;
+  /* tx_pkt_num is the smallest outgoing packet number where the
+     current discovery is performed.  In other words, acknowledging
+     packet whose packet number lower than that does not indicate the
+     success of Path MTU Discovery. */
+  int64_t tx_pkt_num;
+  /* max_udp_payload_size is the maximum UDP payload size which is
+     known to work. */
+  size_t max_udp_payload_size;
+  /* min_fail_udp_payload_size is the minimum UDP payload size that is
+     known to fail. */
+  size_t min_fail_udp_payload_size;
+} ngtcp2_pmtud;
+
+/*
+ * ngtcp2_pmtud_new creates new ngtcp2_pmtud object, and assigns its
+ * pointer to |*ppmtud|.  |max_udp_payload_size| is the maximum UDP
+ * payload size that is known to work for the current path.
+ * |tx_pkt_num| should be the next packet number to send, which is
+ * used to differentiate the PMTUD probe packet sent by the previous
+ * PMTUD.  PMTUD might finish immediately if |max_udp_payload_size| is
+ * larger than or equal to all UDP payload probe candidates.
+ * Therefore, call ngtcp2_pmtud_finished to check this situation.
+ *
+ * This function returns 0 if it succeeds, or one of the following
+ * negative error codes:
+ *
+ * NGTCP2_ERR_NOMEM
+ *     Out of memory.
+ */
+int ngtcp2_pmtud_new(ngtcp2_pmtud **ppmtud, size_t max_udp_payload_size,
+                     int64_t tx_pkt_num, const ngtcp2_mem *mem);
+
+/*
+ * ngtcp2_pmtud_del deletes |pmtud|.
+ */
+void ngtcp2_pmtud_del(ngtcp2_pmtud *pmtud);
+
+/*
+ * ngtcp2_pmtud_probelen returns the length of UDP payload size for a
+ * PMTUD probe packet.
+ */
+size_t ngtcp2_pmtud_probelen(ngtcp2_pmtud *pmtud);
+
+/*
+ * ngtcp2_pmtud_probe_sent should be invoked when a PMTUD probe packet is
+ * sent.
+ */
+void ngtcp2_pmtud_probe_sent(ngtcp2_pmtud *pmtud, ngtcp2_duration pto,
+                             ngtcp2_tstamp ts);
+
+/*
+ * ngtcp2_pmtud_require_probe returns nonzero if a PMTUD probe packet
+ * should be sent.
+ */
+int ngtcp2_pmtud_require_probe(ngtcp2_pmtud *pmtud);
+
+/*
+ * ngtcp2_pmtud_probe_success should be invoked when a PMTUD probe
+ * UDP datagram sized |payloadlen| is acknowledged.
+ */
+void ngtcp2_pmtud_probe_success(ngtcp2_pmtud *pmtud, size_t payloadlen);
+
+/*
+ * ngtcp2_pmtud_handle_expiry handles expiry.
+ */
+void ngtcp2_pmtud_handle_expiry(ngtcp2_pmtud *pmtud, ngtcp2_tstamp ts);
+
+/*
+ * ngtcp2_pmtud_finished returns nonzero if PMTUD has finished.
+ */
+int ngtcp2_pmtud_finished(ngtcp2_pmtud *pmtud);
+
+#endif /* NGTCP2_PMTUD_H */

--- a/lib/ngtcp2_rtb.h
+++ b/lib/ngtcp2_rtb.h
@@ -221,6 +221,9 @@ void ngtcp2_frame_chain_list_objalloc_del(ngtcp2_frame_chain *frc,
 /* NGTCP2_RTB_ENTRY_FLAG_DATAGRAM indicates that the entry includes
    DATAGRAM frame. */
 #define NGTCP2_RTB_ENTRY_FLAG_DATAGRAM 0x40
+/* NGTCP2_RTB_ENTRY_FLAG_PMTUD_PROBE indicates that the entry includes
+   a PMTUD probe packet. */
+#define NGTCP2_RTB_ENTRY_FLAG_PMTUD_PROBE 0x80
 
 typedef struct ngtcp2_rtb_entry ngtcp2_rtb_entry;
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -49,6 +49,7 @@ if(HAVE_CUNIT)
     ngtcp2_vec_test.c
     ngtcp2_strm_test.c
     ngtcp2_pv_test.c
+    ngtcp2_pmtud_test.c
     ngtcp2_str_test.c
   )
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -45,6 +45,7 @@ OBJECTS = \
 	ngtcp2_vec_test.c \
 	ngtcp2_strm_test.c \
 	ngtcp2_pv_test.c \
+	ngtcp2_pmtud_test.c \
 	ngtcp2_str_test.c \
 	ngtcp2_test_helper.c
 HFILES= \
@@ -64,6 +65,7 @@ HFILES= \
 	ngtcp2_vec_test.h \
 	ngtcp2_strm_test.h \
 	ngtcp2_pv_test.h \
+	ngtcp2_pmtud_test.h \
 	ngtcp2_str_test.h \
 	ngtcp2_test_helper.h
 

--- a/tests/main.c
+++ b/tests/main.c
@@ -47,6 +47,7 @@
 #include "ngtcp2_vec_test.h"
 #include "ngtcp2_strm_test.h"
 #include "ngtcp2_pv_test.h"
+#include "ngtcp2_pmtud_test.h"
 #include "ngtcp2_str_test.h"
 
 static int init_suite1(void) { return 0; }
@@ -320,6 +321,7 @@ int main(void) {
                    test_ngtcp2_strm_streamfrq_unacked_pop) ||
       !CU_add_test(pSuite, "pv_add_entry", test_ngtcp2_pv_add_entry) ||
       !CU_add_test(pSuite, "pv_validate", test_ngtcp2_pv_validate) ||
+      !CU_add_test(pSuite, "pmtud_probe", test_ngtcp2_pmtud_probe) ||
       !CU_add_test(pSuite, "encode_ipv4", test_ngtcp2_encode_ipv4) ||
       !CU_add_test(pSuite, "encode_ipv6", test_ngtcp2_encode_ipv6)) {
     CU_cleanup_registry();

--- a/tests/ngtcp2_conn_test.c
+++ b/tests/ngtcp2_conn_test.c
@@ -677,6 +677,8 @@ static void setup_default_server(ngtcp2_conn **pconn) {
   remote_params->initial_max_streams_uni = 1;
   remote_params->initial_max_data = 64 * 1024;
   remote_params->active_connection_id_limit = 8;
+  remote_params->max_udp_payload_size =
+      NGTCP2_DEFAULT_MAX_RECV_UDP_PAYLOAD_SIZE;
   (*pconn)->local.bidi.max_streams = remote_params->initial_max_streams_bidi;
   (*pconn)->local.uni.max_streams = remote_params->initial_max_streams_uni;
   (*pconn)->tx.max_offset = remote_params->initial_max_data;
@@ -729,6 +731,8 @@ static void setup_default_client(ngtcp2_conn **pconn) {
   remote_params->initial_max_streams_uni = 1;
   remote_params->initial_max_data = 64 * 1024;
   remote_params->active_connection_id_limit = 8;
+  remote_params->max_udp_payload_size =
+      NGTCP2_DEFAULT_MAX_RECV_UDP_PAYLOAD_SIZE;
   (*pconn)->local.bidi.max_streams = remote_params->initial_max_streams_bidi;
   (*pconn)->local.uni.max_streams = remote_params->initial_max_streams_uni;
   (*pconn)->tx.max_offset = remote_params->initial_max_data;
@@ -849,6 +853,7 @@ static void setup_early_client(ngtcp2_conn **pconn) {
   params.initial_max_streams_uni = 1;
   params.initial_max_data = 64 * 1024;
   params.active_connection_id_limit = 8;
+  params.max_udp_payload_size = NGTCP2_DEFAULT_MAX_RECV_UDP_PAYLOAD_SIZE;
 
   ngtcp2_conn_set_early_remote_transport_params(*pconn, &params);
 }

--- a/tests/ngtcp2_pmtud_test.c
+++ b/tests/ngtcp2_pmtud_test.c
@@ -1,0 +1,123 @@
+/*
+ * ngtcp2
+ *
+ * Copyright (c) 2022 ngtcp2 contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+#include "ngtcp2_pmtud_test.h"
+
+#include <CUnit/CUnit.h>
+
+#include "ngtcp2_pmtud.h"
+#include "ngtcp2_test_helper.h"
+
+void test_ngtcp2_pmtud_probe(void) {
+  const ngtcp2_mem *mem = ngtcp2_mem_default();
+  ngtcp2_pmtud *pmtud;
+  int rv;
+
+  /* Send probe and get success */
+  rv = ngtcp2_pmtud_new(&pmtud, NGTCP2_MAX_UDP_PAYLOAD_SIZE, 0, mem);
+
+  CU_ASSERT(0 == rv);
+  CU_ASSERT(0 == pmtud->mtu_idx);
+  CU_ASSERT(!ngtcp2_pmtud_finished(pmtud));
+  CU_ASSERT(ngtcp2_pmtud_require_probe(pmtud));
+  CU_ASSERT(1454 - 48 == ngtcp2_pmtud_probelen(pmtud));
+
+  ngtcp2_pmtud_probe_sent(pmtud, 2, 0);
+
+  CU_ASSERT(1 == pmtud->num_pkts_sent);
+  CU_ASSERT(2 == pmtud->expiry);
+  CU_ASSERT(!ngtcp2_pmtud_require_probe(pmtud));
+
+  ngtcp2_pmtud_handle_expiry(pmtud, 1);
+
+  CU_ASSERT(!ngtcp2_pmtud_require_probe(pmtud));
+
+  ngtcp2_pmtud_handle_expiry(pmtud, 2);
+
+  CU_ASSERT(ngtcp2_pmtud_require_probe(pmtud));
+
+  ngtcp2_pmtud_probe_sent(pmtud, 2, 2);
+
+  CU_ASSERT(2 == pmtud->num_pkts_sent);
+  CU_ASSERT(4 == pmtud->expiry);
+  CU_ASSERT(!ngtcp2_pmtud_require_probe(pmtud));
+
+  ngtcp2_pmtud_handle_expiry(pmtud, 4);
+
+  CU_ASSERT(ngtcp2_pmtud_require_probe(pmtud));
+
+  ngtcp2_pmtud_probe_sent(pmtud, 2, 4);
+
+  CU_ASSERT(3 == pmtud->num_pkts_sent);
+  CU_ASSERT(10 == pmtud->expiry);
+  CU_ASSERT(!ngtcp2_pmtud_require_probe(pmtud));
+
+  ngtcp2_pmtud_probe_success(pmtud, ngtcp2_pmtud_probelen(pmtud));
+
+  CU_ASSERT(2 == pmtud->mtu_idx);
+  CU_ASSERT(UINT64_MAX == pmtud->expiry);
+  CU_ASSERT(0 == pmtud->num_pkts_sent);
+  CU_ASSERT(ngtcp2_pmtud_require_probe(pmtud));
+  CU_ASSERT(1500 - 48 == ngtcp2_pmtud_probelen(pmtud));
+
+  ngtcp2_pmtud_probe_sent(pmtud, 2, 10);
+  ngtcp2_pmtud_handle_expiry(pmtud, 12);
+  ngtcp2_pmtud_probe_sent(pmtud, 2, 12);
+  ngtcp2_pmtud_handle_expiry(pmtud, 14);
+  ngtcp2_pmtud_probe_sent(pmtud, 2, 14);
+  ngtcp2_pmtud_handle_expiry(pmtud, 20);
+
+  CU_ASSERT(1500 - 48 == pmtud->min_fail_udp_payload_size);
+  CU_ASSERT(ngtcp2_pmtud_finished(pmtud));
+
+  ngtcp2_pmtud_del(pmtud);
+
+  /* Failing first probe should skip the third probe */
+  rv = ngtcp2_pmtud_new(&pmtud, NGTCP2_MAX_UDP_PAYLOAD_SIZE, 0, mem);
+
+  ngtcp2_pmtud_probe_sent(pmtud, 2, 0);
+  ngtcp2_pmtud_handle_expiry(pmtud, 2);
+  ngtcp2_pmtud_probe_sent(pmtud, 2, 2);
+  ngtcp2_pmtud_handle_expiry(pmtud, 4);
+  ngtcp2_pmtud_probe_sent(pmtud, 2, 4);
+  ngtcp2_pmtud_handle_expiry(pmtud, 10);
+
+  CU_ASSERT(1454 - 48 == pmtud->min_fail_udp_payload_size);
+  CU_ASSERT(1 == pmtud->mtu_idx);
+
+  ngtcp2_pmtud_probe_sent(pmtud, 2, 10);
+  ngtcp2_pmtud_probe_success(pmtud, 1280 - 48);
+
+  CU_ASSERT(ngtcp2_pmtud_finished(pmtud));
+
+  ngtcp2_pmtud_del(pmtud);
+
+  /* PMTUD finishes immediately */
+  rv = ngtcp2_pmtud_new(&pmtud, 1500 - 48, 0, mem);
+
+  CU_ASSERT(0 == rv);
+  CU_ASSERT(ngtcp2_pmtud_finished(pmtud));
+
+  ngtcp2_pmtud_del(pmtud);
+}

--- a/tests/ngtcp2_pmtud_test.h
+++ b/tests/ngtcp2_pmtud_test.h
@@ -1,8 +1,7 @@
 /*
  * ngtcp2
  *
- * Copyright (c) 2017 ngtcp2 contributors
- * Copyright (c) 2016 nghttp2 contributors
+ * Copyright (c) 2022 ngtcp2 contributors
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the
@@ -23,61 +22,13 @@
  * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-#ifndef NETWORK_H
-#define NETWORK_H
+#ifndef NGTCP2_PMTUD_TEST_H
+#define NGTCP2_PMTUD_TEST_H
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif // HAVE_CONFIG_H
+#endif /* HAVE_CONFIG_H */
 
-#include <sys/types.h>
-#ifdef HAVE_SYS_SOCKET_H
-#  include <sys/socket.h>
-#endif // HAVE_SYS_SOCKET_H
-#include <sys/un.h>
-#ifdef HAVE_NETINET_IN_H
-#  include <netinet/in.h>
-#endif // HAVE_NETINET_IN_H
-#ifdef HAVE_ARPA_INET_H
-#  include <arpa/inet.h>
-#endif // HAVE_ARPA_INET_H
+void test_ngtcp2_pmtud_probe(void);
 
-#include <array>
-
-#include <ngtcp2/ngtcp2.h>
-
-namespace ngtcp2 {
-
-constexpr size_t server_max_udp_payload_size = 1472;
-constexpr size_t client_max_udp_payload_size = 1472;
-
-enum network_error {
-  NETWORK_ERR_OK = 0,
-  NETWORK_ERR_FATAL = -10,
-  NETWORK_ERR_SEND_BLOCKED = -11,
-  NETWORK_ERR_CLOSE_WAIT = -12,
-  NETWORK_ERR_RETRY = -13,
-  NETWORK_ERR_DROP_CONN = -14,
-};
-
-union in_addr_union {
-  in_addr in;
-  in6_addr in6;
-};
-
-union sockaddr_union {
-  sockaddr_storage storage;
-  sockaddr sa;
-  sockaddr_in6 in6;
-  sockaddr_in in;
-};
-
-struct Address {
-  socklen_t len;
-  union sockaddr_union su;
-  uint32_t ifindex;
-};
-
-} // namespace ngtcp2
-
-#endif // NETWORK_H
+#endif /* NGTCP2_PMTUD_TEST_H */


### PR DESCRIPTION
This adds simple Path MTU Discovery mechanism, which probes predefined
size of path MTU.  ngtcp2_settings.assume_symmetric_path is removed in
favor of Path MTU Discovery.  This commits also other datagram size
enforcements and fixes like limiting a packet containing
PATH_CHALLENGE/PATH_RESPONSE frames to unvalidated path to 1200.
ngtcp2_conn_get_path_max_udp_payload_size is replaced with
ngtcp2_conn_get_max_udp_payload_size because it is unknown in advance
that ngtcp2_conn_writev_* writes to which path.