### PR TITLE
Avoid SO_REUSEADDR on client side

### DIFF
--- a/examples/client.cc
+++ b/examples/client.cc
@@ -1151,13 +1151,6 @@ int udp_sock(int family) {
     return -1;
   }
 
-  auto val = 1;
-  if (setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &val,
-                 static_cast<socklen_t>(sizeof(val))) == -1) {
-    close(fd);
-    return -1;
-  }
-
   fd_set_recv_ecn(fd, family);
   fd_set_ip_mtu_discover(fd, family);
   fd_set_ip_dontfrag(fd, family);

--- a/examples/h09client.cc
+++ b/examples/h09client.cc
@@ -1054,13 +1054,6 @@ int udp_sock(int family) {
     return -1;
   }
 
-  auto val = 1;
-  if (setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &val,
-                 static_cast<socklen_t>(sizeof(val))) == -1) {
-    close(fd);
-    return -1;
-  }
-
   fd_set_recv_ecn(fd, family);
   fd_set_ip_mtu_discover(fd, family);
   fd_set_ip_dontfrag(fd, family);


### PR DESCRIPTION
Avoid SO_REUSEADDR on client side which allows bind to assign the same
port multiple times if it is not an active listening port.