### PR TITLE
Make token a pair of pointer to const uint8_t and its size

### DIFF
--- a/examples/client.cc
+++ b/examples/client.cc
@@ -578,13 +578,13 @@ int Client::extend_max_stream_data(int64_t stream_id, uint64_t max_data) {
 }
 
 namespace {
-int recv_new_token(ngtcp2_conn *conn, const ngtcp2_vec *token,
+int recv_new_token(ngtcp2_conn *conn, const uint8_t *token, size_t tokenlen,
                    void *user_data) {
   if (config.token_file.empty()) {
     return 0;
   }
 
-  util::write_token(config.token_file, token->base, token->len);
+  util::write_token(config.token_file, token, tokenlen);
 
   return 0;
 }
@@ -747,8 +747,8 @@ int Client::init(int fd, const Address &local_addr, const Address &remote_addr,
     auto t = util::read_token(config.token_file);
     if (t) {
       token = std::move(*t);
-      settings.token.base = reinterpret_cast<uint8_t *>(token.data());
-      settings.token.len = token.size();
+      settings.token = reinterpret_cast<const uint8_t *>(token.data());
+      settings.tokenlen = token.size();
     }
   }
 

--- a/examples/h09client.cc
+++ b/examples/h09client.cc
@@ -539,7 +539,7 @@ int Client::extend_max_stream_data(int64_t stream_id, uint64_t max_data) {
 }
 
 namespace {
-int recv_new_token(ngtcp2_conn *conn, const ngtcp2_vec *token,
+int recv_new_token(ngtcp2_conn *conn, const uint8_t *token, size_t tokenlen,
                    void *user_data) {
   if (config.token_file.empty()) {
     return 0;
@@ -551,7 +551,7 @@ int recv_new_token(ngtcp2_conn *conn, const ngtcp2_vec *token,
     return 0;
   }
 
-  PEM_write_bio(f, "QUIC TOKEN", "", token->base, token->len);
+  PEM_write_bio(f, "QUIC TOKEN", "", token, tokenlen);
   BIO_free(f);
 
   return 0;
@@ -692,8 +692,8 @@ int Client::init(int fd, const Address &local_addr, const Address &remote_addr,
     auto t = util::read_token(config.token_file);
     if (t) {
       token = std::move(*t);
-      settings.token.base = reinterpret_cast<uint8_t *>(token.data());
-      settings.token.len = token.size();
+      settings.token = reinterpret_cast<const uint8_t *>(token.data());
+      settings.tokenlen = token.size();
     }
   }
 

--- a/examples/h09server.cc
+++ b/examples/h09server.cc
@@ -672,7 +672,8 @@ int Handler::init(const Endpoint &ep, const Address &local_addr,
   ngtcp2_settings_default(&settings);
   settings.log_printf = config.quiet ? nullptr : debug::log_printf;
   settings.initial_ts = util::timestamp(loop_);
-  settings.token = ngtcp2_vec{const_cast<uint8_t *>(token), tokenlen};
+  settings.token = token;
+  settings.tokenlen = tokenlen;
   settings.cc_algo = config.cc_algo;
   settings.initial_rtt = config.initial_rtt;
   settings.max_window = config.max_window;
@@ -1754,21 +1755,21 @@ int Server::on_read(Endpoint &ep) {
 
       assert(hd.type == NGTCP2_PKT_INITIAL);
 
-      if (config.validate_addr || hd.token.len) {
+      if (config.validate_addr || hd.tokenlen) {
         std::cerr << "Perform stateless address validation" << std::endl;
-        if (hd.token.len == 0) {
+        if (hd.tokenlen == 0) {
           send_retry(&hd, ep, *local_addr, &su.sa, msg.msg_namelen, nread * 3);
           continue;
         }
 
-        if (hd.token.base[0] != NGTCP2_CRYPTO_TOKEN_MAGIC_RETRY &&
+        if (hd.token[0] != NGTCP2_CRYPTO_TOKEN_MAGIC_RETRY &&
             hd.dcid.datalen < NGTCP2_MIN_INITIAL_DCIDLEN) {
           send_stateless_connection_close(&hd, ep, *local_addr, &su.sa,
                                           msg.msg_namelen);
           continue;
         }
 
-        switch (hd.token.base[0]) {
+        switch (hd.token[0]) {
         case NGTCP2_CRYPTO_TOKEN_MAGIC_RETRY:
           if (verify_retry_token(&ocid, &hd, &su.sa, msg.msg_namelen) != 0) {
             send_stateless_connection_close(&hd, ep, *local_addr, &su.sa,
@@ -1785,8 +1786,8 @@ int Server::on_read(Endpoint &ep) {
               continue;
             }
 
-            hd.token.base = nullptr;
-            hd.token.len = 0;
+            hd.token = nullptr;
+            hd.tokenlen = 0;
           }
           break;
         default:
@@ -1799,16 +1800,15 @@ int Server::on_read(Endpoint &ep) {
             continue;
           }
 
-          hd.token.base = nullptr;
-          hd.token.len = 0;
+          hd.token = nullptr;
+          hd.tokenlen = 0;
           break;
         }
       }
 
       auto h = std::make_unique<Handler>(loop_, this);
       if (h->init(ep, *local_addr, &su.sa, msg.msg_namelen, &hd.scid, &hd.dcid,
-                  pocid, hd.token.base, hd.token.len, hd.version,
-                  tls_ctx_) != 0) {
+                  pocid, hd.token, hd.tokenlen, hd.version, tls_ctx_) != 0) {
         continue;
       }
 
@@ -2076,7 +2076,7 @@ int Server::verify_retry_token(ngtcp2_cid *ocid, const ngtcp2_pkt_hd *hd,
   if (!config.quiet) {
     std::cerr << "Verifying Retry token from [" << host.data()
               << "]:" << port.data() << std::endl;
-    util::hexdump(stderr, hd->token.base, hd->token.len);
+    util::hexdump(stderr, hd->token, hd->tokenlen);
   }
 
   auto t = std::chrono::duration_cast<std::chrono::nanoseconds>(
@@ -2084,7 +2084,7 @@ int Server::verify_retry_token(ngtcp2_cid *ocid, const ngtcp2_pkt_hd *hd,
                .count();
 
   if (ngtcp2_crypto_verify_retry_token(
-          ocid, hd->token.base, hd->token.len, config.static_secret.data(),
+          ocid, hd->token, hd->tokenlen, config.static_secret.data(),
           config.static_secret.size(), hd->version, sa, salen, &hd->dcid,
           10 * NGTCP2_SECONDS, t) != 0) {
     std::cerr << "Could not verify Retry token" << std::endl;
@@ -2114,14 +2114,14 @@ int Server::verify_token(const ngtcp2_pkt_hd *hd, const sockaddr *sa,
   if (!config.quiet) {
     std::cerr << "Verifying token from [" << host.data() << "]:" << port.data()
               << std::endl;
-    util::hexdump(stderr, hd->token.base, hd->token.len);
+    util::hexdump(stderr, hd->token, hd->tokenlen);
   }
 
   auto t = std::chrono::duration_cast<std::chrono::nanoseconds>(
                std::chrono::system_clock::now().time_since_epoch())
                .count();
 
-  if (ngtcp2_crypto_verify_regular_token(hd->token.base, hd->token.len,
+  if (ngtcp2_crypto_verify_regular_token(hd->token, hd->tokenlen,
                                          config.static_secret.data(),
                                          config.static_secret.size(), sa, salen,
                                          3600 * NGTCP2_SECONDS, t) != 0) {

--- a/lib/includes/ngtcp2/ngtcp2.h
+++ b/lib/includes/ngtcp2/ngtcp2.h
@@ -1182,7 +1182,11 @@ typedef struct ngtcp2_pkt_hd {
    * :member:`token` contains token for Initial
    * packet.
    */
-  ngtcp2_vec token;
+  const uint8_t *token;
+  /**
+   * :member:`tokenlen` is the length of :member:`token`.
+   */
+  size_t tokenlen;
   /**
    * :member:`pkt_numlen` is the number of bytes spent to encode
    * :member:`pkt_num`.
@@ -1907,7 +1911,11 @@ typedef struct ngtcp2_settings {
    * `ngtcp2_conn_server_new` and `ngtcp2_conn_client_new` make a copy
    * of token.
    */
-  ngtcp2_vec token;
+  const uint8_t *token;
+  /**
+   * :member:`tokenlen` is the length of :member:`token`.
+   */
+  size_t tokenlen;
   /**
    * :member:`rand_ctx` is an optional random number generator to be
    * passed to :type:`ngtcp2_rand` callback.
@@ -3166,14 +3174,14 @@ typedef int (*ngtcp2_connection_id_status)(ngtcp2_conn *conn, int type,
  * :type:`ngtcp2_recv_new_token` is a callback function which is
  * called when new token is received from server.
  *
- * |token| is the received token.
+ * |token| is the received token of length |tokenlen| bytes long.
  *
  * The callback function must return 0 if it succeeds.  Returning
  * :macro:`NGTCP2_ERR_CALLBACK_FAILURE` makes the library call return
  * immediately.
  */
-typedef int (*ngtcp2_recv_new_token)(ngtcp2_conn *conn, const ngtcp2_vec *token,
-                                     void *user_data);
+typedef int (*ngtcp2_recv_new_token)(ngtcp2_conn *conn, const uint8_t *token,
+                                     size_t tokenlen, void *user_data);
 
 /**
  * @functypedef

--- a/lib/ngtcp2_log.c
+++ b/lib/ngtcp2_log.c
@@ -429,16 +429,16 @@ static void log_fr_new_token(ngtcp2_log *log, const ngtcp2_pkt_hd *hd,
   uint8_t buf[128 + 1 + 1];
   uint8_t *p;
 
-  if (fr->token.len > 64) {
-    p = ngtcp2_encode_hex(buf, fr->token.base, 64);
+  if (fr->tokenlen > 64) {
+    p = ngtcp2_encode_hex(buf, fr->token, 64);
     p[128] = '*';
     p[129] = '\0';
   } else {
-    p = ngtcp2_encode_hex(buf, fr->token.base, fr->token.len);
+    p = ngtcp2_encode_hex(buf, fr->token, fr->tokenlen);
   }
   log->log_printf(
       log->user_data, (NGTCP2_LOG_PKT " NEW_TOKEN(0x%02x) token=0x%s len=%zu"),
-      NGTCP2_LOG_FRM_HD_FIELDS(dir), fr->type, (const char *)p, fr->token.len);
+      NGTCP2_LOG_FRM_HD_FIELDS(dir), fr->type, (const char *)p, fr->tokenlen);
 }
 
 static void log_fr_retire_connection_id(ngtcp2_log *log,

--- a/lib/ngtcp2_pkt.h
+++ b/lib/ngtcp2_pkt.h
@@ -139,7 +139,8 @@
 
 typedef struct ngtcp2_pkt_retry {
   ngtcp2_cid odcid;
-  ngtcp2_vec token;
+  uint8_t *token;
+  size_t tokenlen;
   uint8_t tag[NGTCP2_RETRY_TAGLEN];
 } ngtcp2_pkt_retry;
 
@@ -313,7 +314,8 @@ typedef struct ngtcp2_crypto {
 
 typedef struct ngtcp2_new_token {
   uint8_t type;
-  ngtcp2_vec token;
+  uint8_t *token;
+  size_t tokenlen;
 } ngtcp2_new_token;
 
 typedef struct ngtcp2_retire_connection_id {

--- a/lib/ngtcp2_ppe.c
+++ b/lib/ngtcp2_ppe.c
@@ -55,7 +55,7 @@ int ngtcp2_ppe_encode_hd(ngtcp2_ppe *ppe, const ngtcp2_pkt_hd *hd) {
   if (hd->flags & NGTCP2_PKT_FLAG_LONG_FORM) {
     ppe->len_offset = 1 + 4 + 1 + hd->dcid.datalen + 1 + hd->scid.datalen;
     if (hd->type == NGTCP2_PKT_INITIAL) {
-      ppe->len_offset += ngtcp2_put_uvarintlen(hd->token.len) + hd->token.len;
+      ppe->len_offset += ngtcp2_put_uvarintlen(hd->tokenlen) + hd->tokenlen;
     }
     ppe->pkt_num_offset = ppe->len_offset + NGTCP2_PKT_LENGTHLEN;
     rv = ngtcp2_pkt_encode_hd_long(

--- a/lib/ngtcp2_qlog.c
+++ b/lib/ngtcp2_qlog.c
@@ -285,9 +285,9 @@ static uint8_t *write_pkt_hd(uint8_t *p, const ngtcp2_pkt_hd *hd) {
   p = write_pair(p, "packet_type", qlog_pkt_type(hd));
   *p++ = ',';
   p = write_pair_number(p, "packet_number", (uint64_t)hd->pkt_num);
-  if (hd->type == NGTCP2_PKT_INITIAL && hd->token.len) {
+  if (hd->type == NGTCP2_PKT_INITIAL && hd->tokenlen) {
     p = write_verbatim(p, ",\"token\":{");
-    p = write_pair_hex(p, "data", hd->token.base, hd->token.len);
+    p = write_pair_hex(p, "data", hd->token, hd->tokenlen);
     *p++ = '}';
   }
   /* TODO Write DCIL and DCID */
@@ -433,9 +433,9 @@ static uint8_t *write_new_token_frame(uint8_t *p, const ngtcp2_new_token *fr) {
 #define NGTCP2_QLOG_NEW_TOKEN_FRAME_OVERHEAD 75
 
   p = write_verbatim(p, "{\"frame_type\":\"new_token\",");
-  p = write_pair_number(p, "length", fr->token.len);
+  p = write_pair_number(p, "length", fr->tokenlen);
   p = write_verbatim(p, ",\"token\":{");
-  p = write_pair_hex(p, "data", fr->token.base, fr->token.len);
+  p = write_pair_hex(p, "data", fr->token, fr->tokenlen);
   *p++ = '}';
   *p++ = '}';
 
@@ -716,7 +716,7 @@ static void qlog_pkt_write_end(ngtcp2_qlog *qlog, const ngtcp2_pkt_hd *hd,
   (1 + 50 + NGTCP2_QLOG_PKT_HD_OVERHEAD)
 
   if (ngtcp2_buf_left(&qlog->buf) <
-      NGTCP2_QLOG_PKT_WRITE_END_OVERHEAD + hd->token.len * 2) {
+      NGTCP2_QLOG_PKT_WRITE_END_OVERHEAD + hd->tokenlen * 2) {
     return;
   }
 
@@ -792,8 +792,8 @@ void ngtcp2_qlog_write_frame(ngtcp2_qlog *qlog, const ngtcp2_frame *fr) {
     p = write_crypto_frame(p, &fr->crypto);
     break;
   case NGTCP2_FRAME_NEW_TOKEN:
-    if (ngtcp2_buf_left(&qlog->buf) < NGTCP2_QLOG_NEW_TOKEN_FRAME_OVERHEAD +
-                                          fr->new_token.token.len * 2 + 1) {
+    if (ngtcp2_buf_left(&qlog->buf) <
+        NGTCP2_QLOG_NEW_TOKEN_FRAME_OVERHEAD + fr->new_token.tokenlen * 2 + 1) {
       return;
     }
     p = write_new_token_frame(p, &fr->new_token);
@@ -1129,16 +1129,15 @@ void ngtcp2_qlog_retry_pkt_received(ngtcp2_qlog *qlog, const ngtcp2_pkt_hd *hd,
       ",\"name\":\"transport:packet_received\",\"data\":{\"header\":");
 
   if (ngtcp2_buf_left(&buf) <
-      NGTCP2_QLOG_PKT_HD_OVERHEAD + hd->token.len * 2 +
+      NGTCP2_QLOG_PKT_HD_OVERHEAD + hd->tokenlen * 2 +
           sizeof(",\"retry_token\":{\"data\":\"\"}}}\n") - 1 +
-          retry->token.len * 2) {
+          retry->tokenlen * 2) {
     return;
   }
 
   buf.last = write_pkt_hd(buf.last, hd);
   buf.last = write_verbatim(buf.last, ",\"retry_token\":{");
-  buf.last =
-      write_pair_hex(buf.last, "data", retry->token.base, retry->token.len);
+  buf.last = write_pair_hex(buf.last, "data", retry->token, retry->tokenlen);
   buf.last = write_verbatim(buf.last, "}}}\n");
 
   qlog->write(qlog->user_data, NGTCP2_QLOG_WRITE_FLAG_NONE, buf.pos,

--- a/lib/ngtcp2_rtb.h
+++ b/lib/ngtcp2_rtb.h
@@ -160,7 +160,8 @@ int ngtcp2_frame_chain_crypto_datacnt_objalloc_new(ngtcp2_frame_chain **pfrc,
                                                    const ngtcp2_mem *mem);
 
 int ngtcp2_frame_chain_new_token_objalloc_new(ngtcp2_frame_chain **pfrc,
-                                              const ngtcp2_vec *token,
+                                              const uint8_t *token,
+                                              size_t tokenlen,
                                               ngtcp2_objalloc *objalloc,
                                               const ngtcp2_mem *mem);
 

--- a/tests/ngtcp2_pkt_test.c
+++ b/tests/ngtcp2_pkt_test.c
@@ -1232,7 +1232,8 @@ void test_ngtcp2_pkt_encode_new_token_frame(void) {
   size_t framelen;
 
   fr.type = NGTCP2_FRAME_NEW_TOKEN;
-  ngtcp2_vec_init(&fr.new_token.token, token, strsize(token));
+  fr.new_token.token = (uint8_t *)token;
+  fr.new_token.tokenlen = strsize(token);
 
   framelen = 1 + 1 + strsize(token);
 
@@ -1244,9 +1245,9 @@ void test_ngtcp2_pkt_encode_new_token_frame(void) {
 
   CU_ASSERT((ngtcp2_ssize)framelen == rv);
   CU_ASSERT(fr.type == nfr.type);
-  CU_ASSERT(fr.new_token.token.len == nfr.new_token.token.len);
-  CU_ASSERT(0 == memcmp(fr.new_token.token.base, nfr.new_token.token.base,
-                        fr.new_token.token.len));
+  CU_ASSERT(fr.new_token.tokenlen == nfr.new_token.tokenlen);
+  CU_ASSERT(0 == memcmp(fr.new_token.token, nfr.new_token.token,
+                        fr.new_token.tokenlen));
 }
 
 void test_ngtcp2_pkt_encode_retire_connection_id_frame(void) {
@@ -1522,8 +1523,8 @@ void test_ngtcp2_pkt_write_retry(void) {
   rv = ngtcp2_pkt_decode_retry(&retry, buf + nread, (size_t)(spktlen - nread));
 
   CU_ASSERT(0 == rv);
-  CU_ASSERT(sizeof(token) == retry.token.len);
-  CU_ASSERT(0 == memcmp(token, retry.token.base, sizeof(token)));
+  CU_ASSERT(sizeof(token) == retry.tokenlen);
+  CU_ASSERT(0 == memcmp(token, retry.token, sizeof(token)));
   CU_ASSERT(0 == memcmp(tag, retry.tag, sizeof(tag)));
 }
 

--- a/tests/ngtcp2_test_helper.c
+++ b/tests/ngtcp2_test_helper.c
@@ -191,8 +191,8 @@ static size_t write_long_header_pkt_generic(
           : version,
       0);
 
-  hd.token.base = (uint8_t *)token;
-  hd.token.len = tokenlen;
+  hd.token = token;
+  hd.tokenlen = tokenlen;
 
   ngtcp2_ppe_init(&ppe, out, outlen, &cc);
   rv = ngtcp2_ppe_encode_hd(&ppe, &hd);


### PR DESCRIPTION
Previously, tokens are of type ngtcp2_vec.  Meanwhile, in other places, we use a pair of plain pointer to const uint8_t and size_t as length.  This commit changes the type of tokens to a pair of pointer and size_t for consistency.