### PR TITLE
Define WIN32_LEAN_AND_MEAN before ws2tcpip.h

### DIFF
--- a/crypto/includes/ngtcp2/ngtcp2_crypto.h
+++ b/crypto/includes/ngtcp2/ngtcp2_crypto.h
@@ -32,6 +32,9 @@ extern "C" {
 #endif
 
 #ifdef WIN32
+#  ifndef WIN32_LEAN_AND_MEAN
+#    define WIN32_LEAN_AND_MEAN
+#  endif
 #  include <ws2tcpip.h>
 #endif /* WIN32 */
 

--- a/lib/includes/ngtcp2/ngtcp2.h
+++ b/lib/includes/ngtcp2/ngtcp2.h
@@ -52,6 +52,9 @@
 
 #ifndef NGTCP2_USE_GENERIC_SOCKADDR
 #  ifdef WIN32
+#    ifndef WIN32_LEAN_AND_MEAN
+#      define WIN32_LEAN_AND_MEAN
+#    endif
 #    include <ws2tcpip.h>
 #  else
 #    include <sys/socket.h>


### PR DESCRIPTION
Including `ws2tcpip.h` ends up including `wincrypt.h` which defines symbols which collide with OpenSSL structures, such as `X509_NAME`, unless `WIN32_LEAN_AND_MEAN` is present.