### PR TITLE
Remove the default handshake timeout

### DIFF
--- a/examples/client.cc
+++ b/examples/client.cc
@@ -2230,7 +2230,7 @@ void config_set_default(Config &config) {
   config.max_streams_uni = 100;
   config.cc_algo = NGTCP2_CC_ALGO_CUBIC;
   config.initial_rtt = NGTCP2_DEFAULT_INITIAL_RTT;
-  config.handshake_timeout = NGTCP2_DEFAULT_HANDSHAKE_TIMEOUT;
+  config.handshake_timeout = UINT64_MAX;
   config.ack_thresh = 2;
 }
 } // namespace
@@ -2420,9 +2420,8 @@ Options:
   --max-udp-payload-size=<SIZE>
               Override maximum UDP payload size that client transmits.
   --handshake-timeout=<DURATION>
-              Set the QUIC handshake timeout.
-              Default: )"
-            << util::format_duration(config.handshake_timeout) << R"(
+              Set  the  QUIC handshake  timeout.   It  defaults to  no
+              timeout.
   --no-pmtud  Disables Path MTU Discovery.
   --ack-thresh=<N>
               The minimum number of the received ACK eliciting packets

--- a/examples/h09client.cc
+++ b/examples/h09client.cc
@@ -1797,7 +1797,7 @@ void config_set_default(Config &config) {
   config.max_streams_uni = 100;
   config.cc_algo = NGTCP2_CC_ALGO_CUBIC;
   config.initial_rtt = NGTCP2_DEFAULT_INITIAL_RTT;
-  config.handshake_timeout = NGTCP2_DEFAULT_HANDSHAKE_TIMEOUT;
+  config.handshake_timeout = UINT64_MAX;
   config.ack_thresh = 2;
 }
 } // namespace
@@ -1982,9 +1982,8 @@ Options:
   --max-udp-payload-size=<SIZE>
               Override maximum UDP payload size that client transmits.
   --handshake-timeout=<DURATION>
-              Set the QUIC handshake timeout.
-              Default: )"
-            << util::format_duration(config.handshake_timeout) << R"(
+              Set  the  QUIC handshake  timeout.   It  defaults to  no
+              timeout.
   --no-pmtud  Disables Path MTU Discovery.
   --ack-thresh=<N>
               The minimum number of the received ACK eliciting packets

--- a/examples/h09server.cc
+++ b/examples/h09server.cc
@@ -2406,7 +2406,7 @@ void config_set_default(Config &config) {
   config.cc_algo = NGTCP2_CC_ALGO_CUBIC;
   config.initial_rtt = NGTCP2_DEFAULT_INITIAL_RTT;
   config.max_gso_dgrams = 64;
-  config.handshake_timeout = NGTCP2_DEFAULT_HANDSHAKE_TIMEOUT;
+  config.handshake_timeout = UINT64_MAX;
   config.ack_thresh = 2;
 }
 } // namespace
@@ -2541,9 +2541,8 @@ Options:
               Default: )"
             << config.max_gso_dgrams << R"(
   --handshake-timeout=<DURATION>
-              Set the QUIC handshake timeout.
-              Default: )"
-            << util::format_duration(config.handshake_timeout) << R"(
+              Set  the  QUIC handshake  timeout.   It  defaults to  no
+              timeout.
   --preferred-versions=<HEX>[[,<HEX>]...]
               Specify  QUIC versions  in hex  string in  the order  of
               preference.  Server negotiates one  of those versions if

--- a/examples/server.cc
+++ b/examples/server.cc
@@ -3113,7 +3113,7 @@ void config_set_default(Config &config) {
   config.cc_algo = NGTCP2_CC_ALGO_CUBIC;
   config.initial_rtt = NGTCP2_DEFAULT_INITIAL_RTT;
   config.max_gso_dgrams = 64;
-  config.handshake_timeout = NGTCP2_DEFAULT_HANDSHAKE_TIMEOUT;
+  config.handshake_timeout = UINT64_MAX;
   config.ack_thresh = 2;
 }
 } // namespace
@@ -3248,9 +3248,8 @@ Options:
               Default: )"
             << config.max_gso_dgrams << R"(
   --handshake-timeout=<DURATION>
-              Set the QUIC handshake timeout.
-              Default: )"
-            << util::format_duration(config.handshake_timeout) << R"(
+              Set  the  QUIC handshake  timeout.   It  defaults to  no
+              timeout.
   --preferred-versions=<HEX>[[,<HEX>]...]
               Specify  QUIC versions  in hex  string in  the order  of
               preference.  Server negotiates one  of those versions if

--- a/lib/includes/ngtcp2/ngtcp2.h
+++ b/lib/includes/ngtcp2/ngtcp2.h
@@ -475,14 +475,6 @@ typedef struct ngtcp2_mem {
 #define NGTCP2_MIN_INITIAL_DCIDLEN 8
 
 /**
- * @macro
- *
- * :macro:`NGTCP2_DEFAULT_HANDSHAKE_TIMEOUT` is the default handshake
- * timeout.
- */
-#define NGTCP2_DEFAULT_HANDSHAKE_TIMEOUT (10 * NGTCP2_SECONDS)
-
-/**
  * @macrosection
  *
  * ECN related macros
@@ -5597,7 +5589,7 @@ NGTCP2_EXTERN void ngtcp2_path_storage_zero(ngtcp2_path_storage *ps);
  * * :type:`max_tx_udp_payload_size
  *   <ngtcp2_settings.max_tx_udp_payload_size>` = 1452
  * * :type:`handshake_timeout <ngtcp2_settings.handshake_timeout>` =
- *   :macro:`NGTCP2_DEFAULT_HANDSHAKE_TIMEOUT`.
+ *   ``UINT64_MAX``
  */
 NGTCP2_EXTERN void ngtcp2_settings_default_versioned(int settings_version,
                                                      ngtcp2_settings *settings);

--- a/lib/ngtcp2_conn.c
+++ b/lib/ngtcp2_conn.c
@@ -13596,7 +13596,7 @@ void ngtcp2_settings_default_versioned(int settings_version,
   settings->initial_rtt = NGTCP2_DEFAULT_INITIAL_RTT;
   settings->ack_thresh = 2;
   settings->max_tx_udp_payload_size = 1500 - 48;
-  settings->handshake_timeout = NGTCP2_DEFAULT_HANDSHAKE_TIMEOUT;
+  settings->handshake_timeout = UINT64_MAX;
 }
 
 void ngtcp2_transport_params_default_versioned(

--- a/tests/ngtcp2_conn_test.c
+++ b/tests/ngtcp2_conn_test.c
@@ -546,7 +546,7 @@ static void server_default_settings(ngtcp2_settings *settings) {
   settings->initial_rtt = NGTCP2_DEFAULT_INITIAL_RTT;
   settings->max_tx_udp_payload_size = 2048;
   settings->no_tx_udp_payload_size_shaping = 1;
-  settings->handshake_timeout = NGTCP2_DEFAULT_HANDSHAKE_TIMEOUT;
+  settings->handshake_timeout = 10 * NGTCP2_SECONDS;
 }
 
 static void server_default_transport_params(ngtcp2_transport_params *params) {


### PR DESCRIPTION
Remove the default handshake timeout because the current value (10 seconds) is arbitrary choice and no good reason behind it.