### PR TITLE
Server other_versions defaults to v1

### DIFF
--- a/examples/h09server.cc
+++ b/examples/h09server.cc
@@ -2003,7 +2003,6 @@ int Server::send_version_negotiation(uint32_t version, const uint8_t *dcid,
 
   if (config.preferred_versions.empty()) {
     *p++ = NGTCP2_PROTO_VER_V1;
-    *p++ = NGTCP2_PROTO_VER_V2_DRAFT;
   } else {
     for (auto v : config.preferred_versions) {
       *p++ = v;
@@ -2445,7 +2444,6 @@ void config_set_default(Config &config) {
   config.initial_rtt = NGTCP2_DEFAULT_INITIAL_RTT;
   config.max_gso_dgrams = 10;
   config.handshake_timeout = NGTCP2_DEFAULT_HANDSHAKE_TIMEOUT;
-  config.other_versions = {NGTCP2_PROTO_VER_V1, NGTCP2_PROTO_VER_V2_DRAFT};
 }
 } // namespace
 
@@ -2919,10 +2917,6 @@ int main(int argc, char **argv) {
       }
       case 28: {
         // --other-versions
-        if (strlen(optarg) == 0) {
-          config.other_versions.resize(0);
-          break;
-        }
         auto l = util::split_str(optarg);
         config.other_versions.resize(l.size());
         auto it = std::begin(config.other_versions);

--- a/examples/server.cc
+++ b/examples/server.cc
@@ -2672,7 +2672,6 @@ int Server::send_version_negotiation(uint32_t version, const uint8_t *dcid,
 
   if (config.preferred_versions.empty()) {
     *p++ = NGTCP2_PROTO_VER_V1;
-    *p++ = NGTCP2_PROTO_VER_V2_DRAFT;
   } else {
     for (auto v : config.preferred_versions) {
       *p++ = v;
@@ -3117,7 +3116,6 @@ void config_set_default(Config &config) {
   config.initial_rtt = NGTCP2_DEFAULT_INITIAL_RTT;
   config.max_gso_dgrams = 10;
   config.handshake_timeout = NGTCP2_DEFAULT_HANDSHAKE_TIMEOUT;
-  config.other_versions = {NGTCP2_PROTO_VER_V1, NGTCP2_PROTO_VER_V2_DRAFT};
 }
 } // namespace
 
@@ -3623,10 +3621,6 @@ int main(int argc, char **argv) {
       }
       case 28: {
         // --other-versions
-        if (strlen(optarg) == 0) {
-          config.other_versions.resize(0);
-          break;
-        }
         auto l = util::split_str(optarg);
         config.other_versions.resize(l.size());
         auto it = std::begin(config.other_versions);

--- a/lib/includes/ngtcp2/ngtcp2.h
+++ b/lib/includes/ngtcp2/ngtcp2.h
@@ -1873,8 +1873,11 @@ typedef struct ngtcp2_settings {
    * field of outgoing version_information QUIC transport parameter.
    *
    * For server, this corresponds to Fully-Deployed Versions in QUIC
-   * Version Negotiation draft.  Server which sends Version
-   * Negotiation packet must specify this field with non-empty array.
+   * Version Negotiation draft.  If this field is set not, it is set
+   * to :member:`preferred_versions` internally if
+   * :member:`preferred_versionslen` is not zero.  If this field is
+   * not set, and :member:`preferred_versionslen` is zero, this field
+   * is set to :macro:`NGTCP2_PROTO_VER_V1` internally.
    *
    * Client must include |client_chosen_version| passed to
    * `ngtcp2_conn_client_new` in this array if this field is set and


### PR DESCRIPTION
This commit makes server other_versions default to v1.  server VN is
adjusted to reflect this and now it sends only v1 (+ a reserved
version) in VN.  The side effect of this change is that we cannot
specify empty other_versions field.  But since other_versions cannot
be empty on incompatible version negotiation, we almost always need
non-empty server other_versions.