### PR TITLE
Disable the internal session cache if TLS session is stored externally

### DIFF
--- a/examples/tls_client_context_boringssl.cc
+++ b/examples/tls_client_context_boringssl.cc
@@ -101,7 +101,7 @@ int TLSClientContext::init(const char *private_key_file,
 
   if (config.session_file) {
     SSL_CTX_set_session_cache_mode(
-        ssl_ctx_, SSL_SESS_CACHE_CLIENT | SSL_SESS_CACHE_NO_INTERNAL_STORE);
+        ssl_ctx_, SSL_SESS_CACHE_CLIENT | SSL_SESS_CACHE_NO_INTERNAL);
     SSL_CTX_sess_set_new_cb(ssl_ctx_, new_session_cb);
   }
 

--- a/examples/tls_client_context_openssl.cc
+++ b/examples/tls_client_context_openssl.cc
@@ -112,7 +112,7 @@ int TLSClientContext::init(const char *private_key_file,
 
   if (config.session_file) {
     SSL_CTX_set_session_cache_mode(
-        ssl_ctx_, SSL_SESS_CACHE_CLIENT | SSL_SESS_CACHE_NO_INTERNAL_STORE);
+        ssl_ctx_, SSL_SESS_CACHE_CLIENT | SSL_SESS_CACHE_NO_INTERNAL);
     SSL_CTX_sess_set_new_cb(ssl_ctx_, new_session_cb);
   }
 


### PR DESCRIPTION
Since TLS session has been stored externally, I feel that there is no need to enable session caching in OpenSSL and BoringSSL, just like [what Google QUICHE does](https://github.com/google/quiche/blob/74aa2867de8e650809d85cd6454aca4200ec6e36/quiche/quic/core/crypto/tls_client_connection.cc#L24-L27).