### PR TITLE
Do not return NGTCP2_ERR_STREAM_NOT_FOUND

### DIFF
--- a/examples/client.cc
+++ b/examples/client.cc
@@ -1940,9 +1940,6 @@ int Client::stop_sending(int64_t stream_id, uint64_t app_error_code) {
       rv != 0) {
     std::cerr << "ngtcp2_conn_shutdown_stream_read: " << ngtcp2_strerror(rv)
               << std::endl;
-    if (rv == NGTCP2_ERR_STREAM_NOT_FOUND) {
-      return 0;
-    }
     return -1;
   }
   return 0;
@@ -1966,9 +1963,6 @@ int Client::reset_stream(int64_t stream_id, uint64_t app_error_code) {
       rv != 0) {
     std::cerr << "ngtcp2_conn_shutdown_stream_write: " << ngtcp2_strerror(rv)
               << std::endl;
-    if (rv == NGTCP2_ERR_STREAM_NOT_FOUND) {
-      return 0;
-    }
     return -1;
   }
   return 0;

--- a/examples/server.cc
+++ b/examples/server.cc
@@ -1164,9 +1164,6 @@ int Handler::http_stop_sending(int64_t stream_id, uint64_t app_error_code) {
       rv != 0) {
     std::cerr << "ngtcp2_conn_shutdown_stream_read: " << ngtcp2_strerror(rv)
               << std::endl;
-    if (rv == NGTCP2_ERR_STREAM_NOT_FOUND) {
-      return 0;
-    }
     return -1;
   }
   return 0;
@@ -1190,9 +1187,6 @@ int Handler::http_reset_stream(int64_t stream_id, uint64_t app_error_code) {
       rv != 0) {
     std::cerr << "ngtcp2_conn_shutdown_stream_write: " << ngtcp2_strerror(rv)
               << std::endl;
-    if (rv == NGTCP2_ERR_STREAM_NOT_FOUND) {
-      return 0;
-    }
     return -1;
   }
   return 0;

--- a/lib/includes/ngtcp2/ngtcp2.h
+++ b/lib/includes/ngtcp2/ngtcp2.h
@@ -4256,8 +4256,6 @@ NGTCP2_EXTERN int ngtcp2_conn_open_uni_stream(ngtcp2_conn *conn,
  *
  * :macro:`NGTCP2_ERR_NOMEM`
  *     Out of memory
- * :macro:`NGTCP2_ERR_STREAM_NOT_FOUND`
- *     Stream does not exist
  */
 NGTCP2_EXTERN int ngtcp2_conn_shutdown_stream(ngtcp2_conn *conn,
                                               int64_t stream_id,
@@ -4278,8 +4276,6 @@ NGTCP2_EXTERN int ngtcp2_conn_shutdown_stream(ngtcp2_conn *conn,
  *
  * :macro:`NGTCP2_ERR_NOMEM`
  *     Out of memory
- * :macro:`NGTCP2_ERR_STREAM_NOT_FOUND`
- *     Stream does not exist
  */
 NGTCP2_EXTERN int ngtcp2_conn_shutdown_stream_write(ngtcp2_conn *conn,
                                                     int64_t stream_id,
@@ -4299,8 +4295,6 @@ NGTCP2_EXTERN int ngtcp2_conn_shutdown_stream_write(ngtcp2_conn *conn,
  *
  * :macro:`NGTCP2_ERR_NOMEM`
  *     Out of memory
- * :macro:`NGTCP2_ERR_STREAM_NOT_FOUND`
- *     Stream does not exist
  */
 NGTCP2_EXTERN int ngtcp2_conn_shutdown_stream_read(ngtcp2_conn *conn,
                                                    int64_t stream_id,
@@ -4623,8 +4617,8 @@ NGTCP2_EXTERN int ngtcp2_conn_is_in_draining_period(ngtcp2_conn *conn);
  * This function returns 0 if it succeeds, or one of the following
  * negative error codes:
  *
- * :macro:`NGTCP2_ERR_STREAM_NOT_FOUND`
- *     Stream was not found
+ * :macro:`NGTCP2_ERR_NOMEM`
+ *     Out of memory.
  */
 NGTCP2_EXTERN int ngtcp2_conn_extend_max_stream_offset(ngtcp2_conn *conn,
                                                        int64_t stream_id,

--- a/lib/ngtcp2_conn.c
+++ b/lib/ngtcp2_conn.c
@@ -12327,7 +12327,7 @@ int ngtcp2_conn_shutdown_stream(ngtcp2_conn *conn, int64_t stream_id,
 
   strm = ngtcp2_conn_find_stream(conn, stream_id);
   if (strm == NULL) {
-    return NGTCP2_ERR_STREAM_NOT_FOUND;
+    return 0;
   }
 
   rv = conn_shutdown_stream_read(conn, strm, app_error_code);
@@ -12349,7 +12349,7 @@ int ngtcp2_conn_shutdown_stream_write(ngtcp2_conn *conn, int64_t stream_id,
 
   strm = ngtcp2_conn_find_stream(conn, stream_id);
   if (strm == NULL) {
-    return NGTCP2_ERR_STREAM_NOT_FOUND;
+    return 0;
   }
 
   return conn_shutdown_stream_write(conn, strm, app_error_code);
@@ -12361,7 +12361,7 @@ int ngtcp2_conn_shutdown_stream_read(ngtcp2_conn *conn, int64_t stream_id,
 
   strm = ngtcp2_conn_find_stream(conn, stream_id);
   if (strm == NULL) {
-    return NGTCP2_ERR_STREAM_NOT_FOUND;
+    return 0;
   }
 
   return conn_shutdown_stream_read(conn, strm, app_error_code);
@@ -12409,7 +12409,7 @@ int ngtcp2_conn_extend_max_stream_offset(ngtcp2_conn *conn, int64_t stream_id,
 
   strm = ngtcp2_conn_find_stream(conn, stream_id);
   if (strm == NULL) {
-    return NGTCP2_ERR_STREAM_NOT_FOUND;
+    return 0;
   }
 
   return conn_extend_max_stream_offset(conn, strm, datalen);

--- a/tests/ngtcp2_conn_test.c
+++ b/tests/ngtcp2_conn_test.c
@@ -1356,7 +1356,7 @@ void test_ngtcp2_conn_shutdown_stream_write(void) {
 
   rv = ngtcp2_conn_shutdown_stream_write(conn, 4, NGTCP2_APP_ERR01);
 
-  CU_ASSERT(NGTCP2_ERR_STREAM_NOT_FOUND == rv);
+  CU_ASSERT(0 == rv);
 
   ngtcp2_conn_del(conn);
 


### PR DESCRIPTION
Do not return NGTCP2_ERR_STREAM_NOT_FOUND from the following
functions:

- ngtcp2_conn_shutdown_stream
- ngtcp2_conn_shutdown_stream_write
- ngtcp2_conn_shutdown_stream_read
- ngtcp2_conn_extend_max_stream_offset

and returns 0 if a stream is not found.

The reason is that it is too tedious to check
NGTCP2_ERR_STREAM_NOT_FOUND in every invocation for these functions.
In almost all cases, if NGTCP2_ERR_STREAM_NOT_FOUND is returned, we
just simply ignores it and pretend that the function succeeds.