### PR TITLE
Minor config changes to simpleclient

### DIFF
--- a/examples/simpleclient.c
+++ b/examples/simpleclient.c
@@ -250,6 +250,9 @@ static int client_ssl_init(struct client *c) {
     SSL_set_tlsext_host_name(c->ssl, REMOTE_HOST);
   }
 
+  /* For NGTCP2_PROTO_VER_V1 */
+  SSL_set_quic_transport_version(c->ssl, TLSEXT_TYPE_quic_transport_parameters);
+
   return 0;
 }
 
@@ -405,6 +408,7 @@ static int client_quic_init(struct client *c,
   ngtcp2_transport_params_default(&params);
 
   params.initial_max_streams_uni = 3;
+  params.initial_max_streams_bidi = 3;
   params.initial_max_stream_data_bidi_local = 128 * 1024;
   params.initial_max_data = 1024 * 1024;
 


### PR DESCRIPTION
I was playing around with using simpleclient to connect to meta servers and
found some incorrectly configured settings:
* The quic transport is mismatched between openssl layer and ngtcp2 causing meta servers to reject with fizz exception.
* The default max streams for bidi is 0 and meta server was rejecting with STOP_SENDING frame.