### PR TITLE
Limit PMTUD probe size to ngtcp2_settings.max_udp_payload_size

### DIFF
--- a/lib/includes/ngtcp2/ngtcp2.h
+++ b/lib/includes/ngtcp2/ngtcp2.h
@@ -5251,8 +5251,7 @@ NGTCP2_EXTERN void ngtcp2_path_storage_zero(ngtcp2_path_storage *ps);
  *   :macro:`NGTCP2_DEFAULT_INITIAL_RTT`
  * * :type:`ack_thresh <ngtcp2_settings.ack_thresh>` = 2
  * * :type:`max_udp_payload_size
- *   <ngtcp2_settings.max_udp_payload_size>` =
- *   :macro:`NGTCP2_MAX_UDP_PAYLOAD_SIZE`
+ *   <ngtcp2_settings.max_udp_payload_size>` = 1452
  * * :type:`handshake_timeout <ngtcp2_settings.handshake_timeout>` =
  *   :macro:`NGTCP2_DEFAULT_HANDSHAKE_TIMEOUT`.
  */

--- a/lib/ngtcp2_conn.c
+++ b/lib/ngtcp2_conn.c
@@ -4501,6 +4501,7 @@ static int conn_start_pmtud(ngtcp2_conn *conn) {
   assert(conn_is_handshake_completed(conn));
 
   rv = ngtcp2_pmtud_new(&conn->pmtud, conn->dcid.current.max_udp_payload_size,
+                        conn->local.settings.max_udp_payload_size,
                         conn->pktns.tx.last_pkt_num + 1, conn->mem);
   if (rv != 0) {
     return rv;
@@ -12953,7 +12954,7 @@ void ngtcp2_settings_default_versioned(int settings_version,
   settings->cc_algo = NGTCP2_CC_ALGO_CUBIC;
   settings->initial_rtt = NGTCP2_DEFAULT_INITIAL_RTT;
   settings->ack_thresh = 2;
-  settings->max_udp_payload_size = NGTCP2_MAX_UDP_PAYLOAD_SIZE;
+  settings->max_udp_payload_size = 1500 - 48;
   settings->handshake_timeout = NGTCP2_DEFAULT_HANDSHAKE_TIMEOUT;
 }
 

--- a/lib/ngtcp2_pmtud.h
+++ b/lib/ngtcp2_pmtud.h
@@ -52,6 +52,9 @@ typedef struct ngtcp2_pmtud {
   /* max_udp_payload_size is the maximum UDP payload size which is
      known to work. */
   size_t max_udp_payload_size;
+  /* hard_max_udp_payload_size is the maximum UDP payload size that is
+     going to be probed. */
+  size_t hard_max_udp_payload_size;
   /* min_fail_udp_payload_size is the minimum UDP payload size that is
      known to fail. */
   size_t min_fail_udp_payload_size;
@@ -74,7 +77,8 @@ typedef struct ngtcp2_pmtud {
  *     Out of memory.
  */
 int ngtcp2_pmtud_new(ngtcp2_pmtud **ppmtud, size_t max_udp_payload_size,
-                     int64_t tx_pkt_num, const ngtcp2_mem *mem);
+                     size_t hard_max_udp_payload_size, int64_t tx_pkt_num,
+                     const ngtcp2_mem *mem);
 
 /*
  * ngtcp2_pmtud_del deletes |pmtud|.


### PR DESCRIPTION
Limit PMTUD probe size to ngtcp2_settings.max_udp_payload_size.  To
make PMTUD work with the default value, set 1452 to
ngtcp2_settings.max_udp_payload_size.  max_udp_payload_size per path
is still limited to 1200.