### PR TITLE
User control over PING frames

### DIFF
--- a/examples/client.cc
+++ b/examples/client.cc
@@ -662,6 +662,7 @@ int Client::init(int fd, const Address &local_addr, const Address &remote_addr,
       ngtcp2_crypto_version_negotiation_cb,
       ::recv_rx_key,
       nullptr, // recv_tx_key
+      nullptr, // recv_ping
   };
 
   ngtcp2_cid scid, dcid;

--- a/examples/gtlssimpleclient.c
+++ b/examples/gtlssimpleclient.c
@@ -362,6 +362,7 @@ static int client_quic_init(struct client *c,
       ngtcp2_crypto_version_negotiation_cb,
       NULL, /* recv_rx_key */
       NULL, /* recv_tx_key */
+      NULL, /* recv_ping */
   };
   ngtcp2_cid dcid, scid;
   ngtcp2_settings settings;

--- a/examples/h09client.cc
+++ b/examples/h09client.cc
@@ -612,6 +612,7 @@ int Client::init(int fd, const Address &local_addr, const Address &remote_addr,
       ngtcp2_crypto_version_negotiation_cb,
       nullptr, // recv_rx_key
       nullptr, // recv_tx_key
+      nullptr, // recv_ping
   };
 
   ngtcp2_cid scid, dcid;

--- a/examples/h09server.cc
+++ b/examples/h09server.cc
@@ -709,6 +709,7 @@ int Handler::init(const Endpoint &ep, const Address &local_addr,
       ngtcp2_crypto_version_negotiation_cb,
       nullptr, // recv_rx_key
       nullptr, // recv_tx_key
+      nullptr, // recv_ping
   };
 
   scid_.datalen = NGTCP2_SV_SCIDLEN;

--- a/examples/server.cc
+++ b/examples/server.cc
@@ -1387,6 +1387,7 @@ int Handler::init(const Endpoint &ep, const Address &local_addr,
       ngtcp2_crypto_version_negotiation_cb,
       nullptr, // recv_rx_key
       ::recv_tx_key,
+      nullptr, // recv_ping
   };
 
   scid_.datalen = NGTCP2_SV_SCIDLEN;

--- a/examples/simpleclient.c
+++ b/examples/simpleclient.c
@@ -323,6 +323,7 @@ static int client_quic_init(struct client *c,
       ngtcp2_crypto_version_negotiation_cb,
       NULL, /* recv_rx_key */
       NULL, /* recv_tx_key */
+      NULL, /* recv_ping */
   };
   ngtcp2_cid dcid, scid;
   ngtcp2_settings settings;

--- a/lib/includes/ngtcp2/ngtcp2.h
+++ b/lib/includes/ngtcp2/ngtcp2.h
@@ -3320,6 +3320,17 @@ typedef int (*ngtcp2_version_negotiation)(ngtcp2_conn *conn, uint32_t version,
 typedef int (*ngtcp2_recv_key)(ngtcp2_conn *conn, ngtcp2_crypto_level level,
                                void *user_data);
 
+/**
+ * @functypedef
+ *
+ * :type:`ngtcp2_recv_ping` is invoked when new PING frame is received.
+ *
+ * The callback function must return 0 if it succeeds.  Returning
+ * :macro:`NGTCP2_ERR_CALLBACK_FAILURE` makes the library call return
+ * immediately.
+ */
+typedef int (*ngtcp2_recv_ping)(ngtcp2_conn *conn, void *user_data);
+
 #define NGTCP2_CALLBACKS_VERSION_V1 1
 #define NGTCP2_CALLBACKS_VERSION NGTCP2_CALLBACKS_VERSION_V1
 
@@ -3578,6 +3589,12 @@ typedef struct ngtcp2_callbacks {
    * :enum:`ngtcp2_crypto_level.NGTCP2_CRYPTO_LEVEL_INITIAL`.
    */
   ngtcp2_recv_key recv_tx_key;
+  /**
+   * :member:`recv_ping` is a callback function which is invoked
+   * when a new PING frame is received.  This callback function is
+   * optional.
+   */
+  ngtcp2_recv_ping recv_ping;
 } ngtcp2_callbacks;
 
 /**

--- a/lib/includes/ngtcp2/ngtcp2.h
+++ b/lib/includes/ngtcp2/ngtcp2.h
@@ -4099,6 +4099,13 @@ NGTCP2_EXTERN void ngtcp2_conn_set_keep_alive_timeout(ngtcp2_conn *conn,
 /**
  * @function
  *
+ * `ngtcp2_conn_schedule_ping` schedules PING frame on next write.
+ */
+NGTCP2_EXTERN void ngtcp2_conn_schedule_ping(ngtcp2_conn *conn);
+
+/**
+ * @function
+ *
  * `ngtcp2_conn_get_expiry` returns the next expiry time.
  *
  * Call `ngtcp2_conn_handle_expiry()` and `ngtcp2_conn_write_pkt` (or

--- a/lib/ngtcp2_conn.h
+++ b/lib/ngtcp2_conn.h
@@ -220,6 +220,9 @@ void ngtcp2_path_challenge_entry_init(ngtcp2_path_challenge_entry *pcent,
 /* NGTCP2_CONN_FLAG_KEY_UPDATE_INITIATOR is set when the local
    endpoint has initiated key update. */
 #define NGTCP2_CONN_FLAG_KEY_UPDATE_INITIATOR 0x10000u
+/* NGTCP2_CONN_FLAG_PING_SCHEDULED is set when PING frame
+   should be sent on next write. */
+#define NGTCP2_CONN_FLAG_PING_SCHEDULED 0x20000u
 
 typedef struct ngtcp2_crypto_data {
   ngtcp2_buf buf;


### PR DESCRIPTION
Hello. I'm writing a proxy application betweeen QUIC server and client.

I need to know when one side is receiving a PING frame to send it to the other side.

Setting keep-alive doesn't help, because it hides the control from user application over PING frames anyway.