### PR TITLE
Make ngtcp2_conn_get_local_transport_params return pointer

### DIFF
--- a/examples/server.cc
+++ b/examples/server.cc
@@ -1239,11 +1239,10 @@ int Handler::setup_httpconn() {
     return -1;
   }
 
-  ngtcp2_transport_params params;
-  ngtcp2_conn_get_local_transport_params(conn_, &params);
+  auto params = ngtcp2_conn_get_local_transport_params(conn_);
 
   nghttp3_conn_set_max_client_streams_bidi(httpconn_,
-                                           params.initial_max_streams_bidi);
+                                           params->initial_max_streams_bidi);
 
   int64_t ctrl_stream_id;
 

--- a/lib/includes/ngtcp2/ngtcp2.h
+++ b/lib/includes/ngtcp2/ngtcp2.h
@@ -4155,12 +4155,11 @@ NGTCP2_EXTERN int ngtcp2_conn_set_local_transport_params_versioned(
 /**
  * @function
  *
- * `ngtcp2_conn_get_local_transport_params` fills settings values in
- * |params|.
+ * `ngtcp2_conn_get_local_transport_params` returns a pointer to the
+ * local QUIC transport parameters.
  */
-NGTCP2_EXTERN void ngtcp2_conn_get_local_transport_params_versioned(
-    ngtcp2_conn *conn, int transport_params_version,
-    ngtcp2_transport_params *params);
+NGTCP2_EXTERN const ngtcp2_transport_params *
+ngtcp2_conn_get_local_transport_params(ngtcp2_conn *conn);
 
 /**
  * @function
@@ -5725,15 +5724,6 @@ NGTCP2_EXTERN uint32_t ngtcp2_select_version(const uint32_t *preferred_versions,
  */
 #define ngtcp2_conn_set_local_transport_params(CONN, PARAMS)                   \
   ngtcp2_conn_set_local_transport_params_versioned(                            \
-      (CONN), NGTCP2_TRANSPORT_PARAMS_VERSION, (PARAMS))
-
-/*
- * `ngtcp2_conn_get_local_transport_params` is a wrapper around
- * `ngtcp2_conn_get_local_transport_params_versioned` to set the
- * correct struct version.
- */
-#define ngtcp2_conn_get_local_transport_params(CONN, PARAMS)                   \
-  ngtcp2_conn_get_local_transport_params_versioned(                            \
       (CONN), NGTCP2_TRANSPORT_PARAMS_VERSION, (PARAMS))
 
 /*

--- a/lib/ngtcp2_conn.c
+++ b/lib/ngtcp2_conn.c
@@ -11328,12 +11328,9 @@ int ngtcp2_conn_commit_local_transport_params(ngtcp2_conn *conn) {
   return 0;
 }
 
-void ngtcp2_conn_get_local_transport_params_versioned(
-    ngtcp2_conn *conn, int transport_params_version,
-    ngtcp2_transport_params *params) {
-  (void)transport_params_version;
-
-  *params = conn->local.transport_params;
+const ngtcp2_transport_params *
+ngtcp2_conn_get_local_transport_params(ngtcp2_conn *conn) {
+  return &conn->local.transport_params;
 }
 
 ngtcp2_ssize ngtcp2_conn_encode_local_transport_params(ngtcp2_conn *conn,


### PR DESCRIPTION
Make ngtcp2_conn_get_local_transport_params return a pointer to the
stored object.