### PR TITLE
Add functions to encode/decode transport parameters directly

### DIFF
--- a/crypto/boringssl/boringssl.c
+++ b/crypto/boringssl/boringssl.c
@@ -455,24 +455,13 @@ int ngtcp2_crypto_read_write_crypto_data(ngtcp2_conn *conn,
 
 int ngtcp2_crypto_set_remote_transport_params(ngtcp2_conn *conn, void *tls) {
   SSL *ssl = tls;
-  ngtcp2_transport_params_type exttype =
-      ngtcp2_conn_is_server(conn)
-          ? NGTCP2_TRANSPORT_PARAMS_TYPE_CLIENT_HELLO
-          : NGTCP2_TRANSPORT_PARAMS_TYPE_ENCRYPTED_EXTENSIONS;
   const uint8_t *tp;
   size_t tplen;
-  ngtcp2_transport_params params;
   int rv;
 
   SSL_get_peer_quic_transport_params(ssl, &tp, &tplen);
 
-  rv = ngtcp2_decode_transport_params(&params, exttype, tp, tplen);
-  if (rv != 0) {
-    ngtcp2_conn_set_tls_error(conn, rv);
-    return -1;
-  }
-
-  rv = ngtcp2_conn_set_remote_transport_params(conn, &params);
+  rv = ngtcp2_conn_decode_remote_transport_params(conn, tp, tplen);
   if (rv != 0) {
     ngtcp2_conn_set_tls_error(conn, rv);
     return -1;

--- a/crypto/openssl/openssl.c
+++ b/crypto/openssl/openssl.c
@@ -646,24 +646,13 @@ int ngtcp2_crypto_read_write_crypto_data(ngtcp2_conn *conn,
 
 int ngtcp2_crypto_set_remote_transport_params(ngtcp2_conn *conn, void *tls) {
   SSL *ssl = tls;
-  ngtcp2_transport_params_type exttype =
-      ngtcp2_conn_is_server(conn)
-          ? NGTCP2_TRANSPORT_PARAMS_TYPE_CLIENT_HELLO
-          : NGTCP2_TRANSPORT_PARAMS_TYPE_ENCRYPTED_EXTENSIONS;
   const uint8_t *tp;
   size_t tplen;
-  ngtcp2_transport_params params;
   int rv;
 
   SSL_get_peer_quic_transport_params(ssl, &tp, &tplen);
 
-  rv = ngtcp2_decode_transport_params(&params, exttype, tp, tplen);
-  if (rv != 0) {
-    ngtcp2_conn_set_tls_error(conn, rv);
-    return -1;
-  }
-
-  rv = ngtcp2_conn_set_remote_transport_params(conn, &params);
+  rv = ngtcp2_conn_decode_remote_transport_params(conn, tp, tplen);
   if (rv != 0) {
     ngtcp2_conn_set_tls_error(conn, rv);
     return -1;

--- a/crypto/shared.c
+++ b/crypto/shared.c
@@ -326,17 +326,10 @@ fail:
  * This function returns 0 if it succeeds, or -1.
  */
 static int crypto_set_local_transport_params(ngtcp2_conn *conn, void *tls) {
-  ngtcp2_transport_params_type exttype =
-      ngtcp2_conn_is_server(conn)
-          ? NGTCP2_TRANSPORT_PARAMS_TYPE_ENCRYPTED_EXTENSIONS
-          : NGTCP2_TRANSPORT_PARAMS_TYPE_CLIENT_HELLO;
-  ngtcp2_transport_params params;
   ngtcp2_ssize nwrite;
   uint8_t buf[256];
 
-  ngtcp2_conn_get_local_transport_params(conn, &params);
-
-  nwrite = ngtcp2_encode_transport_params(buf, sizeof(buf), exttype, &params);
+  nwrite = ngtcp2_conn_encode_local_transport_params(conn, buf, sizeof(buf));
   if (nwrite < 0) {
     return -1;
   }

--- a/examples/tls_client_session_picotls.cc
+++ b/examples/tls_client_session_picotls.cc
@@ -54,19 +54,14 @@ TLSClientSession::~TLSClientSession() {
 namespace {
 int set_additional_extensions(ptls_handshake_properties_t &hsprops,
                               ngtcp2_conn *conn) {
-  ngtcp2_transport_params params;
-
-  ngtcp2_conn_get_local_transport_params(conn, &params);
-
   constexpr size_t paramsbuflen = 256;
   auto paramsbuf = std::make_unique<uint8_t[]>(paramsbuflen);
 
-  auto nwrite = ngtcp2_encode_transport_params(
-      paramsbuf.get(), paramsbuflen, NGTCP2_TRANSPORT_PARAMS_TYPE_CLIENT_HELLO,
-      &params);
+  auto nwrite = ngtcp2_conn_encode_local_transport_params(conn, paramsbuf.get(),
+                                                          paramsbuflen);
   if (nwrite < 0) {
-    std::cerr << "ngtcp2_encode_transport_params: " << ngtcp2_strerror(nwrite)
-              << std::endl;
+    std::cerr << "ngtcp2_conn_encode_local_transport_params: "
+              << ngtcp2_strerror(nwrite) << std::endl;
     return -1;
   }
 
@@ -105,21 +100,10 @@ int collected_extensions(ptls_t *ptls,
   auto c = static_cast<ClientBase *>(*ptls_get_data_ptr(ptls));
   auto conn = c->conn();
 
-  ngtcp2_transport_params params;
-
-  if (auto rv = ngtcp2_decode_transport_params(
-          &params, NGTCP2_TRANSPORT_PARAMS_TYPE_ENCRYPTED_EXTENSIONS,
-          extensions->data.base, extensions->data.len);
+  if (auto rv = ngtcp2_conn_decode_remote_transport_params(
+          conn, extensions->data.base, extensions->data.len);
       rv != 0) {
-    std::cerr << "ngtcp2_decode_transport_params: " << ngtcp2_strerror(rv)
-              << std::endl;
-    ngtcp2_conn_set_tls_error(conn, rv);
-    return -1;
-  }
-
-  if (auto rv = ngtcp2_conn_set_remote_transport_params(conn, &params);
-      rv != 0) {
-    std::cerr << "ngtcp2_conn_set_remote_transport_params: "
+    std::cerr << "ngtcp2_conn_decode_remote_transport_params: "
               << ngtcp2_strerror(rv) << std::endl;
     ngtcp2_conn_set_tls_error(conn, rv);
     return -1;

--- a/examples/tls_server_context_picotls.cc
+++ b/examples/tls_server_context_picotls.cc
@@ -39,19 +39,14 @@ extern Config config;
 namespace {
 int set_additional_extensions(ptls_handshake_properties_t &hsprops,
                               ngtcp2_conn *conn) {
-  ngtcp2_transport_params params;
-
-  ngtcp2_conn_get_local_transport_params(conn, &params);
-
   constexpr size_t paramsbuflen = 256;
   auto paramsbuf = std::make_unique<uint8_t[]>(paramsbuflen);
 
-  auto nwrite = ngtcp2_encode_transport_params(
-      paramsbuf.get(), paramsbuflen,
-      NGTCP2_TRANSPORT_PARAMS_TYPE_ENCRYPTED_EXTENSIONS, &params);
+  auto nwrite = ngtcp2_conn_encode_local_transport_params(conn, paramsbuf.get(),
+                                                          paramsbuflen);
   if (nwrite < 0) {
-    std::cerr << "ngtcp2_encode_transport_params: " << ngtcp2_strerror(nwrite)
-              << std::endl;
+    std::cerr << "ngtcp2_conn_encode_local_transport_params: "
+              << ngtcp2_strerror(nwrite) << std::endl;
     return -1;
   }
 

--- a/examples/tls_server_session_gnutls.cc
+++ b/examples/tls_server_session_gnutls.cc
@@ -135,20 +135,9 @@ int set_remote_transport_params(const HandlerBase *handler, const uint8_t *data,
                                 size_t datalen) {
   auto conn = handler->conn();
 
-  ngtcp2_transport_params params;
-
-  if (auto rv = ngtcp2_decode_transport_params(
-          &params, NGTCP2_TRANSPORT_PARAMS_TYPE_CLIENT_HELLO, data, datalen);
+  if (auto rv = ngtcp2_conn_decode_remote_transport_params(conn, data, datalen);
       rv != 0) {
-    std::cerr << "ngtcp2_decode_transport_params: " << ngtcp2_strerror(rv)
-              << std::endl;
-    ngtcp2_conn_set_tls_error(conn, rv);
-    return -1;
-  }
-
-  if (auto rv = ngtcp2_conn_set_remote_transport_params(conn, &params);
-      rv != 0) {
-    std::cerr << "ngtcp2_conn_set_remote_transport_params: "
+    std::cerr << "ngtcp2_conn_decode_remote_transport_params: "
               << ngtcp2_strerror(rv) << std::endl;
     ngtcp2_conn_set_tls_error(conn, rv);
     return -1;
@@ -174,17 +163,13 @@ int append_local_transport_params(const HandlerBase *handler,
                                   gnutls_buffer_t extdata) {
   auto conn = handler->conn();
 
-  ngtcp2_transport_params params;
-  ngtcp2_conn_get_local_transport_params(conn, &params);
-
   std::array<uint8_t, 256> buf;
 
-  auto nwrite = ngtcp2_encode_transport_params(
-      buf.data(), buf.size(), NGTCP2_TRANSPORT_PARAMS_TYPE_ENCRYPTED_EXTENSIONS,
-      &params);
+  auto nwrite =
+      ngtcp2_conn_encode_local_transport_params(conn, buf.data(), buf.size());
   if (nwrite < 0) {
-    std::cerr << "ngtcp2_encode_transport_params: " << ngtcp2_strerror(nwrite)
-              << std::endl;
+    std::cerr << "ngtcp2_conn_encode_local_transport_params: "
+              << ngtcp2_strerror(nwrite) << std::endl;
     return -1;
   }
 

--- a/examples/tls_server_session_picotls.cc
+++ b/examples/tls_server_session_picotls.cc
@@ -58,21 +58,10 @@ int collected_extensions(ptls_t *ptls,
   auto h = static_cast<HandlerBase *>(*ptls_get_data_ptr(ptls));
   auto conn = h->conn();
 
-  ngtcp2_transport_params params;
-
-  if (auto rv = ngtcp2_decode_transport_params(
-          &params, NGTCP2_TRANSPORT_PARAMS_TYPE_CLIENT_HELLO,
-          extensions->data.base, extensions->data.len);
+  if (auto rv = ngtcp2_conn_decode_remote_transport_params(
+          conn, extensions->data.base, extensions->data.len);
       rv != 0) {
-    std::cerr << "ngtcp2_decode_transport_params: " << ngtcp2_strerror(rv)
-              << std::endl;
-    ngtcp2_conn_set_tls_error(conn, rv);
-    return -1;
-  }
-
-  if (auto rv = ngtcp2_conn_set_remote_transport_params(conn, &params);
-      rv != 0) {
-    std::cerr << "ngtcp2_conn_set_remote_transport_params: "
+    std::cerr << "ngtcp2_conn_decode_remote_transport_params: "
               << ngtcp2_strerror(rv) << std::endl;
     ngtcp2_conn_set_tls_error(conn, rv);
     return -1;

--- a/lib/includes/ngtcp2/ngtcp2.h
+++ b/lib/includes/ngtcp2/ngtcp2.h
@@ -3967,18 +3967,48 @@ NGTCP2_EXTERN ngtcp2_duration ngtcp2_conn_get_pto(ngtcp2_conn *conn);
  * @function
  *
  * `ngtcp2_conn_set_remote_transport_params` sets transport parameter
- * |params| to |conn|.
+ * |params| from a remote endpoint to |conn|.
  *
  * This function returns 0 if it succeeds, or one of the following
  * negative error codes:
  *
- * :macro:`NGTCP2_ERR_PROTO`
- *     If |conn| is server, and negotiated_version field is not the
- *     same as the used version.
+ * :macro:`NGTCP2_ERR_TRANSPORT_PARAM`
+ *     Failed to validate a remote transport parameters.
+ * :macro:`NGTCP2_ERR_VERSION_NEGOTIATION_FAILURE`
+ *     Version negotiation failure.
+ * :macro:`NGTCP2_ERR_CALLBACK_FAILURE`
+ *     User callback failed
  */
 NGTCP2_EXTERN int ngtcp2_conn_set_remote_transport_params_versioned(
     ngtcp2_conn *conn, int transport_params_version,
     const ngtcp2_transport_params *params);
+
+/**
+ * @function
+ *
+ * `ngtcp2_conn_decode_remote_transport_params` decodes QUIC transport
+ * parameters from the buffer pointed by |data| of length |datalen|,
+ * and sets the result to |conn|.  This is equivalent to calling
+ * `ngtcp2_decode_transport_params` and then
+ * `ngtcp2_conn_set_remote_transport_params`.
+ *
+ * This function returns 0 if it succeeds, or one of the following
+ * negative error codes:
+ *
+ * :macro:`NGTCP2_ERR_REQUIRED_TRANSPORT_PARAM`
+ *     The required parameter is missing.
+ * :macro:`NGTCP2_ERR_MALFORMED_TRANSPORT_PARAM`
+ *     The input is malformed.
+ * :macro:`NGTCP2_ERR_TRANSPORT_PARAM`
+ *     Failed to validate the remote QUIC transport parameters.
+ * :macro:`NGTCP2_ERR_VERSION_NEGOTIATION_FAILURE`
+ *     Version negotiation failure.
+ * :macro:`NGTCP2_ERR_CALLBACK_FAILURE`
+ *     User callback failed
+ */
+NGTCP2_EXTERN int
+ngtcp2_conn_decode_remote_transport_params(ngtcp2_conn *conn,
+                                           const uint8_t *data, size_t datalen);
 
 /**
  * @function
@@ -4058,6 +4088,23 @@ NGTCP2_EXTERN int ngtcp2_conn_set_local_transport_params_versioned(
 NGTCP2_EXTERN void ngtcp2_conn_get_local_transport_params_versioned(
     ngtcp2_conn *conn, int transport_params_version,
     ngtcp2_transport_params *params);
+
+/**
+ * @function
+ *
+ * `ngtcp2_conn_encode_local_transport_params` encodes the local QUIC
+ * transport parameters in |dest| of length |destlen|.  This is
+ * equivalent to calling `ngtcp2_conn_get_local_transport_params` and
+ * then `ngtcp2_encode_transport_params`.
+ *
+ * This function returns the number of written, or one of the
+ * following negative error codes:
+ *
+ * :macro:`NGTCP2_ERR_NOBUF`
+ *     Buffer is too small.
+ */
+NGTCP2_EXTERN ngtcp2_ssize ngtcp2_conn_encode_local_transport_params(
+    ngtcp2_conn *conn, uint8_t *dest, size_t destlen);
 
 /**
  * @function


### PR DESCRIPTION
Add functions to encode or decode transport parameters from or to
ngtcp2_conn directly.