### PR TITLE
Send PMTUD when there is no Handshake CRYPTO to send

### DIFF
--- a/lib/ngtcp2_conn.c
+++ b/lib/ngtcp2_conn.c
@@ -11632,7 +11632,9 @@ ngtcp2_ssize ngtcp2_conn_write_vmsg(ngtcp2_conn *conn, ngtcp2_path *path,
           }
         }
 
-        if (conn->pmtud) {
+        if (conn->pmtud &&
+            (!conn->hs_pktns ||
+             ngtcp2_ksl_len(&conn->hs_pktns->crypto.tx.frq) == 0)) {
           nwrite = conn_write_pmtud_probe(conn, pi, dest, origdestlen, ts);
           if (nwrite) {
             goto fin;


### PR DESCRIPTION
Send PMTUD when there is no Handshake CRYPTO to send in order not to
interfere multi-packet Handshake messages from client(e.g., client
certificate).  Saving CWND for Handshake CRYPTO is also nice in early
phase of the connection.