### PR TITLE
Tweak condition of stream closure

### DIFF
--- a/tests/ngtcp2_conn_test.c
+++ b/tests/ngtcp2_conn_test.c
@@ -8248,6 +8248,65 @@ void test_ngtcp2_conn_stream_close(void) {
   CU_ASSERT(NGTCP2_APP_ERR01 == ud.stream_close.app_error_code);
 
   ngtcp2_conn_del(conn);
+
+  /* Client sends STREAM fin and then RESET_STREAM.  It receives ACK
+     for the STREAM frame, then response fin. No ACK for
+     RESET_STREAM. */
+  pkt_num = 0;
+
+  setup_default_client(&conn);
+  conn->callbacks.stream_close = stream_close;
+  conn->user_data = &ud;
+
+  rv = ngtcp2_conn_open_bidi_stream(conn, &stream_id, NULL);
+
+  CU_ASSERT(0 == rv);
+
+  spktlen = ngtcp2_conn_write_stream(conn, NULL, NULL, buf, sizeof(buf), NULL,
+                                     NGTCP2_WRITE_STREAM_FLAG_FIN, stream_id,
+                                     null_data, 1, ++t);
+
+  CU_ASSERT(spktlen > 0);
+
+  rv = ngtcp2_conn_shutdown_stream_write(conn, stream_id, NGTCP2_APP_ERR01);
+
+  CU_ASSERT(0 == rv);
+
+  frs[0].type = NGTCP2_FRAME_STREAM;
+  frs[0].stream.flags = 0;
+  frs[0].stream.fin = 1;
+  frs[0].stream.stream_id = stream_id;
+  frs[0].stream.offset = 0;
+  frs[0].stream.datacnt = 0;
+
+  frs[1].type = NGTCP2_FRAME_ACK;
+  frs[1].ack.largest_ack = conn->pktns.tx.last_pkt_num;
+  frs[1].ack.ack_delay = 0;
+  frs[1].ack.first_ack_blklen = 0;
+  frs[1].ack.num_blks = 0;
+
+  spktlen =
+      ngtcp2_conn_write_stream(conn, NULL, NULL, buf, sizeof(buf), NULL,
+                               NGTCP2_WRITE_STREAM_FLAG_NONE, -1, NULL, 0, ++t);
+
+  CU_ASSERT(spktlen > 0);
+
+  pktlen = write_pkt(buf, sizeof(buf), &conn->oscid, ++pkt_num, frs, 2,
+                     conn->pktns.crypto.tx.ckm);
+
+  ud.stream_close.flags = NGTCP2_STREAM_CLOSE_FLAG_NONE;
+  ud.stream_close.stream_id = -1;
+  ud.stream_close.app_error_code = 0;
+
+  rv = ngtcp2_conn_read_pkt(conn, &null_path.path, &null_pi, buf, pktlen, ++t);
+
+  CU_ASSERT(0 == rv);
+  CU_ASSERT(NGTCP2_STREAM_CLOSE_FLAG_APP_ERROR_CODE_SET &
+            ud.stream_close.flags);
+  CU_ASSERT(stream_id == ud.stream_close.stream_id);
+  CU_ASSERT(NGTCP2_APP_ERR01 == ud.stream_close.app_error_code);
+
+  ngtcp2_conn_del(conn);
 }
 
 void test_ngtcp2_conn_buffer_pkt(void) {


### PR DESCRIPTION
If STOP_SENDING is sent, either wait for RESET_STREAM or ACKs that
acknowledge all STREAM data up to fin.

We do not wait for ACK for RESET_STREAM if all tx data have been
acknowledged.