### PR TITLE
fix ngtcp2_htons for windows

### DIFF
--- a/lib/ngtcp2_net.h
+++ b/lib/ngtcp2_net.h
@@ -101,7 +101,7 @@ STIN uint32_t ngtcp2_htonl(uint32_t hostlong) {
 STIN uint16_t ngtcp2_htons(uint16_t hostshort) {
   uint16_t res;
   unsigned char *p = (unsigned char *)&res;
-  *p++ = (unsigned char)hostshort >> 8;
+  *p++ = (unsigned char)(hostshort >> 8);
   *p = hostshort & 0xffu;
   return res;
 }


### PR DESCRIPTION
Fixed a problem with endian conversion in windows.
There was a problem with the lower octet always being zero.