### PR TITLE
Remove QUIC version 2 draft

### DIFF
--- a/crypto/shared.c
+++ b/crypto/shared.c
@@ -95,10 +95,6 @@ int ngtcp2_crypto_derive_initial_secrets(uint32_t version, uint8_t *rx_secret,
     salt = (const uint8_t *)NGTCP2_INITIAL_SALT_V2;
     saltlen = sizeof(NGTCP2_INITIAL_SALT_V2) - 1;
     break;
-  case NGTCP2_PROTO_VER_V2_DRAFT:
-    salt = (const uint8_t *)NGTCP2_INITIAL_SALT_V2_DRAFT;
-    saltlen = sizeof(NGTCP2_INITIAL_SALT_V2_DRAFT) - 1;
-    break;
   default:
     salt = (const uint8_t *)NGTCP2_INITIAL_SALT_DRAFT;
     saltlen = sizeof(NGTCP2_INITIAL_SALT_DRAFT) - 1;
@@ -157,7 +153,6 @@ int ngtcp2_crypto_derive_packet_protection_key(
 
   switch (version) {
   case NGTCP2_PROTO_VER_V2:
-  case NGTCP2_PROTO_VER_V2_DRAFT:
     key_label = KEY_LABEL_V2;
     key_labellen = sizeof(KEY_LABEL_V2) - 1;
     iv_label = IV_LABEL_V2;
@@ -575,10 +570,6 @@ int ngtcp2_crypto_derive_and_install_initial_key(
     case NGTCP2_PROTO_VER_V2:
       retry_key = (const uint8_t *)NGTCP2_RETRY_KEY_V2;
       retry_noncelen = sizeof(NGTCP2_RETRY_NONCE_V2) - 1;
-      break;
-    case NGTCP2_PROTO_VER_V2_DRAFT:
-      retry_key = (const uint8_t *)NGTCP2_RETRY_KEY_V2_DRAFT;
-      retry_noncelen = sizeof(NGTCP2_RETRY_NONCE_V2_DRAFT) - 1;
       break;
     default:
       retry_key = (const uint8_t *)NGTCP2_RETRY_KEY_DRAFT;
@@ -1302,10 +1293,6 @@ ngtcp2_ssize ngtcp2_crypto_write_retry(uint8_t *dest, size_t destlen,
   case NGTCP2_PROTO_VER_V2:
     key = (const uint8_t *)NGTCP2_RETRY_KEY_V2;
     noncelen = sizeof(NGTCP2_RETRY_NONCE_V2) - 1;
-    break;
-  case NGTCP2_PROTO_VER_V2_DRAFT:
-    key = (const uint8_t *)NGTCP2_RETRY_KEY_V2_DRAFT;
-    noncelen = sizeof(NGTCP2_RETRY_NONCE_V2_DRAFT) - 1;
     break;
   default:
     key = (const uint8_t *)NGTCP2_RETRY_KEY_DRAFT;

--- a/crypto/shared.h
+++ b/crypto/shared.h
@@ -54,16 +54,6 @@
 /**
  * @macro
  *
- * :macro:`NGTCP2_INITIAL_SALT_V2_DRAFT` is a salt value which is used to
- * derive initial secret.  It is used for QUIC v2 draft.
- */
-#define NGTCP2_INITIAL_SALT_V2_DRAFT                                           \
-  "\xa7\x07\xc2\x03\xa5\x9b\x47\x18\x4a\x1d\x62\xca\x57\x04\x06\xea\x7a\xe3"   \
-  "\xe5\xd3"
-
-/**
- * @macro
- *
  * :macro:`NGTCP2_INITIAL_SALT_V2` is a salt value which is used to
  * derive initial secret.  It is used for QUIC v2.
  */

--- a/examples/client.cc
+++ b/examples/client.cc
@@ -2266,8 +2266,7 @@ Options:
               version is  not supported by libngtcp2,  client will use
               QUIC v1  long packet  types.  Instead of  specifying hex
               string,  there  are   special  aliases  available:  "v1"
-              indicates QUIC v1, "v2" indicates QUIC v2, and "v2draft"
-              indicates QUIC v2 draft.
+              indicates QUIC v1, and "v2" indicates QUIC v2.
               Default: )"
             << std::hex << "0x" << config.version << std::dec << R"(
   --preferred-versions=<HEX>[[,<HEX>]...]
@@ -2276,16 +2275,16 @@ Options:
               client received Version  Negotiation packet from server.
               These versions must be  supported by libngtcp2.  Instead
               of  specifying hex  string,  there  are special  aliases
-              available: "v1"  indicates QUIC v1, "v2"  indicates QUIC
-              v2, and "v2draft" indicates QUIC v2 draft.
+              available: "v1"  indicates QUIC  v1, and  "v2" indicates
+              QUIC v2.
   --available-versions=<HEX>[[,<HEX>]...]
               Specify QUIC  versions in  hex string  that are  sent in
               available_versions    field    of    version_information
               transport parameter.   This list  can include  a version
               which  is  not  supported   by  libngtcp2.   Instead  of
               specifying  hex   string,  there  are   special  aliases
-              available: "v1"  indicates QUIC v1, "v2"  indicates QUIC
-              v2, and "v2draft" indicates QUIC v2 draft.
+              available: "v1"  indicates QUIC  v1, and  "v2" indicates
+              QUIC v2.
   -q, --quiet Suppress debug output.
   -s, --show-secret
               Print out secrets unless --quiet is used.
@@ -2564,10 +2563,6 @@ int main(int argc, char **argv) {
       }
       if (optarg == "v2"sv) {
         config.version = NGTCP2_PROTO_VER_V2;
-        break;
-      }
-      if (optarg == "v2draft"sv) {
-        config.version = NGTCP2_PROTO_VER_V2_DRAFT;
         break;
       }
       auto rv = util::parse_version(optarg);
@@ -2859,10 +2854,6 @@ int main(int argc, char **argv) {
             *it++ = NGTCP2_PROTO_VER_V2;
             continue;
           }
-          if (k == "v2draft"sv) {
-            *it++ = NGTCP2_PROTO_VER_V2_DRAFT;
-            continue;
-          }
           auto rv = util::parse_version(k);
           if (!rv) {
             std::cerr << "available-versions: invalid version "
@@ -2893,10 +2884,6 @@ int main(int argc, char **argv) {
           }
           if (k == "v2"sv) {
             *it++ = NGTCP2_PROTO_VER_V2;
-            continue;
-          }
-          if (k == "v2draft"sv) {
-            *it++ = NGTCP2_PROTO_VER_V2_DRAFT;
             continue;
           }
           auto rv = util::parse_version(k);

--- a/examples/h09client.cc
+++ b/examples/h09client.cc
@@ -1833,8 +1833,7 @@ Options:
               version is  not supported by libngtcp2,  client will use
               QUIC v1  long packet  types.  Instead of  specifying hex
               string,  there  are   special  aliases  available:  "v1"
-              indicates QUIC v1, "v2" indicates QUIC v2, and "v2draft"
-              indicates QUIC v2 draft.
+              indicates QUIC v1, and "v2" indicates QUIC v2.
               Default: )"
             << std::hex << "0x" << config.version << std::dec << R"(
   --preferred-versions=<HEX>[[,<HEX>]...]
@@ -1843,16 +1842,16 @@ Options:
               client received Version  Negotiation packet from server.
               These versions must be  supported by libngtcp2.  Instead
               of  specifying hex  string,  there  are special  aliases
-              available: "v1"  indicates QUIC v1, "v2"  indicates QUIC
-              v2, and "v2draft" indicates QUIC v2 draft.
+              available: "v1"  indicates QUIC  v1, and  "v2" indicates
+              QUIC v2.
   --available-versions=<HEX>[[,<HEX>]...]
               Specify QUIC  versions in  hex string  that are  sent in
               available_versions    field    of    version_information
               transport parameter.   This list  can include  a version
               which  is  not  supported   by  libngtcp2.   Instead  of
               specifying  hex   string,  there  are   special  aliases
-              available: "v1"  indicates QUIC v1, "v2"  indicates QUIC
-              v2, and "v2draft" indicates QUIC v2 draft.
+              available: "v1"  indicates QUIC  v1, and  "v2" indicates
+              QUIC v2.
   -q, --quiet Suppress debug output.
   -s, --show-secret
               Print out secrets unless --quiet is used.
@@ -2125,10 +2124,6 @@ int main(int argc, char **argv) {
       }
       if (optarg == "v2"sv) {
         config.version = NGTCP2_PROTO_VER_V2;
-        break;
-      }
-      if (optarg == "v2draft"sv) {
-        config.version = NGTCP2_PROTO_VER_V2_DRAFT;
         break;
       }
       auto rv = util::parse_version(optarg);
@@ -2411,10 +2406,6 @@ int main(int argc, char **argv) {
             *it++ = NGTCP2_PROTO_VER_V2;
             continue;
           }
-          if (k == "v2draft"sv) {
-            *it++ = NGTCP2_PROTO_VER_V2_DRAFT;
-            continue;
-          }
           auto rv = util::parse_version(k);
           if (!rv) {
             std::cerr << "available-versions: invalid version "
@@ -2445,10 +2436,6 @@ int main(int argc, char **argv) {
           }
           if (k == "v2"sv) {
             *it++ = NGTCP2_PROTO_VER_V2;
-            continue;
-          }
-          if (k == "v2draft"sv) {
-            *it++ = NGTCP2_PROTO_VER_V2_DRAFT;
             continue;
           }
           auto rv = util::parse_version(k);

--- a/examples/h09server.cc
+++ b/examples/h09server.cc
@@ -2549,16 +2549,16 @@ Options:
               client  initially  selects  a  less  preferred  version.
               These versions must be  supported by libngtcp2.  Instead
               of  specifying hex  string,  there  are special  aliases
-              available: "v1"  indicates QUIC v1, "v2"  indicates QUIC
-              v2, and "v2draft" indicates QUIC v2 draft.
+              available: "v1"  indicates QUIC  v1, and  "v2" indicates
+              QUIC v2.
   --available-versions=<HEX>[[,<HEX>]...]
               Specify QUIC  versions in  hex string  that are  sent in
               available_versions    field    of    version_information
               transport parameter.   This list  can include  a version
               which  is  not  supported   by  libngtcp2.   Instead  of
               specifying  hex   string,  there  are   special  aliases
-              available: "v1"  indicates QUIC v1, "v2"  indicates QUIC
-              v2, and "v2draft" indicates QUIC v2 draft.
+              available: "v1"  indicates QUIC  v1, and  "v2" indicates
+              QUIC v2.
   --no-pmtud  Disables Path MTU Discovery.
   --ack-thresh=<N>
               The minimum number of the received ACK eliciting packets
@@ -2901,10 +2901,6 @@ int main(int argc, char **argv) {
             *it++ = NGTCP2_PROTO_VER_V2;
             continue;
           }
-          if (k == "v2draft"sv) {
-            *it++ = NGTCP2_PROTO_VER_V2_DRAFT;
-            continue;
-          }
           auto rv = util::parse_version(k);
           if (!rv) {
             std::cerr << "preferred-versions: invalid version "
@@ -2932,10 +2928,6 @@ int main(int argc, char **argv) {
           }
           if (k == "v2"sv) {
             *it++ = NGTCP2_PROTO_VER_V2;
-            continue;
-          }
-          if (k == "v2draft"sv) {
-            *it++ = NGTCP2_PROTO_VER_V2_DRAFT;
             continue;
           }
           auto rv = util::parse_version(k);

--- a/examples/server.cc
+++ b/examples/server.cc
@@ -3256,16 +3256,16 @@ Options:
               client  initially  selects  a  less  preferred  version.
               These versions must be  supported by libngtcp2.  Instead
               of  specifying hex  string,  there  are special  aliases
-              available: "v1"  indicates QUIC v1, "v2"  indicates QUIC
-              v2, and "v2draft" indicates QUIC v2 draft.
+              available: "v1"  indicates QUIC  v1, and  "v2" indicates
+              QUIC v2.
   --available-versions=<HEX>[[,<HEX>]...]
               Specify QUIC  versions in  hex string  that are  sent in
               available_versions    field    of    version_information
               transport parameter.   This list  can include  a version
               which  is  not  supported   by  libngtcp2.   Instead  of
               specifying  hex   string,  there  are   special  aliases
-              available: "v1"  indicates QUIC v1, "v2"  indicates QUIC
-              v2, and "v2draft" indicates QUIC v2 draft.
+              available: "v1"  indicates QUIC  v1, and  "v2" indicates
+              QUIC v2.
   --no-pmtud  Disables Path MTU Discovery.
   --ack-thresh=<N>
               The minimum number of the received ACK eliciting packets
@@ -3608,10 +3608,6 @@ int main(int argc, char **argv) {
             *it++ = NGTCP2_PROTO_VER_V2;
             continue;
           }
-          if (k == "v2draft"sv) {
-            *it++ = NGTCP2_PROTO_VER_V2_DRAFT;
-            continue;
-          }
           auto rv = util::parse_version(k);
           if (!rv) {
             std::cerr << "preferred-versions: invalid version "
@@ -3639,10 +3635,6 @@ int main(int argc, char **argv) {
           }
           if (k == "v2"sv) {
             *it++ = NGTCP2_PROTO_VER_V2;
-            continue;
-          }
-          if (k == "v2draft"sv) {
-            *it++ = NGTCP2_PROTO_VER_V2_DRAFT;
             continue;
           }
           auto rv = util::parse_version(k);

--- a/examples/tls_server_context_boringssl.cc
+++ b/examples/tls_server_context_boringssl.cc
@@ -77,7 +77,6 @@ int alpn_select_proto_h3_cb(SSL *ssl, const unsigned char **out,
     break;
   case NGTCP2_PROTO_VER_V1:
   case NGTCP2_PROTO_VER_V2:
-  case NGTCP2_PROTO_VER_V2_DRAFT:
     alpn = H3_ALPN_V1;
     alpnlen = str_size(H3_ALPN_V1);
     break;
@@ -136,7 +135,6 @@ int alpn_select_proto_hq_cb(SSL *ssl, const unsigned char **out,
     break;
   case NGTCP2_PROTO_VER_V1:
   case NGTCP2_PROTO_VER_V2:
-  case NGTCP2_PROTO_VER_V2_DRAFT:
     alpn = HQ_ALPN_V1;
     alpnlen = str_size(HQ_ALPN_V1);
     break;

--- a/examples/tls_server_context_openssl.cc
+++ b/examples/tls_server_context_openssl.cc
@@ -79,7 +79,6 @@ int alpn_select_proto_h3_cb(SSL *ssl, const unsigned char **out,
     break;
   case NGTCP2_PROTO_VER_V1:
   case NGTCP2_PROTO_VER_V2:
-  case NGTCP2_PROTO_VER_V2_DRAFT:
     alpn = H3_ALPN_V1;
     alpnlen = str_size(H3_ALPN_V1);
     break;
@@ -138,7 +137,6 @@ int alpn_select_proto_hq_cb(SSL *ssl, const unsigned char **out,
     break;
   case NGTCP2_PROTO_VER_V1:
   case NGTCP2_PROTO_VER_V2:
-  case NGTCP2_PROTO_VER_V2_DRAFT:
     alpn = HQ_ALPN_V1;
     alpnlen = str_size(HQ_ALPN_V1);
     break;

--- a/examples/tls_server_context_wolfssl.cc
+++ b/examples/tls_server_context_wolfssl.cc
@@ -77,7 +77,6 @@ int alpn_select_proto_h3_cb(WOLFSSL *ssl, const unsigned char **out,
     break;
   case NGTCP2_PROTO_VER_V1:
   case NGTCP2_PROTO_VER_V2:
-  case NGTCP2_PROTO_VER_V2_DRAFT:
     alpn = H3_ALPN_V1;
     alpnlen = str_size(H3_ALPN_V1);
     break;
@@ -137,7 +136,6 @@ int alpn_select_proto_hq_cb(WOLFSSL *ssl, const unsigned char **out,
     break;
   case NGTCP2_PROTO_VER_V1:
   case NGTCP2_PROTO_VER_V2:
-  case NGTCP2_PROTO_VER_V2_DRAFT:
     alpn = HQ_ALPN_V1;
     alpnlen = str_size(HQ_ALPN_V1);
     break;

--- a/lib/includes/ngtcp2/ngtcp2.h
+++ b/lib/includes/ngtcp2/ngtcp2.h
@@ -276,16 +276,6 @@ typedef struct ngtcp2_mem {
 /**
  * @macro
  *
- * :macro:`NGTCP2_PROTO_VER_V2_DRAFT` is the provisional version
- * number for QUIC version 2 draft.
- *
- * https://quicwg.org/quic-v2/draft-ietf-quic-v2.html
- */
-#define NGTCP2_PROTO_VER_V2_DRAFT ((uint32_t)0x709a50c4u)
-
-/**
- * @macro
- *
  * :macro:`NGTCP2_PROTO_VER_DRAFT_MAX` is the maximum QUIC draft
  * version that this library supports.
  */
@@ -438,28 +428,6 @@ typedef struct ngtcp2_mem {
  * https://quicwg.org/quic-v2/draft-ietf-quic-v2.html
  */
 #define NGTCP2_RETRY_NONCE_V2 "\xd8\x69\x69\xbc\x2d\x7c\x6d\x99\x90\xef\xb0\x4a"
-
-/**
- * @macro
- *
- * :macro:`NGTCP2_RETRY_KEY_V2_DRAFT` is an encryption key to create
- * integrity tag of Retry packet.  It is used for QUIC v2 draft.
- *
- * https://quicwg.org/quic-v2/draft-ietf-quic-v2.html
- */
-#define NGTCP2_RETRY_KEY_V2_DRAFT                                              \
-  "\xba\x85\x8d\xc7\xb4\x3d\xe5\xdb\xf8\x76\x17\xff\x4a\xb2\x53\xdb"
-
-/**
- * @macro
- *
- * :macro:`NGTCP2_RETRY_NONCE_V2_DRAFT` is nonce used when generating
- * integrity tag of Retry packet.  It is used for QUIC v2 draft.
- *
- * https://quicwg.org/quic-v2/draft-ietf-quic-v2.html
- */
-#define NGTCP2_RETRY_NONCE_V2_DRAFT                                            \
-  "\x14\x1b\x99\xc2\x39\xb0\x3e\x78\x5d\x6a\x2e\x9f"
 
 /**
  * @macro

--- a/lib/ngtcp2_pkt.c
+++ b/lib/ngtcp2_pkt.c
@@ -2248,10 +2248,6 @@ ngtcp2_ssize ngtcp2_pkt_write_retry(
     nonce = (const uint8_t *)NGTCP2_RETRY_NONCE_V2;
     noncelen = sizeof(NGTCP2_RETRY_NONCE_V2) - 1;
     break;
-  case NGTCP2_PROTO_VER_V2_DRAFT:
-    nonce = (const uint8_t *)NGTCP2_RETRY_NONCE_V2_DRAFT;
-    noncelen = sizeof(NGTCP2_RETRY_NONCE_V2_DRAFT) - 1;
-    break;
   default:
     nonce = (const uint8_t *)NGTCP2_RETRY_NONCE_DRAFT;
     noncelen = sizeof(NGTCP2_RETRY_NONCE_DRAFT) - 1;
@@ -2344,10 +2340,6 @@ int ngtcp2_pkt_verify_retry_tag(uint32_t version, const ngtcp2_pkt_retry *retry,
     nonce = (const uint8_t *)NGTCP2_RETRY_NONCE_V2;
     noncelen = sizeof(NGTCP2_RETRY_NONCE_V2) - 1;
     break;
-  case NGTCP2_PROTO_VER_V2_DRAFT:
-    nonce = (const uint8_t *)NGTCP2_RETRY_NONCE_V2_DRAFT;
-    noncelen = sizeof(NGTCP2_RETRY_NONCE_V2_DRAFT) - 1;
-    break;
   default:
     nonce = (const uint8_t *)NGTCP2_RETRY_NONCE_DRAFT;
     noncelen = sizeof(NGTCP2_RETRY_NONCE_DRAFT) - 1;
@@ -2439,7 +2431,6 @@ int ngtcp2_is_supported_version(uint32_t version) {
   switch (version) {
   case NGTCP2_PROTO_VER_V1:
   case NGTCP2_PROTO_VER_V2:
-  case NGTCP2_PROTO_VER_V2_DRAFT:
     return 1;
   default:
     return NGTCP2_PROTO_VER_DRAFT_MIN <= version &&
@@ -2457,7 +2448,6 @@ uint8_t ngtcp2_pkt_get_type_long(uint32_t version, uint8_t c) {
 
   switch (version) {
   case NGTCP2_PROTO_VER_V2:
-  case NGTCP2_PROTO_VER_V2_DRAFT:
     switch (pkt_type) {
     case NGTCP2_PKT_TYPE_INITIAL_V2:
       return NGTCP2_PKT_INITIAL;
@@ -2495,7 +2485,6 @@ uint8_t ngtcp2_pkt_get_type_long(uint32_t version, uint8_t c) {
 uint8_t ngtcp2_pkt_versioned_type(uint32_t version, uint32_t pkt_type) {
   switch (version) {
   case NGTCP2_PROTO_VER_V2:
-  case NGTCP2_PROTO_VER_V2_DRAFT:
     switch (pkt_type) {
     case NGTCP2_PKT_INITIAL:
       return NGTCP2_PKT_TYPE_INITIAL_V2;

--- a/tests/ngtcp2_test_helper.c
+++ b/tests/ngtcp2_test_helper.c
@@ -186,8 +186,7 @@ static size_t write_long_header_pkt_generic(
      later. */
   ngtcp2_pkt_hd_init(
       &hd, NGTCP2_PKT_FLAG_LONG_FORM, pkt_type, dcid, scid, pkt_num, 4,
-      version != NGTCP2_PROTO_VER_V1 && version != NGTCP2_PROTO_VER_V2 &&
-              version != NGTCP2_PROTO_VER_V2_DRAFT
+      version != NGTCP2_PROTO_VER_V1 && version != NGTCP2_PROTO_VER_V2
           ? NGTCP2_PROTO_VER_V1
           : version,
       0);


### PR DESCRIPTION
Remove QUIC version 2 draft because QUIC version 2 draft most likely requires old Version Information transport parameter codepoint, which ngtcp2 does not support anymore.