### PR TITLE
Add ngtcp2_early_data_rejected callback

### DIFF
--- a/crypto/boringssl/boringssl.c
+++ b/crypto/boringssl/boringssl.c
@@ -423,7 +423,10 @@ int ngtcp2_crypto_read_write_crypto_data(ngtcp2_conn *conn,
 
         SSL_reset_early_data_reject(ssl);
 
-        ngtcp2_conn_early_data_rejected(conn);
+        rv = ngtcp2_conn_early_data_rejected(conn);
+        if (rv != 0) {
+          return -1;
+        }
 
         goto retry;
       default:

--- a/crypto/picotls/picotls.c
+++ b/crypto/picotls/picotls.c
@@ -379,7 +379,11 @@ int ngtcp2_crypto_read_write_crypto_data(ngtcp2_conn *conn,
   if (!ngtcp2_conn_is_server(conn) &&
       cptls->handshake_properties.client.early_data_acceptance ==
           PTLS_EARLY_DATA_REJECTED) {
-    ngtcp2_conn_early_data_rejected(conn);
+    rv = ngtcp2_conn_early_data_rejected(conn);
+    if (rv != 0) {
+      rv = -1;
+      goto fin;
+    }
   }
 
   for (i = 0; i < 4; ++i) {

--- a/examples/client.h
+++ b/examples/client.h
@@ -137,6 +137,7 @@ public:
   const std::vector<uint32_t> &get_offered_versions() const;
 
   bool get_early_data() const;
+  void early_data_rejected();
 
 private:
   std::vector<Endpoint> endpoints_;

--- a/examples/gtlssimpleclient.c
+++ b/examples/gtlssimpleclient.c
@@ -362,6 +362,7 @@ static int client_quic_init(struct client *c,
       ngtcp2_crypto_version_negotiation_cb,
       NULL, /* recv_rx_key */
       NULL, /* recv_tx_key */
+      NULL, /* early_data_rejected */
   };
   ngtcp2_cid dcid, scid;
   ngtcp2_settings settings;

--- a/examples/h09client.h
+++ b/examples/h09client.h
@@ -141,6 +141,8 @@ public:
 
   const std::vector<uint32_t> &get_offered_versions() const;
 
+  void early_data_rejected();
+
 private:
   std::vector<Endpoint> endpoints_;
   Address remote_addr_;

--- a/examples/simpleclient.c
+++ b/examples/simpleclient.c
@@ -323,6 +323,7 @@ static int client_quic_init(struct client *c,
       ngtcp2_crypto_version_negotiation_cb,
       NULL, /* recv_rx_key */
       NULL, /* recv_tx_key */
+      NULL, /* early_data_rejected */
   };
   ngtcp2_cid dcid, scid;
   ngtcp2_settings settings;

--- a/lib/includes/ngtcp2/ngtcp2.h
+++ b/lib/includes/ngtcp2/ngtcp2.h
@@ -3319,6 +3319,18 @@ typedef int (*ngtcp2_version_negotiation)(ngtcp2_conn *conn, uint32_t version,
 typedef int (*ngtcp2_recv_key)(ngtcp2_conn *conn, ngtcp2_crypto_level level,
                                void *user_data);
 
+/**
+ * @functypedef
+ *
+ * :type:`ngtcp2_early_data_rejected` is invoked when early data was
+ * rejected by server, or client decided not to attempt early data.
+ *
+ * The callback function must return 0 if it succeeds.  Returning
+ * :macro:`NGTCP2_ERR_CALLBACK_FAILURE` makes the library call return
+ * immediately.
+ */
+typedef int (*ngtcp2_early_data_rejected)(ngtcp2_conn *conn, void *user_data);
+
 #define NGTCP2_CALLBACKS_VERSION_V1 1
 #define NGTCP2_CALLBACKS_VERSION NGTCP2_CALLBACKS_VERSION_V1
 
@@ -3577,6 +3589,13 @@ typedef struct ngtcp2_callbacks {
    * :enum:`ngtcp2_crypto_level.NGTCP2_CRYPTO_LEVEL_INITIAL`.
    */
   ngtcp2_recv_key recv_tx_key;
+  /**
+   * :member:`ngtcp2_early_data_rejected` is a callback function which
+   * is invoked when an attempt to send early data by client was
+   * rejected by server, or client decided not to attempt early data.
+   * This callback function is only used by client.
+   */
+  ngtcp2_early_data_rejected early_data_rejected;
 } ngtcp2_callbacks;
 
 /**
@@ -4816,8 +4835,8 @@ NGTCP2_EXTERN uint32_t ngtcp2_conn_get_negotiated_version(ngtcp2_conn *conn);
  * @function
  *
  * `ngtcp2_conn_early_data_rejected` tells |conn| that early data was
- * rejected by a server.  |conn| discards the following connection
- * states:
+ * rejected by a server, or client decided not to attempt early data
+ * for some reason.  |conn| discards the following connection states:
  *
  * - Any opended streams.
  * - Stream identifier allocations.
@@ -4827,8 +4846,22 @@ NGTCP2_EXTERN uint32_t ngtcp2_conn_get_negotiated_version(ngtcp2_conn *conn);
  *
  * Application which wishes to retransmit early data, it has to open
  * streams and send stream data again.
+ *
+ * This function returns 0 if it succeeds, or one of the following
+ * negative error codes:
+ *
+ * :macro:`NGTCP2_ERR_CALLBACK_FAILURE`
+ *     User callback failed
  */
-NGTCP2_EXTERN void ngtcp2_conn_early_data_rejected(ngtcp2_conn *conn);
+NGTCP2_EXTERN int ngtcp2_conn_early_data_rejected(ngtcp2_conn *conn);
+
+/**
+ * @function
+ *
+ * `ngtcp2_conn_get_early_data_rejected` returns nonzero if
+ * `ngtcp2_conn_early_data_rejected` has been called.
+ */
+NGTCP2_EXTERN int ngtcp2_conn_get_early_data_rejected(ngtcp2_conn *conn);
 
 /**
  * @function

--- a/lib/ngtcp2_conn.c
+++ b/lib/ngtcp2_conn.c
@@ -12586,14 +12586,24 @@ static void conn_discard_early_data_state(ngtcp2_conn *conn) {
   }
 }
 
-void ngtcp2_conn_early_data_rejected(ngtcp2_conn *conn) {
+int ngtcp2_conn_early_data_rejected(ngtcp2_conn *conn) {
   if (conn->flags & NGTCP2_CONN_FLAG_EARLY_DATA_REJECTED) {
-    return;
+    return 0;
   }
 
   conn->flags |= NGTCP2_CONN_FLAG_EARLY_DATA_REJECTED;
 
   conn_discard_early_data_state(conn);
+
+  if (conn->callbacks.early_data_rejected) {
+    return conn->callbacks.early_data_rejected(conn, conn->user_data);
+  }
+
+  return 0;
+}
+
+int ngtcp2_conn_get_early_data_rejected(ngtcp2_conn *conn) {
+  return (conn->flags & NGTCP2_CONN_FLAG_EARLY_DATA_REJECTED) != 0;
 }
 
 int ngtcp2_conn_update_rtt(ngtcp2_conn *conn, ngtcp2_duration rtt,


### PR DESCRIPTION
Add ngtcp2_early_data_rejected callback in order to handle the situation that client decided not to attempt early data before sending its first flight.