### PR TITLE
workflow: Run examples/tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,7 +54,8 @@ jobs:
           libev-dev \
           libgnutls28-dev \
           cmake \
-          cmake-data
+          cmake-data \
+          python3-pytest
 
         echo 'NPROC='"$(nproc)" >> $GITHUB_ENV
     - name: MacOS setup
@@ -193,6 +194,13 @@ jobs:
       run: |
         make -j"$NPROC" distcheck \
           DISTCHECK_CONFIGURE_FLAGS="--enable-werror --with-openssl --with-gnutls --with-boringssl $EXTRA_AUTOTOOLS_OPTS"
+    - name: examples/tests
+      if: matrix.buildtool == 'autotools' && matrix.sockaddr == 'native-sockaddr' && runner.os == 'Linux'
+      run: |
+        cd examples/tests
+        # Do not run resumption and earlydata between gtlsserver and
+        # wsslclient until ubuntu gets GnuTLS v3.7.5.
+        pytest-3 -k 'not (gnutls-wolfssl and (resume or earlydata))'
     - name: Integration test
       if: matrix.buildtool != 'distcheck' && matrix.sockaddr == 'native-sockaddr'
       run: |

--- a/ci/build_openssl3.sh
+++ b/ci/build_openssl3.sh
@@ -3,6 +3,6 @@
 
 git clone --depth 1 -b openssl-3.0.5+quic https://github.com/quictls/openssl
 cd openssl
-./config --prefix=$PWD/build
+./config --prefix=$PWD/build --openssldir=/etc/ssl
 make -j"$(nproc 2> /dev/null || sysctl -n hw.ncpu)"
 make install_sw


### PR DESCRIPTION
Specify --openssldir to the system path in order to avoid 'unregistered scheme' error when receiving client certificate, which is a yet another regression introduced in OpenSSL v3.