### PR TITLE
Make hard-coded static library suffix optional

### DIFF
--- a/crypto/boringssl/CMakeLists.txt
+++ b/crypto/boringssl/CMakeLists.txt
@@ -48,6 +48,7 @@ if(ENABLE_STATIC_LIB)
   add_library(ngtcp2_crypto_boringssl_static ${ngtcp2_crypto_boringssl_SOURCES})
   set_target_properties(ngtcp2_crypto_boringssl_static PROPERTIES
     COMPILE_FLAGS "${WARNCFLAGS}"
+    ARCHIVE_OUTPUT_NAME ngtcp2_crypto_boringssl${STATIC_LIB_SUFFIX}
     C_VISIBILITY_PRESET hidden
   )
   target_compile_definitions(ngtcp2_crypto_boringssl_static PUBLIC

--- a/crypto/gnutls/CMakeLists.txt
+++ b/crypto/gnutls/CMakeLists.txt
@@ -70,6 +70,7 @@ if(ENABLE_STATIC_LIB)
     COMPILE_FLAGS "${WARNCFLAGS}"
     VERSION ${CRYPTO_GNUTLS_LT_VERSION}
     SOVERSION ${CRYPTO_GNUTLS_LT_SOVERSION}
+    ARCHIVE_OUTPUT_NAME ngtcp2_crypto_gnutls${STATIC_LIB_SUFFIX}
     C_VISIBILITY_PRESET hidden
   )
   target_compile_definitions(ngtcp2_crypto_gnutls_static PUBLIC

--- a/crypto/openssl/CMakeLists.txt
+++ b/crypto/openssl/CMakeLists.txt
@@ -70,6 +70,7 @@ if(ENABLE_STATIC_LIB)
     COMPILE_FLAGS "${WARNCFLAGS}"
     VERSION ${CRYPTO_OPENSSL_LT_VERSION}
     SOVERSION ${CRYPTO_OPENSSL_LT_SOVERSION}
+    ARCHIVE_OUTPUT_NAME ngtcp2_crypto_openssl${STATIC_LIB_SUFFIX}
     C_VISIBILITY_PRESET hidden
   )
   target_compile_definitions(ngtcp2_crypto_openssl_static PUBLIC

--- a/crypto/picotls/CMakeLists.txt
+++ b/crypto/picotls/CMakeLists.txt
@@ -49,6 +49,7 @@ if(ENABLE_STATIC_LIB)
   add_library(ngtcp2_crypto_picotls_static ${ngtcp2_crypto_picotls_SOURCES})
   set_target_properties(ngtcp2_crypto_picotls_static PROPERTIES
     COMPILE_FLAGS "${WARNCFLAGS}"
+    ARCHIVE_OUTPUT_NAME ngtcp2_crypto_picotls${STATIC_LIB_SUFFIX}
     C_VISIBILITY_PRESET hidden
   )
   target_compile_definitions(ngtcp2_crypto_picotls_static PUBLIC

--- a/crypto/wolfssl/CMakeLists.txt
+++ b/crypto/wolfssl/CMakeLists.txt
@@ -68,6 +68,7 @@ if(ENABLE_STATIC_LIB)
   add_library(ngtcp2_crypto_wolfssl_static ${ngtcp2_crypto_wolfssl_SOURCES})
   set_target_properties(ngtcp2_crypto_wolfssl_static PROPERTIES
     COMPILE_FLAGS "${WARNCFLAGS}"
+    ARCHIVE_OUTPUT_NAME ngtcp2_crypto_wolfssl${STATIC_LIB_SUFFIX}
     C_VISIBILITY_PRESET hidden
   )
   target_compile_definitions(ngtcp2_crypto_wolfssl_static PUBLIC

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -95,6 +95,7 @@ if(HAVE_CUNIT OR ENABLE_STATIC_LIB)
   set_target_properties(ngtcp2_static PROPERTIES
     COMPILE_FLAGS "${WARNCFLAGS}"
     VERSION ${LT_VERSION} SOVERSION ${LT_SOVERSION}
+    ARCHIVE_OUTPUT_NAME ngtcp2${STATIC_LIB_SUFFIX}
     C_VISIBILITY_PRESET hidden
   )
   target_compile_definitions(ngtcp2_static PUBLIC "-DNGTCP2_STATICLIB")


### PR DESCRIPTION
Add `STATIC_LIB_SUFFIX` to set the suffix directly.

This follows the same behavior as nghttp2 and nghttp3.