### PR TITLE
Unified timer

### DIFF
--- a/doc/source/programmers-guide.rst
+++ b/doc/source/programmers-guide.rst
@@ -251,9 +251,9 @@ endpoint and no longer used by the library.
 Timers
 ------
 
-The library does not ask an operating system any timestamp.  Instead,
-an application has to supply timestamp to the library.  The type of
-timestamp in ngtcp2 library is :type:`ngtcp2_tstamp` which is
+The library does not ask an operating system for any timestamp.
+Instead, an application has to supply timestamp to the library.  The
+type of timestamp in ngtcp2 library is :type:`ngtcp2_tstamp` which is
 nanosecond resolution.  The library only cares the difference of
 timestamp, so it does not have to be a system clock.  A monotonic
 clock should work better.  It should be same clock passed to
@@ -265,11 +265,6 @@ When timer fires, call `ngtcp2_conn_handle_expiry()` and
 
 After calling these functions, new expiry will be set.  The
 application should call `ngtcp2_conn_get_expiry()` to restart timer.
-
-Application also handles connection idle timeout.
-`ngtcp2_conn_get_idle_expiry()` returns the current idle expiry.  If
-idle timer is expired, the connection should be closed without calling
-`ngtcp2_conn_write_connection_close()`.
 
 Connection migration
 --------------------
@@ -284,21 +279,21 @@ Closing connection
 ------------------
 
 In order to close QUIC connection, call
-`ngtcp2_conn_write_connection_close()` or
-`ngtcp2_conn_write_application_close()`.
+`ngtcp2_conn_write_connection_close()`.
 
 Error handling in general
 -------------------------
 
 In general, when error is returned from the ngtcp2 library function,
-call `ngtcp2_conn_write_connection_close()` or
-`ngtcp2_conn_write_application_close()` to get terminal packet.
+call `ngtcp2_conn_write_connection_close()` to get terminal packet.
 Sending it finishes QUIC connection.
 
 If :macro:`NGTCP2_ERR_DROP_CONN` is returned from
 `ngtcp2_conn_read_pkt`, a connection should be dropped without calling
-`ngtcp2_conn_write_connection_close()` or
-`ngtcp2_conn_write_application_close()`.
+`ngtcp2_conn_write_connection_close()`.  Similarly, if
+:macro:`NGTCP2_ERR_IDLE_CLOSE` is returned from
+`ngtcp2_conn_handle_expiry`, a connection should be dropped without
+calling `ngtcp2_conn_write_connection_close()`.
 
 The following error codes must be considered as transitional, and
 application should keep connection alive:

--- a/examples/client.h
+++ b/examples/client.h
@@ -86,7 +86,7 @@ public:
   int feed_data(const Endpoint &ep, const sockaddr *sa, socklen_t salen,
                 const ngtcp2_pkt_info *pi, uint8_t *data, size_t datalen);
   int handle_expiry();
-  void schedule_retransmit();
+  void update_timer();
   int handshake_completed();
   int handshake_confirmed();
 
@@ -127,10 +127,6 @@ public:
   int stop_sending(int64_t stream_id, uint64_t app_error_code);
   int http_stream_close(int64_t stream_id, uint64_t app_error_code);
 
-  void reset_idle_timer();
-
-  void idle_timeout();
-
   void on_send_blocked(const Endpoint &ep, const ngtcp2_addr &remote_addr,
                        unsigned int ecn, size_t datalen);
   void start_wev_endpoint(const Endpoint &ep);
@@ -141,7 +137,6 @@ private:
   Address remote_addr_;
   ev_io wev_;
   ev_timer timer_;
-  ev_timer rttimer_;
   ev_timer change_local_addr_timer_;
   ev_timer key_update_timer_;
   ev_timer delay_stream_timer_;

--- a/examples/gtlssimpleclient.c
+++ b/examples/gtlssimpleclient.c
@@ -149,7 +149,6 @@ struct client {
 
   ev_io rev;
   ev_timer timer;
-  ev_timer idle_timer;
 };
 
 static int hook_func(gnutls_session_t session, unsigned int htype,
@@ -525,16 +524,6 @@ static int client_quic_init(struct client *c,
   return 0;
 }
 
-static void client_reset_idle_timer(struct client *c) {
-  ngtcp2_tstamp expiry = ngtcp2_conn_get_idle_expiry(c->conn);
-  ngtcp2_tstamp now = timestamp();
-
-  c->idle_timer.repeat =
-      expiry < now ? 1e-9 : (ev_tstamp)(expiry - now) / NGTCP2_SECONDS;
-
-  ev_timer_again(EV_DEFAULT, &c->idle_timer);
-}
-
 static int client_read(struct client *c) {
   uint8_t buf[65536];
   struct sockaddr_storage addr;
@@ -589,8 +578,6 @@ static int client_read(struct client *c) {
       return -1;
     }
   }
-
-  client_reset_idle_timer(c);
 
   return 0;
 }
@@ -693,8 +680,6 @@ static int client_write_streams(struct client *c) {
     }
   }
 
-  client_reset_idle_timer(c);
-
   return 0;
 }
 
@@ -733,7 +718,8 @@ static void client_close(struct client *c) {
   ngtcp2_path_storage ps;
   uint8_t buf[1280];
 
-  if (ngtcp2_conn_is_in_closing_period(c->conn) || !c->last_error.error_code) {
+  if (ngtcp2_conn_is_in_closing_period(c->conn) ||
+      ngtcp2_conn_is_in_draining_period(c->conn)) {
     goto fin;
   }
 
@@ -783,16 +769,6 @@ static void timer_cb(struct ev_loop *loop, ev_timer *w, int revents) {
   }
 }
 
-static void idle_timer_cb(struct ev_loop *loop, ev_timer *w, int revents) {
-  (void)loop;
-  (void)w;
-  (void)revents;
-
-  fprintf(stderr, "idle timeout\n");
-
-  ev_break(EV_DEFAULT, EVBREAK_ALL);
-}
-
 static int client_init(struct client *c) {
   struct sockaddr_storage remote_addr, local_addr;
   socklen_t remote_addrlen, local_addrlen = sizeof(local_addr);
@@ -832,10 +808,6 @@ static int client_init(struct client *c) {
 
   ev_timer_init(&c->timer, timer_cb, 0., 0.);
   c->timer.data = c;
-
-  ev_timer_init(&c->idle_timer, idle_timer_cb, 0., 30.);
-  c->idle_timer.data = c;
-  ev_timer_again(EV_DEFAULT, &c->timer);
 
   return 0;
 }

--- a/examples/h09client.cc
+++ b/examples/h09client.cc
@@ -122,24 +122,6 @@ void readcb(struct ev_loop *loop, ev_io *w, int revents) {
 
 namespace {
 void timeoutcb(struct ev_loop *loop, ev_timer *w, int revents) {
-  auto c = static_cast<Client *>(w->data);
-
-  if (!config.quiet) {
-    std::cerr << "Timeout" << std::endl;
-  }
-
-  c->idle_timeout();
-}
-} // namespace
-
-void Client::idle_timeout() {
-  ngtcp2_connection_close_error_set_transport_error_idle_close(&last_error_,
-                                                               nullptr, 0);
-  disconnect();
-}
-
-namespace {
-void retransmitcb(struct ev_loop *loop, ev_timer *w, int revents) {
   int rv;
   auto c = static_cast<Client *>(w->data);
 
@@ -201,11 +183,8 @@ Client::Client(struct ev_loop *loop)
       tx_{} {
   ev_io_init(&wev_, writecb, 0, EV_WRITE);
   wev_.data = this;
-  ev_timer_init(&timer_, timeoutcb, 0.,
-                static_cast<double>(config.timeout) / NGTCP2_SECONDS);
+  ev_timer_init(&timer_, timeoutcb, 0., 0.);
   timer_.data = this;
-  ev_timer_init(&rttimer_, retransmitcb, 0., 0.);
-  rttimer_.data = this;
   ev_timer_init(&change_local_addr_timer_, change_local_addrcb,
                 static_cast<double>(config.change_local_addr) / NGTCP2_SECONDS,
                 0.);
@@ -231,7 +210,6 @@ void Client::disconnect() {
   ev_timer_stop(loop_, &delay_stream_timer_);
   ev_timer_stop(loop_, &key_update_timer_);
   ev_timer_stop(loop_, &change_local_addr_timer_);
-  ev_timer_stop(loop_, &rttimer_);
   ev_timer_stop(loop_, &timer_);
 
   ev_io_stop(loop_, &wev_);
@@ -725,7 +703,6 @@ int Client::init(int fd, const Address &local_addr, const Address &remote_addr,
   }
 
   ev_io_start(loop_, &ep.rev);
-  ev_timer_again(loop_, &timer_);
 
   ev_signal_start(loop_, &sigintev_);
 
@@ -840,25 +817,9 @@ int Client::on_read(const Endpoint &ep) {
     return -1;
   }
 
-  reset_idle_timer();
+  update_timer();
 
   return 0;
-}
-
-void Client::reset_idle_timer() {
-  auto now = util::timestamp(loop_);
-  auto idle_expiry = ngtcp2_conn_get_idle_expiry(conn_);
-  timer_.repeat =
-      idle_expiry > now
-          ? static_cast<ev_tstamp>(idle_expiry - now) / NGTCP2_SECONDS
-          : 1e-9;
-
-  if (!config.quiet) {
-    std::cerr << "Set idle timer=" << std::fixed << timer_.repeat << "s"
-              << std::defaultfloat << std::endl;
-  }
-
-  ev_timer_again(loop_, &timer_);
 }
 
 int Client::handle_expiry() {
@@ -866,8 +827,8 @@ int Client::handle_expiry() {
   if (auto rv = ngtcp2_conn_handle_expiry(conn_, now); rv != 0) {
     std::cerr << "ngtcp2_conn_handle_expiry: " << ngtcp2_strerror(rv)
               << std::endl;
-    ngtcp2_connection_close_error_set_transport_error_liberr(
-        &last_error_, NGTCP2_ERR_INTERNAL, nullptr, 0);
+    ngtcp2_connection_close_error_set_transport_error_liberr(&last_error_, rv,
+                                                             nullptr, 0);
     disconnect();
     return -1;
   }
@@ -895,7 +856,7 @@ int Client::on_write() {
     return -1;
   }
 
-  schedule_retransmit();
+  update_timer();
   return 0;
 }
 
@@ -973,8 +934,6 @@ int Client::write_streams() {
       return 0;
     }
 
-    reset_idle_timer();
-
     auto &ep = *static_cast<Endpoint *>(ps.path.user_data);
 
     if (auto rv =
@@ -1002,13 +961,13 @@ int Client::write_streams() {
   }
 }
 
-void Client::schedule_retransmit() {
+void Client::update_timer() {
   auto expiry = ngtcp2_conn_get_expiry(conn_);
   auto now = util::timestamp(loop_);
   auto t = expiry < now ? 1e-9
                         : static_cast<ev_tstamp>(expiry - now) / NGTCP2_SECONDS;
-  rttimer_.repeat = t;
-  ev_timer_again(loop_, &rttimer_);
+  timer_.repeat = t;
+  ev_timer_again(loop_, &timer_);
 }
 
 #ifdef HAVE_LINUX_RTNETLINK_H
@@ -1448,7 +1407,8 @@ int Client::send_blocked_packet() {
 }
 
 int Client::handle_error() {
-  if (!conn_ || ngtcp2_conn_is_in_closing_period(conn_)) {
+  if (!conn_ || ngtcp2_conn_is_in_closing_period(conn_) ||
+      ngtcp2_conn_is_in_draining_period(conn_)) {
     return 0;
   }
 

--- a/examples/h09client.h
+++ b/examples/h09client.h
@@ -96,7 +96,7 @@ public:
   int feed_data(const Endpoint &ep, const sockaddr *sa, socklen_t salen,
                 const ngtcp2_pkt_info *pi, uint8_t *data, size_t datalen);
   int handle_expiry();
-  void schedule_retransmit();
+  void update_timer();
   int handshake_completed();
   int handshake_confirmed();
 
@@ -131,11 +131,7 @@ public:
                                uint64_t datalen);
   int extend_max_stream_data(int64_t stream_id, uint64_t max_data);
 
-  void reset_idle_timer();
-
   void write_qlog(const void *data, size_t datalen);
-
-  void idle_timeout();
 
   void on_send_blocked(const Endpoint &ep, const ngtcp2_addr &remote_addr,
                        unsigned int ecn, size_t datalen);
@@ -147,7 +143,6 @@ private:
   Address remote_addr_;
   ev_io wev_;
   ev_timer timer_;
-  ev_timer rttimer_;
   ev_timer change_local_addr_timer_;
   ev_timer key_update_timer_;
   ev_timer delay_stream_timer_;

--- a/examples/h09server.cc
+++ b/examples/h09server.cc
@@ -321,11 +321,12 @@ void writecb(struct ev_loop *loop, ev_io *w, int revents) {
 } // namespace
 
 namespace {
-void timeoutcb(struct ev_loop *loop, ev_timer *w, int revents) {
+void close_waitcb(struct ev_loop *loop, ev_timer *w, int revents) {
   auto h = static_cast<Handler *>(w->data);
   auto s = h->server();
+  auto conn = h->conn();
 
-  if (ngtcp2_conn_is_in_closing_period(h->conn())) {
+  if (ngtcp2_conn_is_in_closing_period(conn)) {
     if (!config.quiet) {
       std::cerr << "Closing Period is over" << std::endl;
     }
@@ -333,7 +334,7 @@ void timeoutcb(struct ev_loop *loop, ev_timer *w, int revents) {
     s->remove(h);
     return;
   }
-  if (h->draining()) {
+  if (ngtcp2_conn_is_in_draining_period(conn)) {
     if (!config.quiet) {
       std::cerr << "Draining Period is over" << std::endl;
     }
@@ -342,16 +343,12 @@ void timeoutcb(struct ev_loop *loop, ev_timer *w, int revents) {
     return;
   }
 
-  if (!config.quiet) {
-    std::cerr << "Timeout" << std::endl;
-  }
-
-  h->start_draining_period();
+  assert(0);
 }
 } // namespace
 
 namespace {
-void retransmitcb(struct ev_loop *loop, ev_timer *w, int revents) {
+void timeoutcb(struct ev_loop *loop, ev_timer *w, int revents) {
   int rv;
 
   auto h = static_cast<Handler *>(w->data);
@@ -391,17 +388,13 @@ Handler::Handler(struct ev_loop *loop, Server *server)
       qlog_(nullptr),
       scid_{},
       nkey_update_(0),
-      draining_(false),
       tx_{
           .data = std::unique_ptr<uint8_t[]>(new uint8_t[64_k]),
       } {
   ev_io_init(&wev_, writecb, 0, EV_WRITE);
   wev_.data = this;
-  ev_timer_init(&timer_, timeoutcb, 0.,
-                static_cast<double>(config.timeout) / NGTCP2_SECONDS);
+  ev_timer_init(&timer_, timeoutcb, 0., 0.);
   timer_.data = this;
-  ev_timer_init(&rttimer_, retransmitcb, 0., 0.);
-  rttimer_.data = this;
 }
 
 Handler::~Handler() {
@@ -409,7 +402,6 @@ Handler::~Handler() {
     std::cerr << scid_ << " Closing QUIC connection " << std::endl;
   }
 
-  ev_timer_stop(loop_, &rttimer_);
   ev_timer_stop(loop_, &timer_);
   ev_io_stop(loop_, &wev_);
 
@@ -849,7 +841,6 @@ int Handler::init(const Endpoint &ep, const Address &local_addr,
   ngtcp2_conn_set_tls_native_handle(conn_, tls_session_.get_native_handle());
 
   ev_io_set(&wev_, ep.fd, EV_WRITE);
-  ev_timer_again(loop_, &timer_);
 
   return 0;
 }
@@ -916,25 +907,9 @@ int Handler::on_read(const Endpoint &ep, const Address &local_addr,
     return rv;
   }
 
-  reset_idle_timer();
+  update_timer();
 
   return 0;
-}
-
-void Handler::reset_idle_timer() {
-  auto now = util::timestamp(loop_);
-  auto idle_expiry = ngtcp2_conn_get_idle_expiry(conn_);
-  timer_.repeat =
-      idle_expiry > now
-          ? static_cast<ev_tstamp>(idle_expiry - now) / NGTCP2_SECONDS
-          : 1e-9;
-
-  if (!config.quiet) {
-    std::cerr << "Set idle timer=" << std::fixed << timer_.repeat << "s"
-              << std::defaultfloat << std::endl;
-  }
-
-  ev_timer_again(loop_, &timer_);
 }
 
 int Handler::handle_expiry() {
@@ -970,7 +945,7 @@ int Handler::on_write() {
     return rv;
   }
 
-  schedule_retransmit();
+  update_timer();
 
   return 0;
 }
@@ -1067,11 +1042,8 @@ int Handler::write_streams() {
 
           start_wev_endpoint(ep);
           ngtcp2_conn_update_pkt_tx_time(conn_, ts);
-          reset_idle_timer();
           return 0;
         }
-
-        reset_idle_timer();
       }
 
       ev_io_stop(loop_, &wev_);
@@ -1124,7 +1096,6 @@ int Handler::write_streams() {
       }
 
       ngtcp2_conn_update_pkt_tx_time(conn_, ts);
-      reset_idle_timer();
       return 0;
     }
 
@@ -1146,12 +1117,9 @@ int Handler::write_streams() {
 
       start_wev_endpoint(ep);
       ngtcp2_conn_update_pkt_tx_time(conn_, ts);
-      reset_idle_timer();
       return 0;
     }
 #else  // !NGTCP2_ENABLE_UDP_GSO
-    reset_idle_timer();
-
     auto &ep = *static_cast<Endpoint *>(ps.path.user_data);
     auto data = tx_.data.get();
     auto datalen = bufpos - data;
@@ -1252,14 +1220,10 @@ int Handler::send_blocked_packet() {
 
 void Handler::signal_write() { ev_io_start(loop_, &wev_); }
 
-bool Handler::draining() const { return draining_; }
-
 void Handler::start_draining_period() {
-  draining_ = true;
-
-  ev_timer_stop(loop_, &rttimer_);
   ev_io_stop(loop_, &wev_);
 
+  ev_set_cb(&timer_, close_waitcb);
   timer_.repeat =
       static_cast<ev_tstamp>(ngtcp2_conn_get_pto(conn_)) / NGTCP2_SECONDS * 3;
   ev_timer_again(loop_, &timer_);
@@ -1271,13 +1235,14 @@ void Handler::start_draining_period() {
 }
 
 int Handler::start_closing_period() {
-  if (!conn_ || ngtcp2_conn_is_in_closing_period(conn_)) {
+  if (!conn_ || ngtcp2_conn_is_in_closing_period(conn_) ||
+      ngtcp2_conn_is_in_draining_period(conn_)) {
     return 0;
   }
 
-  ev_timer_stop(loop_, &rttimer_);
   ev_io_stop(loop_, &wev_);
 
+  ev_set_cb(&timer_, close_waitcb);
   timer_.repeat =
       static_cast<ev_tstamp>(ngtcp2_conn_get_pto(conn_)) / NGTCP2_SECONDS * 3;
   ev_timer_again(loop_, &timer_);
@@ -1313,8 +1278,17 @@ int Handler::start_closing_period() {
 }
 
 int Handler::handle_error() {
+  if (last_error_.type ==
+      NGTCP2_CONNECTION_CLOSE_ERROR_CODE_TYPE_TRANSPORT_IDLE_CLOSE) {
+    return -1;
+  }
+
   if (start_closing_period() != 0) {
     return -1;
+  }
+
+  if (ngtcp2_conn_is_in_draining_period(conn_)) {
+    return NETWORK_ERR_CLOSE_WAIT;
   }
 
   if (auto rv = send_conn_close(); rv != NETWORK_ERR_OK) {
@@ -1331,6 +1305,7 @@ int Handler::send_conn_close() {
 
   assert(conn_closebuf_ && conn_closebuf_->size());
   assert(conn_);
+  assert(!ngtcp2_conn_is_in_draining_period(conn_));
 
   auto path = ngtcp2_conn_get_path(conn_);
 
@@ -1339,7 +1314,7 @@ int Handler::send_conn_close() {
       /* ecn = */ 0, conn_closebuf_->rpos(), conn_closebuf_->size(), 0);
 }
 
-void Handler::schedule_retransmit() {
+void Handler::update_timer() {
   auto expiry = ngtcp2_conn_get_expiry(conn_);
   auto now = util::timestamp(loop_);
   auto t = expiry < now ? 1e-9
@@ -1348,8 +1323,8 @@ void Handler::schedule_retransmit() {
     std::cerr << "Set timer=" << std::fixed << t << "s" << std::defaultfloat
               << std::endl;
   }
-  rttimer_.repeat = t;
-  ev_timer_again(loop_, &rttimer_);
+  timer_.repeat = t;
+  ev_timer_again(loop_, &timer_);
 }
 
 namespace {
@@ -1948,7 +1923,8 @@ int Server::on_read(Endpoint &ep) {
     }
 
     auto h = (*handler_it).second;
-    if (ngtcp2_conn_is_in_closing_period(h->conn())) {
+    auto conn = h->conn();
+    if (ngtcp2_conn_is_in_closing_period(conn)) {
       // TODO do exponential backoff.
       switch (h->send_conn_close()) {
       case 0:
@@ -1958,7 +1934,7 @@ int Server::on_read(Endpoint &ep) {
       }
       continue;
     }
-    if (h->draining()) {
+    if (ngtcp2_conn_is_in_draining_period(conn)) {
       continue;
     }
 

--- a/examples/h09server.h
+++ b/examples/h09server.h
@@ -116,7 +116,7 @@ public:
   int feed_data(const Endpoint &ep, const Address &local_addr,
                 const sockaddr *sa, socklen_t salen, const ngtcp2_pkt_info *pi,
                 uint8_t *data, size_t datalen);
-  void schedule_retransmit();
+  void update_timer();
   int handle_expiry();
   void signal_write();
   int handshake_completed();
@@ -131,7 +131,6 @@ public:
   int on_stream_close(int64_t stream_id, uint64_t app_error_code);
   void start_draining_period();
   int start_closing_period();
-  bool draining() const;
   int handle_error();
   int send_conn_close();
 
@@ -144,8 +143,6 @@ public:
   Stream *find_stream(int64_t stream_id);
   int extend_max_stream_data(int64_t stream_id, uint64_t max_data);
   void shutdown_read(int64_t stream_id, int app_error_code);
-
-  void reset_idle_timer();
 
   void write_qlog(const void *data, size_t datalen);
   void add_sendq(Stream *stream);
@@ -162,7 +159,6 @@ private:
   Server *server_;
   ev_io wev_;
   ev_timer timer_;
-  ev_timer rttimer_;
   FILE *qlog_;
   ngtcp2_cid scid_;
   std::unordered_map<int64_t, std::unique_ptr<Stream>> streams_;
@@ -173,8 +169,6 @@ private:
   std::unique_ptr<Buffer> conn_closebuf_;
   // nkey_update_ is the number of key update occurred.
   size_t nkey_update_;
-  // draining_ becomes true when draining period starts.
-  bool draining_;
 
   struct {
     bool send_blocked;

--- a/examples/server.h
+++ b/examples/server.h
@@ -122,7 +122,7 @@ public:
   int feed_data(const Endpoint &ep, const Address &local_addr,
                 const sockaddr *sa, socklen_t salen, const ngtcp2_pkt_info *pi,
                 uint8_t *data, size_t datalen);
-  void schedule_retransmit();
+  void update_timer();
   int handle_expiry();
   void signal_write();
   int handshake_completed();
@@ -136,7 +136,6 @@ public:
   int on_stream_close(int64_t stream_id, uint64_t app_error_code);
   void start_draining_period();
   int start_closing_period();
-  bool draining() const;
   int handle_error();
   int send_conn_close();
 
@@ -165,8 +164,6 @@ public:
   int http_stop_sending(int64_t stream_id, uint64_t app_error_code);
   int http_reset_stream(int64_t stream_id, uint64_t app_error_code);
 
-  void reset_idle_timer();
-
   void write_qlog(const void *data, size_t datalen);
 
   void on_send_blocked(Endpoint &ep, const ngtcp2_addr &local_addr,
@@ -181,7 +178,6 @@ private:
   Server *server_;
   ev_io wev_;
   ev_timer timer_;
-  ev_timer rttimer_;
   FILE *qlog_;
   ngtcp2_cid scid_;
   nghttp3_conn *httpconn_;
@@ -192,8 +188,6 @@ private:
   std::unique_ptr<Buffer> conn_closebuf_;
   // nkey_update_ is the number of key update occurred.
   size_t nkey_update_;
-  // draining_ becomes true when draining period starts.
-  bool draining_;
 
   struct {
     bool send_blocked;

--- a/lib/includes/ngtcp2/ngtcp2.h
+++ b/lib/includes/ngtcp2/ngtcp2.h
@@ -782,6 +782,13 @@ typedef struct NGTCP2_ALIGN(8) ngtcp2_pkt_info {
 /**
  * @macro
  *
+ * :macro:`NGTCP2_ERR_IDLE_CLOSE` indicates the connection should be
+ * closed silently because of idle timeout.
+ */
+#define NGTCP2_ERR_IDLE_CLOSE -248
+/**
+ * @macro
+ *
  * :macro:`NGTCP2_ERR_FATAL` indicates that error codes less than this
  * value is fatal error.  When this error is returned, an endpoint
  * should drop connection immediately.
@@ -3888,15 +3895,6 @@ NGTCP2_EXTERN int ngtcp2_conn_handle_expiry(ngtcp2_conn *conn,
 /**
  * @function
  *
- * `ngtcp2_conn_get_idle_expiry` returns the time when a connection
- * should be closed if it continues to be idle.  If idle timeout is
- * disabled, this function returns ``UINT64_MAX``.
- */
-NGTCP2_EXTERN ngtcp2_tstamp ngtcp2_conn_get_idle_expiry(ngtcp2_conn *conn);
-
-/**
- * @function
- *
  * `ngtcp2_conn_get_pto` returns Probe Timeout (PTO).
  */
 NGTCP2_EXTERN ngtcp2_duration ngtcp2_conn_get_pto(ngtcp2_conn *conn);
@@ -4978,6 +4976,12 @@ NGTCP2_EXTERN void ngtcp2_connection_close_error_set_transport_error(
  * :enum:`ngtcp2_connection_close_error_code_type.NGTCP2_CONNECTION_CLOSE_ERROR_CODE_TYPE_TRANSPORT_VERSION_NEGOTIATION`,
  * and :member:`ccerr->error_code
  * <ngtcp2_connection_close_error.error_code>` to
+ * :macro:`NGTCP2_NO_ERROR`.  If |liberr| is
+ * :macro:`NGTCP2_ERR_IDLE_CLOSE`, :member:`ccerr->type
+ * <ngtcp2_connection_close_error.type>` is set to
+ * :enum:`ngtcp2_connection_close_error_code_type.NGTCP2_CONNECTION_CLOSE_ERROR_CODE_TYPE_TRANSPORT_IDLE_CLOSE`,
+ * and :member:`ccerr->error_code
+ * <ngtcp2_connection_close_error.error_code>` to
  * :macro:`NGTCP2_NO_ERROR`.  Otherwise, :member:`ccerr->type
  * <ngtcp2_connection_close_error.type>` is set to
  * :enum:`ngtcp2_connection_close_error_code_type.NGTCP2_CONNECTION_CLOSE_ERROR_CODE_TYPE_TRANSPORT`,
@@ -5007,22 +5011,6 @@ NGTCP2_EXTERN void ngtcp2_connection_close_error_set_transport_error_liberr(
 NGTCP2_EXTERN void ngtcp2_connection_close_error_set_transport_error_tls_alert(
     ngtcp2_connection_close_error *ccerr, uint8_t tls_alert,
     const uint8_t *reason, size_t reasonlen);
-
-/**
- * @function
- *
- * `ngtcp2_connection_close_error_set_transport_error_idle_close` sets
- * :member:`ccerr->type <ngtcp2_connection_close_error.type>` to
- * :enum:`ngtcp2_connection_close_error_code_type.NGTCP2_CONNECTION_CLOSE_ERROR_CODE_TYPE_TRANSPORT_IDLE_CLOSE`,
- * and :member:`ccerr->error_code
- * <ngtcp2_connection_close_error.error_code>` to
- * :macro:`NGTCP2_NO_ERROR`.  |reason| is the reason phrase of length
- * |reasonlen|.  This function does not make a copy of the reason
- * phrase.
- */
-NGTCP2_EXTERN void ngtcp2_connection_close_error_set_transport_error_idle_close(
-    ngtcp2_connection_close_error *ccerr, const uint8_t *reason,
-    size_t reasonlen);
 
 /**
  * @function

--- a/lib/ngtcp2_conn.h
+++ b/lib/ngtcp2_conn.h
@@ -945,6 +945,15 @@ void ngtcp2_conn_cancel_expired_ack_delay_timer(ngtcp2_conn *conn,
  */
 ngtcp2_tstamp ngtcp2_conn_loss_detection_expiry(ngtcp2_conn *conn);
 
+/**
+ * @function
+ *
+ * `ngtcp2_conn_get_idle_expiry` returns the time when a connection
+ * should be closed if it continues to be idle.  If idle timeout is
+ * disabled, this function returns ``UINT64_MAX``.
+ */
+ngtcp2_tstamp ngtcp2_conn_get_idle_expiry(ngtcp2_conn *conn);
+
 ngtcp2_duration ngtcp2_conn_compute_pto(ngtcp2_conn *conn, ngtcp2_pktns *pktns);
 
 /*

--- a/lib/ngtcp2_err.c
+++ b/lib/ngtcp2_err.c
@@ -106,6 +106,8 @@ const char *ngtcp2_strerror(int liberr) {
     return "ERR_HANDSHAKE_TIMEOUT";
   case NGTCP2_ERR_VERSION_NEGOTIATION_FAILURE:
     return "ERR_VERSION_NEGOTIATION_FAILURE";
+  case NGTCP2_ERR_IDLE_CLOSE:
+    return "ERR_IDLE_CLOSE";
   default:
     return "(unknown)";
   }

--- a/tests/ngtcp2_conn_test.c
+++ b/tests/ngtcp2_conn_test.c
@@ -534,7 +534,7 @@ static void server_default_transport_params(ngtcp2_transport_params *params) {
   params->initial_max_data = 128 * 1024;
   params->initial_max_streams_bidi = 3;
   params->initial_max_streams_uni = 2;
-  params->max_idle_timeout = 60;
+  params->max_idle_timeout = 60 * NGTCP2_SECONDS;
   params->max_udp_payload_size = 65535;
   params->stateless_reset_token_present = 1;
   params->active_connection_id_limit = 8;
@@ -583,7 +583,7 @@ static void client_default_transport_params(ngtcp2_transport_params *params) {
   params->initial_max_data = 128 * 1024;
   params->initial_max_streams_bidi = 0;
   params->initial_max_streams_uni = 2;
-  params->max_idle_timeout = 60;
+  params->max_idle_timeout = 60 * NGTCP2_SECONDS;
   params->max_udp_payload_size = 65535;
   params->stateless_reset_token_present = 0;
   params->active_connection_id_limit = 8;
@@ -7700,6 +7700,7 @@ void test_ngtcp2_conn_keep_alive(void) {
   ngtcp2_ssize spktlen;
   ngtcp2_pkt_info pi;
   ngtcp2_tstamp t = 0;
+  int rv;
 
   setup_default_client(&conn);
 
@@ -7719,8 +7720,9 @@ void test_ngtcp2_conn_keep_alive(void) {
 
   t += 10 * NGTCP2_SECONDS;
 
-  ngtcp2_conn_handle_expiry(conn, t);
+  rv = ngtcp2_conn_handle_expiry(conn, t);
 
+  CU_ASSERT(0 == rv);
   CU_ASSERT(conn->flags & NGTCP2_CONN_FLAG_KEEP_ALIVE_CANCELLED);
 
   spktlen = ngtcp2_conn_write_pkt(conn, NULL, &pi, buf, sizeof(buf), t);


### PR DESCRIPTION
Merge expiry from ngtcp2_conn_get_idle_expiry into
ngtcp2_conn_get_expiry, and let ngtcp2_conn_handle_expiry deal with
idle timeout.  On idle timeout, ngtcp2_conn_handle_expiry returns
NGTCP2_ERR_IDLE_CLOSE.  ngtcp2_conn_get_idle_expiry is removed from
the public API surface.
ngtcp2_connection_close_error_set_transport_error_idle_close is
removed in favor of passing NGTCP2_ERR_IDLE_CLOSE to
ngtcp2_connection_close_error_set_transport_error_liberr.

Now ngtcp2_conn_write_connection_close returns 0 if a connection
object is in closing or draining period instead of returning
NGTCP2_ERR_INVALID_STATE.