### PR TITLE
Rename original_version to client_chosen_version

### DIFF
--- a/crypto/shared.c
+++ b/crypto/shared.c
@@ -1321,7 +1321,7 @@ int ngtcp2_crypto_client_initial_cb(ngtcp2_conn *conn, void *user_data) {
 
   if (ngtcp2_crypto_derive_and_install_initial_key(
           conn, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
-          ngtcp2_conn_get_original_version(conn), dcid) != 0) {
+          ngtcp2_conn_get_client_chosen_version(conn), dcid) != 0) {
     return NGTCP2_ERR_CALLBACK_FAILURE;
   }
 
@@ -1343,7 +1343,7 @@ int ngtcp2_crypto_recv_retry_cb(ngtcp2_conn *conn, const ngtcp2_pkt_hd *hd,
 
   if (ngtcp2_crypto_derive_and_install_initial_key(
           conn, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
-          ngtcp2_conn_get_original_version(conn), &hd->scid) != 0) {
+          ngtcp2_conn_get_client_chosen_version(conn), &hd->scid) != 0) {
     return NGTCP2_ERR_CALLBACK_FAILURE;
   }
 
@@ -1357,7 +1357,7 @@ int ngtcp2_crypto_recv_client_initial_cb(ngtcp2_conn *conn,
 
   if (ngtcp2_crypto_derive_and_install_initial_key(
           conn, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
-          ngtcp2_conn_get_original_version(conn), dcid) != 0) {
+          ngtcp2_conn_get_client_chosen_version(conn), dcid) != 0) {
     return NGTCP2_ERR_CALLBACK_FAILURE;
   }
 

--- a/examples/tls_server_context_boringssl.cc
+++ b/examples/tls_server_context_boringssl.cc
@@ -55,7 +55,7 @@ int alpn_select_proto_h3_cb(SSL *ssl, const unsigned char **out,
   size_t alpnlen;
   // This should be the negotiated version, but we have not set the
   // negotiated version when this callback is called.
-  auto version = ngtcp2_conn_get_original_version(h->conn());
+  auto version = ngtcp2_conn_get_client_chosen_version(h->conn());
 
   switch (version) {
   case QUIC_VER_DRAFT29:
@@ -112,7 +112,7 @@ int alpn_select_proto_hq_cb(SSL *ssl, const unsigned char **out,
   size_t alpnlen;
   // This should be the negotiated version, but we have not set the
   // negotiated version when this callback is called.
-  auto version = ngtcp2_conn_get_original_version(h->conn());
+  auto version = ngtcp2_conn_get_client_chosen_version(h->conn());
 
   switch (version) {
   case QUIC_VER_DRAFT29:

--- a/examples/tls_server_context_openssl.cc
+++ b/examples/tls_server_context_openssl.cc
@@ -56,7 +56,7 @@ int alpn_select_proto_h3_cb(SSL *ssl, const unsigned char **out,
   size_t alpnlen;
   // This should be the negotiated version, but we have not set the
   // negotiated version when this callback is called.
-  auto version = ngtcp2_conn_get_original_version(h->conn());
+  auto version = ngtcp2_conn_get_client_chosen_version(h->conn());
 
   switch (version) {
   case QUIC_VER_DRAFT29:
@@ -113,7 +113,7 @@ int alpn_select_proto_hq_cb(SSL *ssl, const unsigned char **out,
   size_t alpnlen;
   // This should be the negotiated version, but we have not set the
   // negotiated version when this callback is called.
-  auto version = ngtcp2_conn_get_original_version(h->conn());
+  auto version = ngtcp2_conn_get_client_chosen_version(h->conn());
 
   switch (version) {
   case QUIC_VER_DRAFT29:

--- a/lib/includes/ngtcp2/ngtcp2.h
+++ b/lib/includes/ngtcp2/ngtcp2.h
@@ -3482,38 +3482,10 @@ NGTCP2_EXTERN int ngtcp2_accept(ngtcp2_pkt_hd *dest, const uint8_t *pkt,
  *
  * `ngtcp2_conn_client_new` creates new :type:`ngtcp2_conn`, and
  * initializes it as client.  |dcid| is randomized destination
- * connection ID.  |scid| is source connection ID.  |version| is a
- * QUIC version to use.  |path| is the network path where this QUIC
- * connection is being established and must not be ``NULL``.
- * |callbacks|, |settings|, and |params| must not be ``NULL``, and the
- * function make a copy of each of them.  |params| is local QUIC
- * transport parameters and sent to a remote endpoint during
- * handshake.  |user_data| is the arbitrary pointer which is passed to
- * the user-defined callback functions.  If |mem| is ``NULL``, the
- * memory allocator returned by `ngtcp2_mem_default()` is used.
- *
- * This function returns 0 if it succeeds, or one of the following
- * negative error codes:
- *
- * :macro:`NGTCP2_ERR_NOMEM`
- *     Out of memory.
- */
-NGTCP2_EXTERN int ngtcp2_conn_client_new_versioned(
-    ngtcp2_conn **pconn, const ngtcp2_cid *dcid, const ngtcp2_cid *scid,
-    const ngtcp2_path *path, uint32_t version, int callbacks_version,
-    const ngtcp2_callbacks *callbacks, int settings_version,
-    const ngtcp2_settings *settings, int transport_params_version,
-    const ngtcp2_transport_params *params, const ngtcp2_mem *mem,
-    void *user_data);
-
-/**
- * @function
- *
- * `ngtcp2_conn_server_new` creates new :type:`ngtcp2_conn`, and
- * initializes it as server.  |dcid| is a destination connection ID.
- * |scid| is a source connection ID.  |path| is the network path where
- * this QUIC connection is being established and must not be ``NULL``.
- * |version| is a QUIC version to use.  |callbacks|, |settings|, and
+ * connection ID.  |scid| is source connection ID.
+ * |client_chosen_version| is a QUIC version that a cilent chooses.
+ * |path| is the network path where this QUIC connection is being
+ * established and must not be ``NULL``.  |callbacks|, |settings|, and
  * |params| must not be ``NULL``, and the function make a copy of each
  * of them.  |params| is local QUIC transport parameters and sent to a
  * remote endpoint during handshake.  |user_data| is the arbitrary
@@ -3527,13 +3499,42 @@ NGTCP2_EXTERN int ngtcp2_conn_client_new_versioned(
  * :macro:`NGTCP2_ERR_NOMEM`
  *     Out of memory.
  */
+NGTCP2_EXTERN int ngtcp2_conn_client_new_versioned(
+    ngtcp2_conn **pconn, const ngtcp2_cid *dcid, const ngtcp2_cid *scid,
+    const ngtcp2_path *path, uint32_t client_chosen_version,
+    int callbacks_version, const ngtcp2_callbacks *callbacks,
+    int settings_version, const ngtcp2_settings *settings,
+    int transport_params_version, const ngtcp2_transport_params *params,
+    const ngtcp2_mem *mem, void *user_data);
+
+/**
+ * @function
+ *
+ * `ngtcp2_conn_server_new` creates new :type:`ngtcp2_conn`, and
+ * initializes it as server.  |dcid| is a destination connection ID.
+ * |scid| is a source connection ID.  |path| is the network path where
+ * this QUIC connection is being established and must not be ``NULL``.
+ * |client_chosen_version| is a QUIC version that a client chooses.
+ * |callbacks|, |settings|, and |params| must not be ``NULL``, and the
+ * function make a copy of each of them.  |params| is local QUIC
+ * transport parameters and sent to a remote endpoint during
+ * handshake.  |user_data| is the arbitrary pointer which is passed to
+ * the user-defined callback functions.  If |mem| is ``NULL``, the
+ * memory allocator returned by `ngtcp2_mem_default()` is used.
+ *
+ * This function returns 0 if it succeeds, or one of the following
+ * negative error codes:
+ *
+ * :macro:`NGTCP2_ERR_NOMEM`
+ *     Out of memory.
+ */
 NGTCP2_EXTERN int ngtcp2_conn_server_new_versioned(
     ngtcp2_conn **pconn, const ngtcp2_cid *dcid, const ngtcp2_cid *scid,
-    const ngtcp2_path *path, uint32_t version, int callbacks_version,
-    const ngtcp2_callbacks *callbacks, int settings_version,
-    const ngtcp2_settings *settings, int transport_params_version,
-    const ngtcp2_transport_params *params, const ngtcp2_mem *mem,
-    void *user_data);
+    const ngtcp2_path *path, uint32_t client_chosen_version,
+    int callbacks_version, const ngtcp2_callbacks *callbacks,
+    int settings_version, const ngtcp2_settings *settings,
+    int transport_params_version, const ngtcp2_transport_params *params,
+    const ngtcp2_mem *mem, void *user_data);
 
 /**
  * @function
@@ -4570,9 +4571,10 @@ NGTCP2_EXTERN size_t ngtcp2_conn_get_active_dcid(ngtcp2_conn *conn,
 /**
  * @function
  *
- * `ngtcp2_conn_get_original_version` returns the original version.
+ * `ngtcp2_conn_get_client_chosen_version` returns the client chosen
+ * version.
  */
-NGTCP2_EXTERN uint32_t ngtcp2_conn_get_original_version(ngtcp2_conn *conn);
+NGTCP2_EXTERN uint32_t ngtcp2_conn_get_client_chosen_version(ngtcp2_conn *conn);
 
 /**
  * @function

--- a/lib/ngtcp2_conn.c
+++ b/lib/ngtcp2_conn.c
@@ -950,7 +950,7 @@ static void conn_reset_ecn_validation_state(ngtcp2_conn *conn) {
 
 static int conn_new(ngtcp2_conn **pconn, const ngtcp2_cid *dcid,
                     const ngtcp2_cid *scid, const ngtcp2_path *path,
-                    uint32_t original_version, int callbacks_version,
+                    uint32_t client_chosen_version, int callbacks_version,
                     const ngtcp2_callbacks *callbacks, int settings_version,
                     const ngtcp2_settings *settings,
                     int transport_params_version,
@@ -1170,7 +1170,7 @@ static int conn_new(ngtcp2_conn **pconn, const ngtcp2_cid *dcid,
   (*pconn)->server = server;
   (*pconn)->oscid = *scid;
   (*pconn)->callbacks = *callbacks;
-  (*pconn)->original_version = original_version;
+  (*pconn)->client_chosen_version = client_chosen_version;
   (*pconn)->mem = mem;
   (*pconn)->user_data = user_data;
   (*pconn)->idle_ts = settings->initial_ts;
@@ -1216,16 +1216,16 @@ fail_conn:
 
 int ngtcp2_conn_client_new_versioned(
     ngtcp2_conn **pconn, const ngtcp2_cid *dcid, const ngtcp2_cid *scid,
-    const ngtcp2_path *path, uint32_t original_version, int callbacks_version,
-    const ngtcp2_callbacks *callbacks, int settings_version,
-    const ngtcp2_settings *settings, int transport_params_version,
-    const ngtcp2_transport_params *params, const ngtcp2_mem *mem,
-    void *user_data) {
+    const ngtcp2_path *path, uint32_t client_chosen_version,
+    int callbacks_version, const ngtcp2_callbacks *callbacks,
+    int settings_version, const ngtcp2_settings *settings,
+    int transport_params_version, const ngtcp2_transport_params *params,
+    const ngtcp2_mem *mem, void *user_data) {
   int rv;
 
-  rv = conn_new(pconn, dcid, scid, path, original_version, callbacks_version,
-                callbacks, settings_version, settings, transport_params_version,
-                params, mem, user_data, 0);
+  rv = conn_new(pconn, dcid, scid, path, client_chosen_version,
+                callbacks_version, callbacks, settings_version, settings,
+                transport_params_version, params, mem, user_data, 0);
   if (rv != 0) {
     return rv;
   }
@@ -1245,18 +1245,18 @@ int ngtcp2_conn_client_new_versioned(
 
 int ngtcp2_conn_server_new_versioned(
     ngtcp2_conn **pconn, const ngtcp2_cid *dcid, const ngtcp2_cid *scid,
-    const ngtcp2_path *path, uint32_t original_version, int callbacks_version,
-    const ngtcp2_callbacks *callbacks, int settings_version,
-    const ngtcp2_settings *settings, int transport_params_version,
-    const ngtcp2_transport_params *params, const ngtcp2_mem *mem,
-    void *user_data) {
+    const ngtcp2_path *path, uint32_t client_chosen_version,
+    int callbacks_version, const ngtcp2_callbacks *callbacks,
+    int settings_version, const ngtcp2_settings *settings,
+    int transport_params_version, const ngtcp2_transport_params *params,
+    const ngtcp2_mem *mem, void *user_data) {
   int rv;
   uint32_t *preferred_versions;
   size_t i;
 
-  rv = conn_new(pconn, dcid, scid, path, original_version, callbacks_version,
-                callbacks, settings_version, settings, transport_params_version,
-                params, mem, user_data, 1);
+  rv = conn_new(pconn, dcid, scid, path, client_chosen_version,
+                callbacks_version, callbacks, settings_version, settings,
+                transport_params_version, params, mem, user_data, 1);
   if (rv != 0) {
     return rv;
   }
@@ -2407,8 +2407,8 @@ conn_write_handshake_pkt(ngtcp2_conn *conn, ngtcp2_pkt_info *pi, uint8_t *dest,
     assert(conn->in_pktns->crypto.tx.ckm);
     pktns = conn->in_pktns;
     version = conn->negotiated_version ? conn->negotiated_version
-                                       : conn->original_version;
-    if (version == conn->original_version) {
+                                       : conn->client_chosen_version;
+    if (version == conn->client_chosen_version) {
       cc.ckm = pktns->crypto.tx.ckm;
       cc.hp_ctx = pktns->crypto.tx.hp_ctx;
     } else {
@@ -3406,7 +3406,7 @@ static ngtcp2_ssize conn_write_pkt(ngtcp2_conn *conn, ngtcp2_pkt_info *pi,
       cc->hp = conn->early.ctx.hp;
       cc->ckm = conn->early.ckm;
       cc->hp_ctx = conn->early.hp_ctx;
-      version = conn->original_version;
+      version = conn->client_chosen_version;
       break;
     default:
       /* Unreachable */
@@ -4167,8 +4167,8 @@ ngtcp2_ssize ngtcp2_conn_write_single_frame_pkt(
     hd_flags = conn_pkt_flags_long(conn);
     scid = &conn->oscid;
     version = conn->negotiated_version ? conn->negotiated_version
-                                       : conn->original_version;
-    if (version == conn->original_version) {
+                                       : conn->client_chosen_version;
+    if (version == conn->client_chosen_version) {
       cc.ckm = pktns->crypto.tx.ckm;
       cc.hp_ctx = pktns->crypto.tx.hp_ctx;
     } else {
@@ -4984,7 +4984,7 @@ static int conn_on_version_negotiation(ngtcp2_conn *conn,
   ngtcp2_qlog_version_negotiation_pkt_received(&conn->qlog, hd, p, nsv);
 
   for (i = 0; i < nsv; ++i) {
-    if (p[i] == conn->original_version) {
+    if (p[i] == conn->client_chosen_version) {
       ngtcp2_log_info(&conn->log, NGTCP2_LOG_EVENT_PKT,
                       "ignore Version Negotiation because it contains version "
                       "selected by client");
@@ -5141,7 +5141,7 @@ static int conn_on_retry(ngtcp2_conn *conn, const ngtcp2_pkt_hd *hd,
   retry.odcid = conn->dcid.current.cid;
 
   rv = ngtcp2_pkt_verify_retry_tag(
-      conn->original_version, &retry, pkt, pktlen, conn->callbacks.encrypt,
+      conn->client_chosen_version, &retry, pkt, pktlen, conn->callbacks.encrypt,
       &conn->crypto.retry_aead, &conn->crypto.retry_aead_ctx);
   if (rv != 0) {
     ngtcp2_log_info(&conn->log, NGTCP2_LOG_EVENT_PKT,
@@ -6067,7 +6067,7 @@ conn_recv_handshake_pkt(ngtcp2_conn *conn, const ngtcp2_path *path,
       return NGTCP2_ERR_DISCARD_PKT;
     }
 
-    if (conn->original_version != hd.version) {
+    if (conn->client_chosen_version != hd.version) {
       return NGTCP2_ERR_DISCARD_PKT;
     }
 
@@ -6092,11 +6092,12 @@ conn_recv_handshake_pkt(ngtcp2_conn *conn, const ngtcp2_path *path,
   }
 
   if (conn->server) {
-    if (hd.version != conn->original_version &&
+    if (hd.version != conn->client_chosen_version &&
         (!conn->negotiated_version || hd.version != conn->negotiated_version)) {
       return NGTCP2_ERR_DISCARD_PKT;
     }
-  } else if (hd.version != conn->original_version && conn->negotiated_version &&
+  } else if (hd.version != conn->client_chosen_version &&
+             conn->negotiated_version &&
              hd.version != conn->negotiated_version) {
     return NGTCP2_ERR_DISCARD_PKT;
   }
@@ -6117,7 +6118,7 @@ conn_recv_handshake_pkt(ngtcp2_conn *conn, const ngtcp2_path *path,
       return NGTCP2_ERR_DISCARD_PKT;
     }
 
-    if (hd.version != conn->original_version) {
+    if (hd.version != conn->client_chosen_version) {
       return NGTCP2_ERR_DISCARD_PKT;
     }
 
@@ -6194,8 +6195,8 @@ conn_recv_handshake_pkt(ngtcp2_conn *conn, const ngtcp2_path *path,
         return NGTCP2_ERR_DISCARD_PKT;
       }
 
-      if (hd.version != conn->original_version && !conn->negotiated_version &&
-          conn->vneg.version != hd.version) {
+      if (hd.version != conn->client_chosen_version &&
+          !conn->negotiated_version && conn->vneg.version != hd.version) {
         if (!vneg_other_versions_includes(conn->vneg.other_versions,
                                           conn->vneg.other_versionslen,
                                           hd.version)) {
@@ -6220,7 +6221,7 @@ conn_recv_handshake_pkt(ngtcp2_conn *conn, const ngtcp2_path *path,
     crypto = &pktns->crypto.strm;
     crypto_level = NGTCP2_CRYPTO_LEVEL_INITIAL;
 
-    if (hd.version == conn->original_version) {
+    if (hd.version == conn->client_chosen_version) {
       ckm = pktns->crypto.rx.ckm;
       hp_ctx = &pktns->crypto.rx.hp_ctx;
     } else {
@@ -6345,7 +6346,7 @@ conn_recv_handshake_pkt(ngtcp2_conn *conn, const ngtcp2_path *path,
     return NGTCP2_ERR_PROTO;
   }
 
-  if (!conn->server && hd.version != conn->original_version &&
+  if (!conn->server && hd.version != conn->client_chosen_version &&
       !conn->negotiated_version) {
     conn->negotiated_version = hd.version;
 
@@ -8597,7 +8598,7 @@ static ngtcp2_ssize conn_recv_pkt(ngtcp2_conn *conn, const ngtcp2_path *path,
 
     assert(conn->negotiated_version);
 
-    if (hd.version != conn->original_version &&
+    if (hd.version != conn->client_chosen_version &&
         hd.version != conn->negotiated_version) {
       return NGTCP2_ERR_DISCARD_PKT;
     }
@@ -8638,7 +8639,7 @@ static ngtcp2_ssize conn_recv_pkt(ngtcp2_conn *conn, const ngtcp2_path *path,
       decrypt = conn->callbacks.decrypt;
       break;
     case NGTCP2_PKT_0RTT:
-      if (!conn->server || hd.version != conn->original_version) {
+      if (!conn->server || hd.version != conn->client_chosen_version) {
         return NGTCP2_ERR_DISCARD_PKT;
       }
 
@@ -10103,7 +10104,7 @@ static ngtcp2_ssize conn_client_write_handshake(ngtcp2_conn *conn,
     /* If spktlen > 0, we are making a compound packet.  If Initial
        packet is written, we have to pad bytes to 0-RTT packet. */
     version = conn->negotiated_version ? conn->negotiated_version
-                                       : conn->original_version;
+                                       : conn->client_chosen_version;
     if (spktlen > 0 &&
         ngtcp2_pkt_get_type_long(version, dest[0]) == NGTCP2_PKT_INITIAL) {
       wflags |= NGTCP2_WRITE_PKT_FLAG_REQUIRE_PADDING;
@@ -10782,7 +10783,7 @@ conn_client_validate_transport_params(ngtcp2_conn *conn,
     if (conn->negotiated_version != params->version_info.chosen_version) {
       return NGTCP2_ERR_VERSION_NEGOTIATION_FAILURE;
     }
-  } else if (conn->original_version != conn->negotiated_version) {
+  } else if (conn->client_chosen_version != conn->negotiated_version) {
     return NGTCP2_ERR_VERSION_NEGOTIATION_FAILURE;
   }
 
@@ -10795,10 +10796,10 @@ ngtcp2_conn_server_negotiate_version(ngtcp2_conn *conn,
   size_t i, j, preferred_versionslen = conn->vneg.preferred_versionslen;
 
   assert(conn->server);
-  assert(conn->original_version == version_info->chosen_version);
+  assert(conn->client_chosen_version == version_info->chosen_version);
 
   if (!preferred_versionslen || !version_info->other_versionslen) {
-    return conn->original_version;
+    return conn->client_chosen_version;
   }
 
   for (i = 0; i < preferred_versionslen; ++i) {
@@ -10819,7 +10820,7 @@ ngtcp2_conn_server_negotiate_version(ngtcp2_conn *conn,
     }
   }
 
-  return conn->original_version;
+  return conn->client_chosen_version;
 }
 
 int ngtcp2_conn_set_remote_transport_params_versioned(
@@ -10850,13 +10851,13 @@ int ngtcp2_conn_set_remote_transport_params_versioned(
 
   if (conn->server) {
     if (params->version_info_present) {
-      if (params->version_info.chosen_version != conn->original_version) {
+      if (params->version_info.chosen_version != conn->client_chosen_version) {
         return NGTCP2_ERR_VERSION_NEGOTIATION_FAILURE;
       }
 
       conn->negotiated_version =
           ngtcp2_conn_server_negotiate_version(conn, &params->version_info);
-      if (conn->negotiated_version != conn->original_version) {
+      if (conn->negotiated_version != conn->client_chosen_version) {
         rv = conn_call_version_negotiation(conn, conn->negotiated_version,
                                            &conn->rcid);
         if (rv != 0) {
@@ -10864,7 +10865,7 @@ int ngtcp2_conn_set_remote_transport_params_versioned(
         }
       }
     } else {
-      conn->negotiated_version = conn->original_version;
+      conn->negotiated_version = conn->client_chosen_version;
     }
 
     ngtcp2_log_info(&conn->log, NGTCP2_LOG_EVENT_CON,
@@ -11047,7 +11048,7 @@ void ngtcp2_conn_get_local_transport_params_versioned(
   if (conn->server) {
     params->version_info.chosen_version = conn->negotiated_version;
   } else {
-    params->version_info.chosen_version = conn->original_version;
+    params->version_info.chosen_version = conn->client_chosen_version;
   }
 
   params->version_info.other_versions = conn->vneg.other_versions;
@@ -12105,8 +12106,8 @@ const ngtcp2_cid *ngtcp2_conn_get_client_initial_dcid(ngtcp2_conn *conn) {
   return &conn->rcid;
 }
 
-uint32_t ngtcp2_conn_get_original_version(ngtcp2_conn *conn) {
-  return conn->original_version;
+uint32_t ngtcp2_conn_get_client_chosen_version(ngtcp2_conn *conn) {
+  return conn->client_chosen_version;
 }
 
 uint32_t ngtcp2_conn_get_negotiated_version(ngtcp2_conn *conn) {

--- a/lib/ngtcp2_conn.h
+++ b/lib/ngtcp2_conn.h
@@ -677,7 +677,7 @@ struct ngtcp2_conn {
   /* idle_ts is the time instant when idle timer started. */
   ngtcp2_tstamp idle_ts;
   void *user_data;
-  uint32_t original_version;
+  uint32_t client_chosen_version;
   uint32_t negotiated_version;
   /* flags is bitwise OR of zero or more of NGTCP2_CONN_FLAG_*. */
   uint32_t flags;


### PR DESCRIPTION
client chosen version is a new concept introduced by QUIC Version
Negotiation Draft-07.  Since the current code in ngtcp2 only supports
compatible negotiation inside a single connection attempt, client
chosen version is more suitable than original version.