### PR TITLE
Rename ngtcp2_get_varint_len and ngtcp2_put_varint_len

### DIFF
--- a/lib/ngtcp2_conv.c
+++ b/lib/ngtcp2_conv.c
@@ -220,11 +220,11 @@ uint8_t *ngtcp2_put_pkt_num(uint8_t *p, int64_t pkt_num, size_t len) {
   }
 }
 
-size_t ngtcp2_get_varint_len(const uint8_t *p) {
+size_t ngtcp2_get_varintlen(const uint8_t *p) {
   return (size_t)(1u << (*p >> 6));
 }
 
-size_t ngtcp2_put_varint_len(uint64_t n) {
+size_t ngtcp2_put_varintlen(uint64_t n) {
   if (n < 64) {
     return 1;
   }

--- a/lib/ngtcp2_conv.h
+++ b/lib/ngtcp2_conv.h
@@ -155,16 +155,16 @@ uint8_t *ngtcp2_put_varint30(uint8_t *p, uint32_t n);
 uint8_t *ngtcp2_put_pkt_num(uint8_t *p, int64_t pkt_num, size_t len);
 
 /*
- * ngtcp2_get_varint_len returns the required number of bytes to read
+ * ngtcp2_get_varintlen returns the required number of bytes to read
  * variable-length integer starting at |p|.
  */
-size_t ngtcp2_get_varint_len(const uint8_t *p);
+size_t ngtcp2_get_varintlen(const uint8_t *p);
 
 /*
- * ngtcp2_put_varint_len returns the required number of bytes to
- * encode |n|.
+ * ngtcp2_put_varintlen returns the required number of bytes to encode
+ * |n|.
  */
-size_t ngtcp2_put_varint_len(uint64_t n);
+size_t ngtcp2_put_varintlen(uint64_t n);
 
 /*
  * ngtcp2_nth_server_bidi_id returns |n|-th server bidirectional

--- a/lib/ngtcp2_crypto.c
+++ b/lib/ngtcp2_crypto.c
@@ -107,8 +107,8 @@ void ngtcp2_crypto_create_nonce(uint8_t *dest, const uint8_t *iv, size_t ivlen,
  * which has variable integer in its parameter.
  */
 static size_t varint_paramlen(ngtcp2_transport_param_id id, uint64_t param) {
-  size_t valuelen = ngtcp2_put_varint_len(param);
-  return ngtcp2_put_varint_len(id) + ngtcp2_put_varint_len(valuelen) + valuelen;
+  size_t valuelen = ngtcp2_put_varintlen(param);
+  return ngtcp2_put_varintlen(id) + ngtcp2_put_varintlen(valuelen) + valuelen;
 }
 
 /*
@@ -118,7 +118,7 @@ static size_t varint_paramlen(ngtcp2_transport_param_id id, uint64_t param) {
 static uint8_t *write_varint_param(uint8_t *p, ngtcp2_transport_param_id id,
                                    uint64_t value) {
   p = ngtcp2_put_varint(p, id);
-  p = ngtcp2_put_varint(p, ngtcp2_put_varint_len(value));
+  p = ngtcp2_put_varint(p, ngtcp2_put_varintlen(value));
   return ngtcp2_put_varint(p, value);
 }
 
@@ -128,7 +128,7 @@ static uint8_t *write_varint_param(uint8_t *p, ngtcp2_transport_param_id id,
  */
 static size_t cid_paramlen(ngtcp2_transport_param_id id,
                            const ngtcp2_cid *cid) {
-  return ngtcp2_put_varint_len(id) + ngtcp2_put_varint_len(cid->datalen) +
+  return ngtcp2_put_varintlen(id) + ngtcp2_put_varintlen(cid->datalen) +
          cid->datalen;
 }
 
@@ -173,8 +173,8 @@ ngtcp2_ssize ngtcp2_encode_transport_params_versioned(
 
     if (params->stateless_reset_token_present) {
       len +=
-          ngtcp2_put_varint_len(NGTCP2_TRANSPORT_PARAM_STATELESS_RESET_TOKEN) +
-          ngtcp2_put_varint_len(NGTCP2_STATELESS_RESET_TOKENLEN) +
+          ngtcp2_put_varintlen(NGTCP2_TRANSPORT_PARAM_STATELESS_RESET_TOKEN) +
+          ngtcp2_put_varintlen(NGTCP2_STATELESS_RESET_TOKENLEN) +
           NGTCP2_STATELESS_RESET_TOKENLEN;
     }
     if (params->preferred_address_present) {
@@ -185,8 +185,8 @@ ngtcp2_ssize ngtcp2_encode_transport_params_versioned(
                           + 1 +
                           params->preferred_address.cid.datalen /* CID */ +
                           NGTCP2_STATELESS_RESET_TOKENLEN;
-      len += ngtcp2_put_varint_len(NGTCP2_TRANSPORT_PARAM_PREFERRED_ADDRESS) +
-             ngtcp2_put_varint_len(preferred_addrlen) + preferred_addrlen;
+      len += ngtcp2_put_varintlen(NGTCP2_TRANSPORT_PARAM_PREFERRED_ADDRESS) +
+             ngtcp2_put_varintlen(preferred_addrlen) + preferred_addrlen;
     }
     if (params->retry_scid_present) {
       len += cid_paramlen(NGTCP2_TRANSPORT_PARAM_RETRY_SOURCE_CONNECTION_ID,
@@ -237,8 +237,8 @@ ngtcp2_ssize ngtcp2_encode_transport_params_versioned(
   }
   if (params->disable_active_migration) {
     len +=
-        ngtcp2_put_varint_len(NGTCP2_TRANSPORT_PARAM_DISABLE_ACTIVE_MIGRATION) +
-        ngtcp2_put_varint_len(0);
+        ngtcp2_put_varintlen(NGTCP2_TRANSPORT_PARAM_DISABLE_ACTIVE_MIGRATION) +
+        ngtcp2_put_varintlen(0);
   }
   if (params->max_ack_delay != NGTCP2_DEFAULT_MAX_ACK_DELAY) {
     len += varint_paramlen(NGTCP2_TRANSPORT_PARAM_MAX_ACK_DELAY,
@@ -259,14 +259,14 @@ ngtcp2_ssize ngtcp2_encode_transport_params_versioned(
                            params->max_datagram_frame_size);
   }
   if (params->grease_quic_bit) {
-    len += ngtcp2_put_varint_len(NGTCP2_TRANSPORT_PARAM_GREASE_QUIC_BIT) +
-           ngtcp2_put_varint_len(0);
+    len += ngtcp2_put_varintlen(NGTCP2_TRANSPORT_PARAM_GREASE_QUIC_BIT) +
+           ngtcp2_put_varintlen(0);
   }
   if (params->version_info_present) {
     version_infolen = sizeof(uint32_t) + params->version_info.other_versionslen;
-    len += ngtcp2_put_varint_len(
-               NGTCP2_TRANSPORT_PARAM_VERSION_INFORMATION_DRAFT) +
-           ngtcp2_put_varint_len(version_infolen) + version_infolen;
+    len +=
+        ngtcp2_put_varintlen(NGTCP2_TRANSPORT_PARAM_VERSION_INFORMATION_DRAFT) +
+        ngtcp2_put_varintlen(version_infolen) + version_infolen;
   }
 
   if (dest == NULL && destlen == 0) {
@@ -437,7 +437,7 @@ static int decode_varint(uint64_t *pdest, const uint8_t **pp,
     return -1;
   }
 
-  len = ngtcp2_get_varint_len(p);
+  len = ngtcp2_get_varintlen(p);
   if ((uint64_t)(end - p) < len) {
     return -1;
   }
@@ -471,7 +471,7 @@ static int decode_varint_param(uint64_t *pdest, const uint8_t **pp,
     return -1;
   }
 
-  if (ngtcp2_get_varint_len(p) != valuelen) {
+  if (ngtcp2_get_varintlen(p) != valuelen) {
     return -1;
   }
 

--- a/lib/ngtcp2_pkt.c
+++ b/lib/ngtcp2_pkt.c
@@ -256,7 +256,7 @@ ngtcp2_ssize ngtcp2_pkt_decode_hd_long(ngtcp2_pkt_hd *dest, const uint8_t *pkt,
 
   if (type == NGTCP2_PKT_INITIAL) {
     /* Token Length */
-    ntokenlen = ngtcp2_get_varint_len(p);
+    ntokenlen = ngtcp2_get_varintlen(p);
     len += ntokenlen - 1;
 
     if (pktlen < len) {
@@ -288,7 +288,7 @@ ngtcp2_ssize ngtcp2_pkt_decode_hd_long(ngtcp2_pkt_hd *dest, const uint8_t *pkt,
     }
 
     /* Length */
-    n = ngtcp2_get_varint_len(p);
+    n = ngtcp2_get_varintlen(p);
     len += n - 1;
 
     if (pktlen < len) {
@@ -392,7 +392,7 @@ ngtcp2_ssize ngtcp2_pkt_encode_hd_long(uint8_t *out, size_t outlen,
   }
 
   if (hd->type == NGTCP2_PKT_INITIAL) {
-    len += ngtcp2_put_varint_len(hd->token.len) + hd->token.len;
+    len += ngtcp2_put_varintlen(hd->token.len) + hd->token.len;
   }
 
   if (outlen < len) {
@@ -568,7 +568,7 @@ ngtcp2_ssize ngtcp2_pkt_decode_stream_frame(ngtcp2_stream *dest,
 
   p = payload + 1;
 
-  n = ngtcp2_get_varint_len(p);
+  n = ngtcp2_get_varintlen(p);
   len += n - 1;
 
   if (payloadlen < len) {
@@ -583,7 +583,7 @@ ngtcp2_ssize ngtcp2_pkt_decode_stream_frame(ngtcp2_stream *dest,
       return NGTCP2_ERR_FRAME_ENCODING;
     }
 
-    n = ngtcp2_get_varint_len(p);
+    n = ngtcp2_get_varintlen(p);
     len += n - 1;
 
     if (payloadlen < len) {
@@ -599,7 +599,7 @@ ngtcp2_ssize ngtcp2_pkt_decode_stream_frame(ngtcp2_stream *dest,
       return NGTCP2_ERR_FRAME_ENCODING;
     }
 
-    ndatalen = ngtcp2_get_varint_len(p);
+    ndatalen = ngtcp2_get_varintlen(p);
     len += ndatalen - 1;
 
     if (payloadlen < len) {
@@ -671,7 +671,7 @@ ngtcp2_ssize ngtcp2_pkt_decode_ack_frame(ngtcp2_ack *dest,
   p = payload + 1;
 
   /* Largest Acknowledged */
-  n = ngtcp2_get_varint_len(p);
+  n = ngtcp2_get_varintlen(p);
   len += n - 1;
 
   if (payloadlen < len) {
@@ -681,7 +681,7 @@ ngtcp2_ssize ngtcp2_pkt_decode_ack_frame(ngtcp2_ack *dest,
   p += n;
 
   /* ACK Delay */
-  n = ngtcp2_get_varint_len(p);
+  n = ngtcp2_get_varintlen(p);
   len += n - 1;
 
   if (payloadlen < len) {
@@ -691,7 +691,7 @@ ngtcp2_ssize ngtcp2_pkt_decode_ack_frame(ngtcp2_ack *dest,
   p += n;
 
   /* ACK Range Count */
-  nrangecnt = ngtcp2_get_varint_len(p);
+  nrangecnt = ngtcp2_get_varintlen(p);
   len += nrangecnt - 1;
 
   if (payloadlen < len) {
@@ -707,7 +707,7 @@ ngtcp2_ssize ngtcp2_pkt_decode_ack_frame(ngtcp2_ack *dest,
   len += rangecnt * (1 + 1);
 
   /* First ACK Range */
-  n = ngtcp2_get_varint_len(p);
+  n = ngtcp2_get_varintlen(p);
   len += n - 1;
 
   if (payloadlen < len) {
@@ -719,7 +719,7 @@ ngtcp2_ssize ngtcp2_pkt_decode_ack_frame(ngtcp2_ack *dest,
   for (i = 0; i < rangecnt; ++i) {
     /* Gap, and Additional ACK Range */
     for (j = 0; j < 2; ++j) {
-      n = ngtcp2_get_varint_len(p);
+      n = ngtcp2_get_varintlen(p);
       len += n - 1;
 
       if (payloadlen < len) {
@@ -737,7 +737,7 @@ ngtcp2_ssize ngtcp2_pkt_decode_ack_frame(ngtcp2_ack *dest,
     }
 
     for (i = 0; i < 3; ++i) {
-      n = ngtcp2_get_varint_len(p);
+      n = ngtcp2_get_varintlen(p);
       len += n - 1;
 
       if (payloadlen < len) {
@@ -768,8 +768,8 @@ ngtcp2_ssize ngtcp2_pkt_decode_ack_frame(ngtcp2_ack *dest,
     p = ngtcp2_get_uvarint(&range->len, p);
   }
   for (i = max_rangecnt; i < rangecnt; ++i) {
-    p += ngtcp2_get_varint_len(p);
-    p += ngtcp2_get_varint_len(p);
+    p += ngtcp2_get_varintlen(p);
+    p += ngtcp2_get_varintlen(p);
   }
 
   if (type == NGTCP2_FRAME_ACK_ECN) {
@@ -815,19 +815,19 @@ ngtcp2_ssize ngtcp2_pkt_decode_reset_stream_frame(ngtcp2_reset_stream *dest,
 
   p = payload + 1;
 
-  n = ngtcp2_get_varint_len(p);
+  n = ngtcp2_get_varintlen(p);
   len += n - 1;
   if (payloadlen < len) {
     return NGTCP2_ERR_FRAME_ENCODING;
   }
   p += n;
-  n = ngtcp2_get_varint_len(p);
+  n = ngtcp2_get_varintlen(p);
   len += n - 1;
   if (payloadlen < len) {
     return NGTCP2_ERR_FRAME_ENCODING;
   }
   p += n;
-  n = ngtcp2_get_varint_len(p);
+  n = ngtcp2_get_varintlen(p);
   len += n - 1;
   if (payloadlen < len) {
     return NGTCP2_ERR_FRAME_ENCODING;
@@ -863,7 +863,7 @@ ngtcp2_ssize ngtcp2_pkt_decode_connection_close_frame(
 
   p = payload + 1;
 
-  n = ngtcp2_get_varint_len(p);
+  n = ngtcp2_get_varintlen(p);
   len += n - 1;
   if (payloadlen < len) {
     return NGTCP2_ERR_FRAME_ENCODING;
@@ -874,7 +874,7 @@ ngtcp2_ssize ngtcp2_pkt_decode_connection_close_frame(
   if (type == NGTCP2_FRAME_CONNECTION_CLOSE) {
     ++len;
 
-    n = ngtcp2_get_varint_len(p);
+    n = ngtcp2_get_varintlen(p);
     len += n - 1;
     if (payloadlen < len) {
       return NGTCP2_ERR_FRAME_ENCODING;
@@ -883,7 +883,7 @@ ngtcp2_ssize ngtcp2_pkt_decode_connection_close_frame(
     p += n;
   }
 
-  nreasonlen = ngtcp2_get_varint_len(p);
+  nreasonlen = ngtcp2_get_varintlen(p);
   len += nreasonlen - 1;
   if (payloadlen < len) {
     return NGTCP2_ERR_FRAME_ENCODING;
@@ -932,7 +932,7 @@ ngtcp2_ssize ngtcp2_pkt_decode_max_data_frame(ngtcp2_max_data *dest,
 
   p = payload + 1;
 
-  n = ngtcp2_get_varint_len(p);
+  n = ngtcp2_get_varintlen(p);
   len += n - 1;
 
   if (payloadlen < len) {
@@ -959,7 +959,7 @@ ngtcp2_ssize ngtcp2_pkt_decode_max_stream_data_frame(
 
   p = payload + 1;
 
-  n = ngtcp2_get_varint_len(p);
+  n = ngtcp2_get_varintlen(p);
   len += n - 1;
 
   if (payloadlen < len) {
@@ -968,7 +968,7 @@ ngtcp2_ssize ngtcp2_pkt_decode_max_stream_data_frame(
 
   p += n;
 
-  n = ngtcp2_get_varint_len(p);
+  n = ngtcp2_get_varintlen(p);
   len += n - 1;
 
   if (payloadlen < len) {
@@ -999,7 +999,7 @@ ngtcp2_ssize ngtcp2_pkt_decode_max_streams_frame(ngtcp2_max_streams *dest,
 
   p = payload + 1;
 
-  n = ngtcp2_get_varint_len(p);
+  n = ngtcp2_get_varintlen(p);
   len += n - 1;
 
   if (payloadlen < len) {
@@ -1037,7 +1037,7 @@ ngtcp2_ssize ngtcp2_pkt_decode_data_blocked_frame(ngtcp2_data_blocked *dest,
 
   p = payload + 1;
 
-  n = ngtcp2_get_varint_len(p);
+  n = ngtcp2_get_varintlen(p);
   len += n - 1;
 
   if (payloadlen < len) {
@@ -1066,7 +1066,7 @@ ngtcp2_pkt_decode_stream_data_blocked_frame(ngtcp2_stream_data_blocked *dest,
 
   p = payload + 1;
 
-  n = ngtcp2_get_varint_len(p);
+  n = ngtcp2_get_varintlen(p);
   len += n - 1;
 
   if (payloadlen < len) {
@@ -1075,7 +1075,7 @@ ngtcp2_pkt_decode_stream_data_blocked_frame(ngtcp2_stream_data_blocked *dest,
 
   p += n;
 
-  n = ngtcp2_get_varint_len(p);
+  n = ngtcp2_get_varintlen(p);
   len += n - 1;
 
   if (payloadlen < len) {
@@ -1105,7 +1105,7 @@ ngtcp2_ssize ngtcp2_pkt_decode_streams_blocked_frame(
 
   p = payload + 1;
 
-  n = ngtcp2_get_varint_len(p);
+  n = ngtcp2_get_varintlen(p);
   len += n - 1;
 
   if (payloadlen < len) {
@@ -1133,7 +1133,7 @@ ngtcp2_ssize ngtcp2_pkt_decode_new_connection_id_frame(
 
   p = payload + 1;
 
-  n = ngtcp2_get_varint_len(p);
+  n = ngtcp2_get_varintlen(p);
   len += n - 1;
   if (payloadlen < len) {
     return NGTCP2_ERR_FRAME_ENCODING;
@@ -1141,7 +1141,7 @@ ngtcp2_ssize ngtcp2_pkt_decode_new_connection_id_frame(
 
   p += n;
 
-  n = ngtcp2_get_varint_len(p);
+  n = ngtcp2_get_varintlen(p);
   len += n - 1;
   if (payloadlen < len) {
     return NGTCP2_ERR_FRAME_ENCODING;
@@ -1188,14 +1188,14 @@ ngtcp2_ssize ngtcp2_pkt_decode_stop_sending_frame(ngtcp2_stop_sending *dest,
 
   p = payload + 1;
 
-  n = ngtcp2_get_varint_len(p);
+  n = ngtcp2_get_varintlen(p);
   len += n - 1;
 
   if (payloadlen < len) {
     return NGTCP2_ERR_FRAME_ENCODING;
   }
   p += n;
-  n = ngtcp2_get_varint_len(p);
+  n = ngtcp2_get_varintlen(p);
   len += n - 1;
 
   if (payloadlen < len) {
@@ -1271,7 +1271,7 @@ ngtcp2_ssize ngtcp2_pkt_decode_crypto_frame(ngtcp2_crypto *dest,
 
   p = payload + 1;
 
-  n = ngtcp2_get_varint_len(p);
+  n = ngtcp2_get_varintlen(p);
   len += n - 1;
 
   if (payloadlen < len) {
@@ -1280,7 +1280,7 @@ ngtcp2_ssize ngtcp2_pkt_decode_crypto_frame(ngtcp2_crypto *dest,
 
   p += n;
 
-  ndatalen = ngtcp2_get_varint_len(p);
+  ndatalen = ngtcp2_get_varintlen(p);
   len += ndatalen - 1;
 
   if (payloadlen < len) {
@@ -1330,7 +1330,7 @@ ngtcp2_ssize ngtcp2_pkt_decode_new_token_frame(ngtcp2_new_token *dest,
 
   p = payload + 1;
 
-  n = ngtcp2_get_varint_len(p);
+  n = ngtcp2_get_varintlen(p);
   len += n - 1;
 
   if (payloadlen < len) {
@@ -1368,7 +1368,7 @@ ngtcp2_pkt_decode_retire_connection_id_frame(ngtcp2_retire_connection_id *dest,
 
   p = payload + 1;
 
-  n = ngtcp2_get_varint_len(p);
+  n = ngtcp2_get_varintlen(p);
   len += n - 1;
 
   if (payloadlen < len) {
@@ -1422,7 +1422,7 @@ ngtcp2_ssize ngtcp2_pkt_decode_datagram_frame(ngtcp2_datagram *dest,
       return NGTCP2_ERR_FRAME_ENCODING;
     }
 
-    n = ngtcp2_get_varint_len(p);
+    n = ngtcp2_get_varintlen(p);
     len += n - 1;
 
     if (payloadlen < len) {
@@ -1538,16 +1538,16 @@ ngtcp2_ssize ngtcp2_pkt_encode_stream_frame(uint8_t *out, size_t outlen,
 
   if (fr->offset) {
     flags |= NGTCP2_STREAM_OFF_BIT;
-    len += ngtcp2_put_varint_len(fr->offset);
+    len += ngtcp2_put_varintlen(fr->offset);
   }
 
-  len += ngtcp2_put_varint_len((uint64_t)fr->stream_id);
+  len += ngtcp2_put_varintlen((uint64_t)fr->stream_id);
 
   for (i = 0; i < fr->datacnt; ++i) {
     datalen += fr->data[i].len;
   }
 
-  len += ngtcp2_put_varint_len(datalen);
+  len += ngtcp2_put_varintlen(datalen);
   len += datalen;
 
   if (outlen < len) {
@@ -1581,24 +1581,24 @@ ngtcp2_ssize ngtcp2_pkt_encode_stream_frame(uint8_t *out, size_t outlen,
 
 ngtcp2_ssize ngtcp2_pkt_encode_ack_frame(uint8_t *out, size_t outlen,
                                          ngtcp2_ack *fr) {
-  size_t len = 1 + ngtcp2_put_varint_len((uint64_t)fr->largest_ack) +
-               ngtcp2_put_varint_len(fr->ack_delay) +
-               ngtcp2_put_varint_len(fr->rangecnt) +
-               ngtcp2_put_varint_len(fr->first_ack_range);
+  size_t len = 1 + ngtcp2_put_varintlen((uint64_t)fr->largest_ack) +
+               ngtcp2_put_varintlen(fr->ack_delay) +
+               ngtcp2_put_varintlen(fr->rangecnt) +
+               ngtcp2_put_varintlen(fr->first_ack_range);
   uint8_t *p;
   size_t i;
   const ngtcp2_ack_range *range;
 
   for (i = 0; i < fr->rangecnt; ++i) {
     range = &fr->ranges[i];
-    len += ngtcp2_put_varint_len(range->gap);
-    len += ngtcp2_put_varint_len(range->len);
+    len += ngtcp2_put_varintlen(range->gap);
+    len += ngtcp2_put_varintlen(range->len);
   }
 
   if (fr->type == NGTCP2_FRAME_ACK_ECN) {
-    len += ngtcp2_put_varint_len(fr->ecn.ect0) +
-           ngtcp2_put_varint_len(fr->ecn.ect1) +
-           ngtcp2_put_varint_len(fr->ecn.ce);
+    len += ngtcp2_put_varintlen(fr->ecn.ect0) +
+           ngtcp2_put_varintlen(fr->ecn.ect1) +
+           ngtcp2_put_varintlen(fr->ecn.ce);
   }
 
   if (outlen < len) {
@@ -1644,9 +1644,9 @@ ngtcp2_ssize ngtcp2_pkt_encode_padding_frame(uint8_t *out, size_t outlen,
 ngtcp2_ssize
 ngtcp2_pkt_encode_reset_stream_frame(uint8_t *out, size_t outlen,
                                      const ngtcp2_reset_stream *fr) {
-  size_t len = 1 + ngtcp2_put_varint_len((uint64_t)fr->stream_id) +
-               ngtcp2_put_varint_len(fr->app_error_code) +
-               ngtcp2_put_varint_len(fr->final_size);
+  size_t len = 1 + ngtcp2_put_varintlen((uint64_t)fr->stream_id) +
+               ngtcp2_put_varintlen(fr->app_error_code) +
+               ngtcp2_put_varintlen(fr->final_size);
   uint8_t *p;
 
   if (outlen < len) {
@@ -1668,11 +1668,11 @@ ngtcp2_pkt_encode_reset_stream_frame(uint8_t *out, size_t outlen,
 ngtcp2_ssize
 ngtcp2_pkt_encode_connection_close_frame(uint8_t *out, size_t outlen,
                                          const ngtcp2_connection_close *fr) {
-  size_t len = 1 + ngtcp2_put_varint_len(fr->error_code) +
+  size_t len = 1 + ngtcp2_put_varintlen(fr->error_code) +
                (fr->type == NGTCP2_FRAME_CONNECTION_CLOSE
-                    ? ngtcp2_put_varint_len(fr->frame_type)
+                    ? ngtcp2_put_varintlen(fr->frame_type)
                     : 0) +
-               ngtcp2_put_varint_len(fr->reasonlen) + fr->reasonlen;
+               ngtcp2_put_varintlen(fr->reasonlen) + fr->reasonlen;
   uint8_t *p;
 
   if (outlen < len) {
@@ -1698,7 +1698,7 @@ ngtcp2_pkt_encode_connection_close_frame(uint8_t *out, size_t outlen,
 
 ngtcp2_ssize ngtcp2_pkt_encode_max_data_frame(uint8_t *out, size_t outlen,
                                               const ngtcp2_max_data *fr) {
-  size_t len = 1 + ngtcp2_put_varint_len(fr->max_data);
+  size_t len = 1 + ngtcp2_put_varintlen(fr->max_data);
   uint8_t *p;
 
   if (outlen < len) {
@@ -1718,8 +1718,8 @@ ngtcp2_ssize ngtcp2_pkt_encode_max_data_frame(uint8_t *out, size_t outlen,
 ngtcp2_ssize
 ngtcp2_pkt_encode_max_stream_data_frame(uint8_t *out, size_t outlen,
                                         const ngtcp2_max_stream_data *fr) {
-  size_t len = 1 + ngtcp2_put_varint_len((uint64_t)fr->stream_id) +
-               ngtcp2_put_varint_len(fr->max_stream_data);
+  size_t len = 1 + ngtcp2_put_varintlen((uint64_t)fr->stream_id) +
+               ngtcp2_put_varintlen(fr->max_stream_data);
   uint8_t *p;
 
   if (outlen < len) {
@@ -1739,7 +1739,7 @@ ngtcp2_pkt_encode_max_stream_data_frame(uint8_t *out, size_t outlen,
 
 ngtcp2_ssize ngtcp2_pkt_encode_max_streams_frame(uint8_t *out, size_t outlen,
                                                  const ngtcp2_max_streams *fr) {
-  size_t len = 1 + ngtcp2_put_varint_len(fr->max_streams);
+  size_t len = 1 + ngtcp2_put_varintlen(fr->max_streams);
   uint8_t *p;
 
   if (outlen < len) {
@@ -1772,7 +1772,7 @@ ngtcp2_ssize ngtcp2_pkt_encode_ping_frame(uint8_t *out, size_t outlen,
 ngtcp2_ssize
 ngtcp2_pkt_encode_data_blocked_frame(uint8_t *out, size_t outlen,
                                      const ngtcp2_data_blocked *fr) {
-  size_t len = 1 + ngtcp2_put_varint_len(fr->offset);
+  size_t len = 1 + ngtcp2_put_varintlen(fr->offset);
   uint8_t *p;
 
   if (outlen < len) {
@@ -1791,8 +1791,8 @@ ngtcp2_pkt_encode_data_blocked_frame(uint8_t *out, size_t outlen,
 
 ngtcp2_ssize ngtcp2_pkt_encode_stream_data_blocked_frame(
     uint8_t *out, size_t outlen, const ngtcp2_stream_data_blocked *fr) {
-  size_t len = 1 + ngtcp2_put_varint_len((uint64_t)fr->stream_id) +
-               ngtcp2_put_varint_len(fr->offset);
+  size_t len = 1 + ngtcp2_put_varintlen((uint64_t)fr->stream_id) +
+               ngtcp2_put_varintlen(fr->offset);
   uint8_t *p;
 
   if (outlen < len) {
@@ -1813,7 +1813,7 @@ ngtcp2_ssize ngtcp2_pkt_encode_stream_data_blocked_frame(
 ngtcp2_ssize
 ngtcp2_pkt_encode_streams_blocked_frame(uint8_t *out, size_t outlen,
                                         const ngtcp2_streams_blocked *fr) {
-  size_t len = 1 + ngtcp2_put_varint_len(fr->max_streams);
+  size_t len = 1 + ngtcp2_put_varintlen(fr->max_streams);
   uint8_t *p;
 
   if (outlen < len) {
@@ -1833,9 +1833,9 @@ ngtcp2_pkt_encode_streams_blocked_frame(uint8_t *out, size_t outlen,
 ngtcp2_ssize
 ngtcp2_pkt_encode_new_connection_id_frame(uint8_t *out, size_t outlen,
                                           const ngtcp2_new_connection_id *fr) {
-  size_t len = 1 + ngtcp2_put_varint_len(fr->seq) +
-               ngtcp2_put_varint_len(fr->retire_prior_to) + 1 +
-               fr->cid.datalen + NGTCP2_STATELESS_RESET_TOKENLEN;
+  size_t len = 1 + ngtcp2_put_varintlen(fr->seq) +
+               ngtcp2_put_varintlen(fr->retire_prior_to) + 1 + fr->cid.datalen +
+               NGTCP2_STATELESS_RESET_TOKENLEN;
   uint8_t *p;
 
   if (outlen < len) {
@@ -1860,8 +1860,8 @@ ngtcp2_pkt_encode_new_connection_id_frame(uint8_t *out, size_t outlen,
 ngtcp2_ssize
 ngtcp2_pkt_encode_stop_sending_frame(uint8_t *out, size_t outlen,
                                      const ngtcp2_stop_sending *fr) {
-  size_t len = 1 + ngtcp2_put_varint_len((uint64_t)fr->stream_id) +
-               ngtcp2_put_varint_len(fr->app_error_code);
+  size_t len = 1 + ngtcp2_put_varintlen((uint64_t)fr->stream_id) +
+               ngtcp2_put_varintlen(fr->app_error_code);
   uint8_t *p;
 
   if (outlen < len) {
@@ -1926,13 +1926,13 @@ ngtcp2_ssize ngtcp2_pkt_encode_crypto_frame(uint8_t *out, size_t outlen,
   size_t i;
   size_t datalen = 0;
 
-  len += ngtcp2_put_varint_len(fr->offset);
+  len += ngtcp2_put_varintlen(fr->offset);
 
   for (i = 0; i < fr->datacnt; ++i) {
     datalen += fr->data[i].len;
   }
 
-  len += ngtcp2_put_varint_len(datalen);
+  len += ngtcp2_put_varintlen(datalen);
   len += datalen;
 
   if (outlen < len) {
@@ -1958,7 +1958,7 @@ ngtcp2_ssize ngtcp2_pkt_encode_crypto_frame(uint8_t *out, size_t outlen,
 
 ngtcp2_ssize ngtcp2_pkt_encode_new_token_frame(uint8_t *out, size_t outlen,
                                                const ngtcp2_new_token *fr) {
-  size_t len = 1 + ngtcp2_put_varint_len(fr->token.len) + fr->token.len;
+  size_t len = 1 + ngtcp2_put_varintlen(fr->token.len) + fr->token.len;
   uint8_t *p;
 
   assert(fr->token.len);
@@ -1981,7 +1981,7 @@ ngtcp2_ssize ngtcp2_pkt_encode_new_token_frame(uint8_t *out, size_t outlen,
 
 ngtcp2_ssize ngtcp2_pkt_encode_retire_connection_id_frame(
     uint8_t *out, size_t outlen, const ngtcp2_retire_connection_id *fr) {
-  size_t len = 1 + ngtcp2_put_varint_len(fr->seq);
+  size_t len = 1 + ngtcp2_put_varintlen(fr->seq);
   uint8_t *p;
 
   if (outlen < len) {
@@ -2018,7 +2018,7 @@ ngtcp2_ssize ngtcp2_pkt_encode_datagram_frame(uint8_t *out, size_t outlen,
   uint64_t datalen = ngtcp2_vec_len(fr->data, fr->datacnt);
   uint64_t len =
       1 +
-      (fr->type == NGTCP2_FRAME_DATAGRAM ? 0 : ngtcp2_put_varint_len(datalen)) +
+      (fr->type == NGTCP2_FRAME_DATAGRAM ? 0 : ngtcp2_put_varintlen(datalen)) +
       datalen;
   uint8_t *p;
   size_t i;
@@ -2361,8 +2361,8 @@ int ngtcp2_pkt_verify_retry_tag(uint32_t version, const ngtcp2_pkt_retry *retry,
 
 size_t ngtcp2_pkt_stream_max_datalen(int64_t stream_id, uint64_t offset,
                                      uint64_t len, size_t left) {
-  size_t n = 1 /* type */ + ngtcp2_put_varint_len((uint64_t)stream_id) +
-             (offset ? ngtcp2_put_varint_len(offset) : 0);
+  size_t n = 1 /* type */ + ngtcp2_put_varintlen((uint64_t)stream_id) +
+             (offset ? ngtcp2_put_varintlen(offset) : 0);
 
   if (left <= n) {
     return (size_t)-1;
@@ -2392,7 +2392,7 @@ size_t ngtcp2_pkt_stream_max_datalen(int64_t stream_id, uint64_t offset,
 }
 
 size_t ngtcp2_pkt_crypto_max_datalen(uint64_t offset, size_t len, size_t left) {
-  size_t n = 1 /* type */ + ngtcp2_put_varint_len(offset);
+  size_t n = 1 /* type */ + ngtcp2_put_varintlen(offset);
 
   /* CRYPTO frame must contain nonzero length data.  Return -1 if
      there is no space to write crypto data. */
@@ -2424,7 +2424,7 @@ size_t ngtcp2_pkt_crypto_max_datalen(uint64_t offset, size_t len, size_t left) {
 }
 
 size_t ngtcp2_pkt_datagram_framelen(size_t len) {
-  return 1 /* type */ + ngtcp2_put_varint_len(len) + len;
+  return 1 /* type */ + ngtcp2_put_varintlen(len) + len;
 }
 
 int ngtcp2_is_supported_version(uint32_t version) {

--- a/lib/ngtcp2_ppe.c
+++ b/lib/ngtcp2_ppe.c
@@ -55,7 +55,7 @@ int ngtcp2_ppe_encode_hd(ngtcp2_ppe *ppe, const ngtcp2_pkt_hd *hd) {
   if (hd->flags & NGTCP2_PKT_FLAG_LONG_FORM) {
     ppe->len_offset = 1 + 4 + 1 + hd->dcid.datalen + 1 + hd->scid.datalen;
     if (hd->type == NGTCP2_PKT_INITIAL) {
-      ppe->len_offset += ngtcp2_put_varint_len(hd->token.len) + hd->token.len;
+      ppe->len_offset += ngtcp2_put_varintlen(hd->token.len) + hd->token.len;
     }
     ppe->pkt_num_offset = ppe->len_offset + NGTCP2_PKT_LENGTHLEN;
     rv = ngtcp2_pkt_encode_hd_long(

--- a/tests/main.c
+++ b/tests/main.c
@@ -139,8 +139,8 @@ int main(void) {
       !CU_add_test(pSuite, "pkt_stream_max_datalen",
                    test_ngtcp2_pkt_stream_max_datalen) ||
       !CU_add_test(pSuite, "get_varint", test_ngtcp2_get_varint) ||
-      !CU_add_test(pSuite, "get_varint_len", test_ngtcp2_get_varint_len) ||
-      !CU_add_test(pSuite, "put_varint_len", test_ngtcp2_put_varint_len) ||
+      !CU_add_test(pSuite, "get_varint_len", test_ngtcp2_get_varintlen) ||
+      !CU_add_test(pSuite, "put_varint_len", test_ngtcp2_put_varintlen) ||
       !CU_add_test(pSuite, "get_uint64", test_ngtcp2_get_uint64) ||
       !CU_add_test(pSuite, "get_uint48", test_ngtcp2_get_uint48) ||
       !CU_add_test(pSuite, "get_uint32", test_ngtcp2_get_uint32) ||

--- a/tests/ngtcp2_conn_test.c
+++ b/tests/ngtcp2_conn_test.c
@@ -4650,7 +4650,7 @@ void test_ngtcp2_conn_writev_datagram(void) {
      occupy the space */
   setup_default_client(&conn);
   conn->remote.transport_params->max_datagram_frame_size =
-      1 + ngtcp2_put_varint_len(2000) + 2000;
+      1 + ngtcp2_put_varintlen(2000) + 2000;
 
   vec.base = null_data;
   vec.len = 2000;

--- a/tests/ngtcp2_conv_test.c
+++ b/tests/ngtcp2_conv_test.c
@@ -136,24 +136,24 @@ void test_ngtcp2_get_varint(void) {
   CU_ASSERT(4611686018427387903LL == s);
 }
 
-void test_ngtcp2_get_varint_len(void) {
+void test_ngtcp2_get_varintlen(void) {
   uint8_t c;
 
   c = 0x00;
 
-  CU_ASSERT(1 == ngtcp2_get_varint_len(&c));
+  CU_ASSERT(1 == ngtcp2_get_varintlen(&c));
 
   c = 0x40;
 
-  CU_ASSERT(2 == ngtcp2_get_varint_len(&c));
+  CU_ASSERT(2 == ngtcp2_get_varintlen(&c));
 
   c = 0x80;
 
-  CU_ASSERT(4 == ngtcp2_get_varint_len(&c));
+  CU_ASSERT(4 == ngtcp2_get_varintlen(&c));
 
   c = 0xc0;
 
-  CU_ASSERT(8 == ngtcp2_get_varint_len(&c));
+  CU_ASSERT(8 == ngtcp2_get_varintlen(&c));
 }
 
 void test_ngtcp2_get_uint64(void) {
@@ -390,15 +390,15 @@ void test_ngtcp2_get_uint16be(void) {
   CU_ASSERT(65535 == n);
 }
 
-void test_ngtcp2_put_varint_len(void) {
-  CU_ASSERT(1 == ngtcp2_put_varint_len(0));
-  CU_ASSERT(1 == ngtcp2_put_varint_len(63));
-  CU_ASSERT(2 == ngtcp2_put_varint_len(64));
-  CU_ASSERT(2 == ngtcp2_put_varint_len(16383));
-  CU_ASSERT(4 == ngtcp2_put_varint_len(16384));
-  CU_ASSERT(4 == ngtcp2_put_varint_len(1073741823));
-  CU_ASSERT(8 == ngtcp2_put_varint_len(1073741824));
-  CU_ASSERT(8 == ngtcp2_put_varint_len(4611686018427387903ULL));
+void test_ngtcp2_put_varintlen(void) {
+  CU_ASSERT(1 == ngtcp2_put_varintlen(0));
+  CU_ASSERT(1 == ngtcp2_put_varintlen(63));
+  CU_ASSERT(2 == ngtcp2_put_varintlen(64));
+  CU_ASSERT(2 == ngtcp2_put_varintlen(16383));
+  CU_ASSERT(4 == ngtcp2_put_varintlen(16384));
+  CU_ASSERT(4 == ngtcp2_put_varintlen(1073741823));
+  CU_ASSERT(8 == ngtcp2_put_varintlen(1073741824));
+  CU_ASSERT(8 == ngtcp2_put_varintlen(4611686018427387903ULL));
 }
 
 void test_ngtcp2_nth_server_bidi_id(void) {

--- a/tests/ngtcp2_conv_test.h
+++ b/tests/ngtcp2_conv_test.h
@@ -30,8 +30,8 @@
 #endif /* HAVE_CONFIG_H */
 
 void test_ngtcp2_get_varint(void);
-void test_ngtcp2_get_varint_len(void);
-void test_ngtcp2_put_varint_len(void);
+void test_ngtcp2_get_varintlen(void);
+void test_ngtcp2_put_varintlen(void);
 void test_ngtcp2_get_uint64(void);
 void test_ngtcp2_get_uint48(void);
 void test_ngtcp2_get_uint32(void);

--- a/tests/ngtcp2_crypto_test.c
+++ b/tests/ngtcp2_crypto_test.c
@@ -33,8 +33,8 @@
 #include "ngtcp2_test_helper.h"
 
 static size_t varint_paramlen(ngtcp2_transport_param_id id, uint64_t value) {
-  size_t valuelen = ngtcp2_put_varint_len(value);
-  return ngtcp2_put_varint_len(id) + ngtcp2_put_varint_len(valuelen) + valuelen;
+  size_t valuelen = ngtcp2_put_varintlen(value);
+  return ngtcp2_put_varintlen(id) + ngtcp2_put_varintlen(valuelen) + valuelen;
 }
 
 void test_ngtcp2_encode_transport_params(void) {
@@ -64,9 +64,9 @@ void test_ngtcp2_encode_transport_params(void) {
   params.max_ack_delay = NGTCP2_DEFAULT_MAX_ACK_DELAY;
   params.initial_scid = scid;
 
-  len = (ngtcp2_put_varint_len(
+  len = (ngtcp2_put_varintlen(
              NGTCP2_TRANSPORT_PARAM_INITIAL_SOURCE_CONNECTION_ID) +
-         ngtcp2_put_varint_len(params.initial_scid.datalen) +
+         ngtcp2_put_varintlen(params.initial_scid.datalen) +
          params.initial_scid.datalen);
 
   nwrite = ngtcp2_encode_transport_params(
@@ -108,13 +108,13 @@ void test_ngtcp2_encode_transport_params(void) {
   params.original_dcid = dcid;
   params.initial_scid = scid;
 
-  len = (ngtcp2_put_varint_len(
+  len = (ngtcp2_put_varintlen(
              NGTCP2_TRANSPORT_PARAM_ORIGINAL_DESTINATION_CONNECTION_ID) +
-         ngtcp2_put_varint_len(params.original_dcid.datalen) +
+         ngtcp2_put_varintlen(params.original_dcid.datalen) +
          params.original_dcid.datalen) +
-        (ngtcp2_put_varint_len(
+        (ngtcp2_put_varintlen(
              NGTCP2_TRANSPORT_PARAM_INITIAL_SOURCE_CONNECTION_ID) +
-         ngtcp2_put_varint_len(params.initial_scid.datalen) +
+         ngtcp2_put_varintlen(params.initial_scid.datalen) +
          params.initial_scid.datalen);
 
   nwrite = ngtcp2_encode_transport_params(
@@ -194,23 +194,23 @@ void test_ngtcp2_encode_transport_params(void) {
                       params.max_udp_payload_size) +
       varint_paramlen(NGTCP2_TRANSPORT_PARAM_ACK_DELAY_EXPONENT,
                       params.ack_delay_exponent) +
-      (ngtcp2_put_varint_len(NGTCP2_TRANSPORT_PARAM_DISABLE_ACTIVE_MIGRATION) +
-       ngtcp2_put_varint_len(0)) +
+      (ngtcp2_put_varintlen(NGTCP2_TRANSPORT_PARAM_DISABLE_ACTIVE_MIGRATION) +
+       ngtcp2_put_varintlen(0)) +
       varint_paramlen(NGTCP2_TRANSPORT_PARAM_MAX_ACK_DELAY,
                       params.max_ack_delay / NGTCP2_MILLISECONDS) +
       varint_paramlen(NGTCP2_TRANSPORT_PARAM_ACTIVE_CONNECTION_ID_LIMIT,
                       params.active_connection_id_limit) +
-      (ngtcp2_put_varint_len(
+      (ngtcp2_put_varintlen(
            NGTCP2_TRANSPORT_PARAM_INITIAL_SOURCE_CONNECTION_ID) +
-       ngtcp2_put_varint_len(params.initial_scid.datalen) +
+       ngtcp2_put_varintlen(params.initial_scid.datalen) +
        params.initial_scid.datalen) +
       varint_paramlen(NGTCP2_TRANSPORT_PARAM_MAX_DATAGRAM_FRAME_SIZE,
                       params.max_datagram_frame_size) +
-      (ngtcp2_put_varint_len(NGTCP2_TRANSPORT_PARAM_GREASE_QUIC_BIT) +
-       ngtcp2_put_varint_len(0)) +
-      (ngtcp2_put_varint_len(NGTCP2_TRANSPORT_PARAM_VERSION_INFORMATION_DRAFT) +
-       ngtcp2_put_varint_len(sizeof(params.version_info.chosen_version) +
-                             params.version_info.other_versionslen) +
+      (ngtcp2_put_varintlen(NGTCP2_TRANSPORT_PARAM_GREASE_QUIC_BIT) +
+       ngtcp2_put_varintlen(0)) +
+      (ngtcp2_put_varintlen(NGTCP2_TRANSPORT_PARAM_VERSION_INFORMATION_DRAFT) +
+       ngtcp2_put_varintlen(sizeof(params.version_info.chosen_version) +
+                            params.version_info.other_versionslen) +
        sizeof(params.version_info.chosen_version) +
        params.version_info.other_versionslen);
 
@@ -320,40 +320,39 @@ void test_ngtcp2_encode_transport_params(void) {
                       params.max_udp_payload_size) +
       varint_paramlen(NGTCP2_TRANSPORT_PARAM_ACK_DELAY_EXPONENT,
                       params.ack_delay_exponent) +
-      (ngtcp2_put_varint_len(NGTCP2_TRANSPORT_PARAM_DISABLE_ACTIVE_MIGRATION) +
-       ngtcp2_put_varint_len(0)) +
+      (ngtcp2_put_varintlen(NGTCP2_TRANSPORT_PARAM_DISABLE_ACTIVE_MIGRATION) +
+       ngtcp2_put_varintlen(0)) +
       varint_paramlen(NGTCP2_TRANSPORT_PARAM_MAX_ACK_DELAY,
                       params.max_ack_delay / NGTCP2_MILLISECONDS) +
       varint_paramlen(NGTCP2_TRANSPORT_PARAM_ACTIVE_CONNECTION_ID_LIMIT,
                       params.active_connection_id_limit) +
-      (ngtcp2_put_varint_len(NGTCP2_TRANSPORT_PARAM_STATELESS_RESET_TOKEN) +
-       ngtcp2_put_varint_len(NGTCP2_STATELESS_RESET_TOKENLEN) +
+      (ngtcp2_put_varintlen(NGTCP2_TRANSPORT_PARAM_STATELESS_RESET_TOKEN) +
+       ngtcp2_put_varintlen(NGTCP2_STATELESS_RESET_TOKENLEN) +
        NGTCP2_STATELESS_RESET_TOKENLEN) +
-      (ngtcp2_put_varint_len(NGTCP2_TRANSPORT_PARAM_PREFERRED_ADDRESS) +
-       ngtcp2_put_varint_len(4 + 2 + 16 + 2 + 1 +
-                             params.preferred_address.cid.datalen +
-                             NGTCP2_STATELESS_RESET_TOKENLEN) +
+      (ngtcp2_put_varintlen(NGTCP2_TRANSPORT_PARAM_PREFERRED_ADDRESS) +
+       ngtcp2_put_varintlen(4 + 2 + 16 + 2 + 1 +
+                            params.preferred_address.cid.datalen +
+                            NGTCP2_STATELESS_RESET_TOKENLEN) +
        4 + 2 + 16 + 2 + 1 + params.preferred_address.cid.datalen +
        NGTCP2_STATELESS_RESET_TOKENLEN) +
-      (ngtcp2_put_varint_len(
-           NGTCP2_TRANSPORT_PARAM_RETRY_SOURCE_CONNECTION_ID) +
-       ngtcp2_put_varint_len(params.retry_scid.datalen) +
+      (ngtcp2_put_varintlen(NGTCP2_TRANSPORT_PARAM_RETRY_SOURCE_CONNECTION_ID) +
+       ngtcp2_put_varintlen(params.retry_scid.datalen) +
        params.retry_scid.datalen) +
-      (ngtcp2_put_varint_len(
+      (ngtcp2_put_varintlen(
            NGTCP2_TRANSPORT_PARAM_ORIGINAL_DESTINATION_CONNECTION_ID) +
-       ngtcp2_put_varint_len(params.original_dcid.datalen) +
+       ngtcp2_put_varintlen(params.original_dcid.datalen) +
        params.original_dcid.datalen) +
-      (ngtcp2_put_varint_len(
+      (ngtcp2_put_varintlen(
            NGTCP2_TRANSPORT_PARAM_INITIAL_SOURCE_CONNECTION_ID) +
-       ngtcp2_put_varint_len(params.initial_scid.datalen) +
+       ngtcp2_put_varintlen(params.initial_scid.datalen) +
        params.initial_scid.datalen) +
       varint_paramlen(NGTCP2_TRANSPORT_PARAM_MAX_DATAGRAM_FRAME_SIZE,
                       params.max_datagram_frame_size) +
-      (ngtcp2_put_varint_len(NGTCP2_TRANSPORT_PARAM_GREASE_QUIC_BIT) +
-       ngtcp2_put_varint_len(0)) +
-      (ngtcp2_put_varint_len(NGTCP2_TRANSPORT_PARAM_VERSION_INFORMATION_DRAFT) +
-       ngtcp2_put_varint_len(sizeof(params.version_info.chosen_version) +
-                             params.version_info.other_versionslen) +
+      (ngtcp2_put_varintlen(NGTCP2_TRANSPORT_PARAM_GREASE_QUIC_BIT) +
+       ngtcp2_put_varintlen(0)) +
+      (ngtcp2_put_varintlen(NGTCP2_TRANSPORT_PARAM_VERSION_INFORMATION_DRAFT) +
+       ngtcp2_put_varintlen(sizeof(params.version_info.chosen_version) +
+                            params.version_info.other_versionslen) +
        sizeof(params.version_info.chosen_version) +
        params.version_info.other_versionslen);
 
@@ -459,13 +458,13 @@ void test_ngtcp2_decode_transport_params_new(void) {
   params.original_dcid = dcid;
   params.initial_scid = scid;
 
-  len = (ngtcp2_put_varint_len(
+  len = (ngtcp2_put_varintlen(
              NGTCP2_TRANSPORT_PARAM_ORIGINAL_DESTINATION_CONNECTION_ID) +
-         ngtcp2_put_varint_len(params.original_dcid.datalen) +
+         ngtcp2_put_varintlen(params.original_dcid.datalen) +
          params.original_dcid.datalen) +
-        (ngtcp2_put_varint_len(
+        (ngtcp2_put_varintlen(
              NGTCP2_TRANSPORT_PARAM_INITIAL_SOURCE_CONNECTION_ID) +
-         ngtcp2_put_varint_len(params.initial_scid.datalen) +
+         ngtcp2_put_varintlen(params.initial_scid.datalen) +
          params.initial_scid.datalen);
 
   nwrite = ngtcp2_encode_transport_params(
@@ -561,40 +560,39 @@ void test_ngtcp2_decode_transport_params_new(void) {
                       params.max_udp_payload_size) +
       varint_paramlen(NGTCP2_TRANSPORT_PARAM_ACK_DELAY_EXPONENT,
                       params.ack_delay_exponent) +
-      (ngtcp2_put_varint_len(NGTCP2_TRANSPORT_PARAM_DISABLE_ACTIVE_MIGRATION) +
-       ngtcp2_put_varint_len(0)) +
+      (ngtcp2_put_varintlen(NGTCP2_TRANSPORT_PARAM_DISABLE_ACTIVE_MIGRATION) +
+       ngtcp2_put_varintlen(0)) +
       varint_paramlen(NGTCP2_TRANSPORT_PARAM_MAX_ACK_DELAY,
                       params.max_ack_delay / NGTCP2_MILLISECONDS) +
       varint_paramlen(NGTCP2_TRANSPORT_PARAM_ACTIVE_CONNECTION_ID_LIMIT,
                       params.active_connection_id_limit) +
-      (ngtcp2_put_varint_len(NGTCP2_TRANSPORT_PARAM_STATELESS_RESET_TOKEN) +
-       ngtcp2_put_varint_len(NGTCP2_STATELESS_RESET_TOKENLEN) +
+      (ngtcp2_put_varintlen(NGTCP2_TRANSPORT_PARAM_STATELESS_RESET_TOKEN) +
+       ngtcp2_put_varintlen(NGTCP2_STATELESS_RESET_TOKENLEN) +
        NGTCP2_STATELESS_RESET_TOKENLEN) +
-      (ngtcp2_put_varint_len(NGTCP2_TRANSPORT_PARAM_PREFERRED_ADDRESS) +
-       ngtcp2_put_varint_len(4 + 2 + 16 + 2 + 1 +
-                             params.preferred_address.cid.datalen +
-                             NGTCP2_STATELESS_RESET_TOKENLEN) +
+      (ngtcp2_put_varintlen(NGTCP2_TRANSPORT_PARAM_PREFERRED_ADDRESS) +
+       ngtcp2_put_varintlen(4 + 2 + 16 + 2 + 1 +
+                            params.preferred_address.cid.datalen +
+                            NGTCP2_STATELESS_RESET_TOKENLEN) +
        4 + 2 + 16 + 2 + 1 + params.preferred_address.cid.datalen +
        NGTCP2_STATELESS_RESET_TOKENLEN) +
-      (ngtcp2_put_varint_len(
-           NGTCP2_TRANSPORT_PARAM_RETRY_SOURCE_CONNECTION_ID) +
-       ngtcp2_put_varint_len(params.retry_scid.datalen) +
+      (ngtcp2_put_varintlen(NGTCP2_TRANSPORT_PARAM_RETRY_SOURCE_CONNECTION_ID) +
+       ngtcp2_put_varintlen(params.retry_scid.datalen) +
        params.retry_scid.datalen) +
-      (ngtcp2_put_varint_len(
+      (ngtcp2_put_varintlen(
            NGTCP2_TRANSPORT_PARAM_ORIGINAL_DESTINATION_CONNECTION_ID) +
-       ngtcp2_put_varint_len(params.original_dcid.datalen) +
+       ngtcp2_put_varintlen(params.original_dcid.datalen) +
        params.original_dcid.datalen) +
-      (ngtcp2_put_varint_len(
+      (ngtcp2_put_varintlen(
            NGTCP2_TRANSPORT_PARAM_INITIAL_SOURCE_CONNECTION_ID) +
-       ngtcp2_put_varint_len(params.initial_scid.datalen) +
+       ngtcp2_put_varintlen(params.initial_scid.datalen) +
        params.initial_scid.datalen) +
       varint_paramlen(NGTCP2_TRANSPORT_PARAM_MAX_DATAGRAM_FRAME_SIZE,
                       params.max_datagram_frame_size) +
-      (ngtcp2_put_varint_len(NGTCP2_TRANSPORT_PARAM_GREASE_QUIC_BIT) +
-       ngtcp2_put_varint_len(0)) +
-      (ngtcp2_put_varint_len(NGTCP2_TRANSPORT_PARAM_VERSION_INFORMATION_DRAFT) +
-       ngtcp2_put_varint_len(sizeof(params.version_info.chosen_version) +
-                             params.version_info.other_versionslen) +
+      (ngtcp2_put_varintlen(NGTCP2_TRANSPORT_PARAM_GREASE_QUIC_BIT) +
+       ngtcp2_put_varintlen(0)) +
+      (ngtcp2_put_varintlen(NGTCP2_TRANSPORT_PARAM_VERSION_INFORMATION_DRAFT) +
+       ngtcp2_put_varintlen(sizeof(params.version_info.chosen_version) +
+                            params.version_info.other_versionslen) +
        sizeof(params.version_info.chosen_version) +
        params.version_info.other_versionslen);
 

--- a/tests/ngtcp2_pkt_test.c
+++ b/tests/ngtcp2_pkt_test.c
@@ -1258,7 +1258,7 @@ void test_ngtcp2_pkt_encode_retire_connection_id_frame(void) {
   fr.type = NGTCP2_FRAME_RETIRE_CONNECTION_ID;
   fr.retire_connection_id.seq = 1000000007;
 
-  framelen = 1 + ngtcp2_put_varint_len(fr.retire_connection_id.seq);
+  framelen = 1 + ngtcp2_put_varintlen(fr.retire_connection_id.seq);
 
   rv = ngtcp2_pkt_encode_retire_connection_id_frame(buf, sizeof(buf),
                                                     &fr.retire_connection_id);


### PR DESCRIPTION
Rename ngtcp2_get_varint_len and ngtcp2_put_varint_len to ngtcp2_get_varintlen and ngtcp2_put_varintlen respectively.