### PR TITLE
Remove return value from ngtcp2_conn_early_data_rejected()

### DIFF
--- a/crypto/boringssl/boringssl.c
+++ b/crypto/boringssl/boringssl.c
@@ -417,10 +417,7 @@ int ngtcp2_crypto_read_write_crypto_data(ngtcp2_conn *conn,
 
         SSL_reset_early_data_reject(ssl);
 
-        rv = ngtcp2_conn_early_data_rejected(conn);
-        if (rv != 0) {
-          return -1;
-        }
+        ngtcp2_conn_early_data_rejected(conn);
 
         goto retry;
       default:

--- a/crypto/picotls/picotls.c
+++ b/crypto/picotls/picotls.c
@@ -379,10 +379,7 @@ int ngtcp2_crypto_read_write_crypto_data(ngtcp2_conn *conn,
   if (!ngtcp2_conn_is_server(conn) &&
       cptls->handshake_properties.client.early_data_acceptance ==
           PTLS_EARLY_DATA_REJECTED) {
-    if (ngtcp2_conn_early_data_rejected(conn) != 0) {
-      rv = -1;
-      goto fin;
-    }
+    ngtcp2_conn_early_data_rejected(conn);
   }
 
   for (i = 0; i < 4; ++i) {

--- a/examples/client.cc
+++ b/examples/client.cc
@@ -301,11 +301,7 @@ int Client::handshake_completed() {
       std::cerr << "Early data was rejected by server" << std::endl;
     }
 
-    if (auto rv = ngtcp2_conn_early_data_rejected(conn_); rv != 0) {
-      std::cerr << "ngtcp2_conn_early_data_rejected: " << ngtcp2_strerror(rv)
-                << std::endl;
-      return -1;
-    }
+    ngtcp2_conn_early_data_rejected(conn_);
 
     nghttp3_conn_del(httpconn_);
     httpconn_ = nullptr;

--- a/examples/h09client.cc
+++ b/examples/h09client.cc
@@ -295,11 +295,7 @@ int Client::handshake_completed() {
       std::cerr << "Early data was rejected by server" << std::endl;
     }
 
-    if (auto rv = ngtcp2_conn_early_data_rejected(conn_); rv != 0) {
-      std::cerr << "ngtcp2_conn_early_data_rejected: " << ngtcp2_strerror(rv)
-                << std::endl;
-      return -1;
-    }
+    ngtcp2_conn_early_data_rejected(conn_);
 
     nstreams_done_ = 0;
     streams_.clear();

--- a/lib/includes/ngtcp2/ngtcp2.h
+++ b/lib/includes/ngtcp2/ngtcp2.h
@@ -4791,7 +4791,7 @@ NGTCP2_EXTERN uint32_t ngtcp2_conn_get_negotiated_version(ngtcp2_conn *conn);
  * Application which wishes to retransmit early data, it has to open
  * streams and send stream data again.
  */
-NGTCP2_EXTERN int ngtcp2_conn_early_data_rejected(ngtcp2_conn *conn);
+NGTCP2_EXTERN void ngtcp2_conn_early_data_rejected(ngtcp2_conn *conn);
 
 /**
  * @function

--- a/lib/ngtcp2_conn.c
+++ b/lib/ngtcp2_conn.c
@@ -12505,16 +12505,14 @@ static void conn_discard_early_data_state(ngtcp2_conn *conn) {
   }
 }
 
-int ngtcp2_conn_early_data_rejected(ngtcp2_conn *conn) {
+void ngtcp2_conn_early_data_rejected(ngtcp2_conn *conn) {
   if (conn->flags & NGTCP2_CONN_FLAG_EARLY_DATA_REJECTED) {
-    return 0;
+    return;
   }
 
   conn->flags |= NGTCP2_CONN_FLAG_EARLY_DATA_REJECTED;
 
   conn_discard_early_data_state(conn);
-
-  return 0;
 }
 
 int ngtcp2_conn_update_rtt(ngtcp2_conn *conn, ngtcp2_duration rtt,


### PR DESCRIPTION
ngtcp2_conn_early_data_rejected() always returns 0.