### PR TITLE
Hide ngtcp2_conn_stat from public API set

### DIFF
--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -114,7 +114,8 @@ HFILES = \
 	ngtcp2_objalloc.h \
 	ngtcp2_rcvry.h \
 	ngtcp2_net.h \
-	ngtcp2_unreachable.h
+	ngtcp2_unreachable.h \
+	ngtcp2_conn_stat.h
 
 libngtcp2_la_SOURCES = $(HFILES) $(OBJECTS)
 libngtcp2_la_LDFLAGS = -no-undefined \

--- a/lib/includes/ngtcp2/ngtcp2.h
+++ b/lib/includes/ngtcp2/ngtcp2.h
@@ -1652,106 +1652,6 @@ typedef enum ngtcp2_pktns_id {
   NGTCP2_PKTNS_ID_MAX
 } ngtcp2_pktns_id;
 
-#define NGTCP2_CONN_STAT_VERSION_V1 1
-#define NGTCP2_CONN_STAT_VERSION NGTCP2_CONN_STAT_VERSION_V1
-
-/**
- * @struct
- *
- * :type:`ngtcp2_conn_stat` holds various connection statistics, and
- * computed data for recovery and congestion controller.
- */
-typedef struct ngtcp2_conn_stat {
-  /**
-   * :member:`latest_rtt` is the latest RTT sample which is not
-   * adjusted by acknowledgement delay.
-   */
-  ngtcp2_duration latest_rtt;
-  /**
-   * :member:`min_rtt` is the minimum RTT seen so far.  It is not
-   * adjusted by acknowledgement delay.
-   */
-  ngtcp2_duration min_rtt;
-  /**
-   * :member:`smoothed_rtt` is the smoothed RTT.
-   */
-  ngtcp2_duration smoothed_rtt;
-  /**
-   * :member:`rttvar` is a mean deviation of observed RTT.
-   */
-  ngtcp2_duration rttvar;
-  /**
-   * :member:`initial_rtt` is the initial RTT which is used when no
-   * RTT sample is available.
-   */
-  ngtcp2_duration initial_rtt;
-  /**
-   * :member:`first_rtt_sample_ts` is the timestamp when the first RTT
-   * sample is obtained.
-   */
-  ngtcp2_tstamp first_rtt_sample_ts;
-  /**
-   * :member:`pto_count` is the count of successive PTO timer
-   * expiration.
-   */
-  size_t pto_count;
-  /**
-   * :member:`loss_detection_timer` is the deadline of the current
-   * loss detection timer.
-   */
-  ngtcp2_tstamp loss_detection_timer;
-  /**
-   * :member:`last_tx_pkt_ts` corresponds to
-   * time_of_last_ack_eliciting_packet in :rfc:`9002`.
-   */
-  ngtcp2_tstamp last_tx_pkt_ts[NGTCP2_PKTNS_ID_MAX];
-  /**
-   * :member:`loss_time` corresponds to loss_time in :rfc:`9002`.
-   */
-  ngtcp2_tstamp loss_time[NGTCP2_PKTNS_ID_MAX];
-  /**
-   * :member:`cwnd` is the size of congestion window.
-   */
-  uint64_t cwnd;
-  /**
-   * :member:`ssthresh` is slow start threshold.
-   */
-  uint64_t ssthresh;
-  /**
-   * :member:`congestion_recovery_start_ts` is the timestamp when
-   * congestion recovery started.
-   */
-  ngtcp2_tstamp congestion_recovery_start_ts;
-  /**
-   * :member:`bytes_in_flight` is the number in bytes of all sent
-   * packets which have not been acknowledged.
-   */
-  uint64_t bytes_in_flight;
-  /**
-   * :member:`max_tx_udp_payload_size` is the maximum size of UDP
-   * datagram payload that this endpoint transmits.  It is used by
-   * congestion controller to compute congestion window.
-   */
-  size_t max_tx_udp_payload_size;
-  /**
-   * :member:`delivery_rate_sec` is the current sending rate measured
-   * in byte per second.
-   */
-  uint64_t delivery_rate_sec;
-  /**
-   * :member:`pacing_rate` is the current packet sending rate computed
-   * by a congestion controller.  0 if a congestion controller does
-   * not set pacing rate.  Even if this value is set to 0, the library
-   * paces packets.
-   */
-  double pacing_rate;
-  /**
-   * :member:`send_quantum` is the maximum size of a data aggregate
-   * scheduled and transmitted together.
-   */
-  size_t send_quantum;
-} ngtcp2_conn_stat;
-
 /**
  * @enum
  *
@@ -4907,16 +4807,6 @@ NGTCP2_EXTERN int ngtcp2_conn_get_early_data_rejected(ngtcp2_conn *conn);
 /**
  * @function
  *
- * `ngtcp2_conn_get_conn_stat` assigns connection statistics data to
- * |*cstat|.
- */
-NGTCP2_EXTERN void ngtcp2_conn_get_conn_stat_versioned(ngtcp2_conn *conn,
-                                                       int conn_stat_version,
-                                                       ngtcp2_conn_stat *cstat);
-
-/**
- * @function
- *
  * `ngtcp2_conn_submit_crypto_data` submits crypto stream data |data|
  * of length |datalen| to the library for transmission.  The
  * encryption level is given in |crypto_level|.
@@ -5870,14 +5760,6 @@ NGTCP2_EXTERN uint32_t ngtcp2_select_version(const uint32_t *preferred_versions,
 #define ngtcp2_transport_params_default(PARAMS)                                \
   ngtcp2_transport_params_default_versioned(NGTCP2_TRANSPORT_PARAMS_VERSION,   \
                                             (PARAMS))
-
-/*
- * `ngtcp2_conn_get_conn_stat` is a wrapper around
- * `ngtcp2_conn_get_conn_stat_versioned` to set the correct struct
- * version.
- */
-#define ngtcp2_conn_get_conn_stat(CONN, CSTAT)                                 \
-  ngtcp2_conn_get_conn_stat_versioned((CONN), NGTCP2_CONN_STAT_VERSION, (CSTAT))
 
 /*
  * `ngtcp2_settings_default` is a wrapper around

--- a/lib/ngtcp2_bbr.c
+++ b/lib/ngtcp2_bbr.c
@@ -31,6 +31,7 @@
 #include "ngtcp2_mem.h"
 #include "ngtcp2_rcvry.h"
 #include "ngtcp2_rst.h"
+#include "ngtcp2_conn_stat.h"
 
 static const double pacing_gain_cycle[] = {1.25, 0.75, 1, 1, 1, 1, 1, 1};
 

--- a/lib/ngtcp2_bbr.h
+++ b/lib/ngtcp2_bbr.h
@@ -35,6 +35,7 @@
 #include "ngtcp2_window_filter.h"
 
 typedef struct ngtcp2_rst ngtcp2_rst;
+typedef struct ngtcp2_conn_stat ngtcp2_conn_stat;
 
 typedef enum ngtcp2_bbr_state {
   NGTCP2_BBR_STATE_STARTUP,

--- a/lib/ngtcp2_bbr2.c
+++ b/lib/ngtcp2_bbr2.c
@@ -31,6 +31,7 @@
 #include "ngtcp2_mem.h"
 #include "ngtcp2_rcvry.h"
 #include "ngtcp2_rst.h"
+#include "ngtcp2_conn_stat.h"
 
 #define NGTCP2_BBR_MAX_BW_FILTERLEN 2
 

--- a/lib/ngtcp2_cc.c
+++ b/lib/ngtcp2_cc.c
@@ -34,6 +34,7 @@
 #include "ngtcp2_macro.h"
 #include "ngtcp2_mem.h"
 #include "ngtcp2_rcvry.h"
+#include "ngtcp2_conn_stat.h"
 
 uint64_t ngtcp2_cc_compute_initcwnd(size_t max_udp_payload_size) {
   uint64_t n = 2 * max_udp_payload_size;

--- a/lib/ngtcp2_cc.h
+++ b/lib/ngtcp2_cc.h
@@ -35,6 +35,7 @@
 #define NGTCP2_PERSISTENT_CONGESTION_THRESHOLD 3
 
 typedef struct ngtcp2_log ngtcp2_log;
+typedef struct ngtcp2_conn_stat ngtcp2_conn_stat;
 
 /**
  * @struct

--- a/lib/ngtcp2_conn.c
+++ b/lib/ngtcp2_conn.c
@@ -12765,14 +12765,6 @@ int ngtcp2_conn_update_rtt(ngtcp2_conn *conn, ngtcp2_duration rtt,
   return 0;
 }
 
-void ngtcp2_conn_get_conn_stat_versioned(ngtcp2_conn *conn,
-                                         int conn_stat_version,
-                                         ngtcp2_conn_stat *cstat) {
-  (void)conn_stat_version;
-
-  *cstat = conn->cstat;
-}
-
 static void conn_get_loss_time_and_pktns(ngtcp2_conn *conn,
                                          ngtcp2_tstamp *ploss_time,
                                          ngtcp2_pktns **ppktns) {

--- a/lib/ngtcp2_conn.h
+++ b/lib/ngtcp2_conn.h
@@ -51,6 +51,7 @@
 #include "ngtcp2_ppe.h"
 #include "ngtcp2_qlog.h"
 #include "ngtcp2_rst.h"
+#include "ngtcp2_conn_stat.h"
 
 typedef enum {
   /* Client specific handshake states */

--- a/lib/ngtcp2_conn_stat.h
+++ b/lib/ngtcp2_conn_stat.h
@@ -1,0 +1,131 @@
+/*
+ * ngtcp2
+ *
+ * Copyright (c) 2023 ngtcp2 contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+#ifndef NGTCP2_CONN_STAT_H
+#define NGTCP2_CONN_STAT_H
+
+#ifdef HAVE_CONFIG_H
+#  include <config.h>
+#endif /* HAVE_CONFIG_H */
+
+#include <ngtcp2/ngtcp2.h>
+
+/**
+ * @struct
+ *
+ * :type:`ngtcp2_conn_stat` holds various connection statistics, and
+ * computed data for recovery and congestion controller.
+ */
+typedef struct ngtcp2_conn_stat {
+  /**
+   * :member:`latest_rtt` is the latest RTT sample which is not
+   * adjusted by acknowledgement delay.
+   */
+  ngtcp2_duration latest_rtt;
+  /**
+   * :member:`min_rtt` is the minimum RTT seen so far.  It is not
+   * adjusted by acknowledgement delay.
+   */
+  ngtcp2_duration min_rtt;
+  /**
+   * :member:`smoothed_rtt` is the smoothed RTT.
+   */
+  ngtcp2_duration smoothed_rtt;
+  /**
+   * :member:`rttvar` is a mean deviation of observed RTT.
+   */
+  ngtcp2_duration rttvar;
+  /**
+   * :member:`initial_rtt` is the initial RTT which is used when no
+   * RTT sample is available.
+   */
+  ngtcp2_duration initial_rtt;
+  /**
+   * :member:`first_rtt_sample_ts` is the timestamp when the first RTT
+   * sample is obtained.
+   */
+  ngtcp2_tstamp first_rtt_sample_ts;
+  /**
+   * :member:`pto_count` is the count of successive PTO timer
+   * expiration.
+   */
+  size_t pto_count;
+  /**
+   * :member:`loss_detection_timer` is the deadline of the current
+   * loss detection timer.
+   */
+  ngtcp2_tstamp loss_detection_timer;
+  /**
+   * :member:`last_tx_pkt_ts` corresponds to
+   * time_of_last_ack_eliciting_packet in :rfc:`9002`.
+   */
+  ngtcp2_tstamp last_tx_pkt_ts[NGTCP2_PKTNS_ID_MAX];
+  /**
+   * :member:`loss_time` corresponds to loss_time in :rfc:`9002`.
+   */
+  ngtcp2_tstamp loss_time[NGTCP2_PKTNS_ID_MAX];
+  /**
+   * :member:`cwnd` is the size of congestion window.
+   */
+  uint64_t cwnd;
+  /**
+   * :member:`ssthresh` is slow start threshold.
+   */
+  uint64_t ssthresh;
+  /**
+   * :member:`congestion_recovery_start_ts` is the timestamp when
+   * congestion recovery started.
+   */
+  ngtcp2_tstamp congestion_recovery_start_ts;
+  /**
+   * :member:`bytes_in_flight` is the number in bytes of all sent
+   * packets which have not been acknowledged.
+   */
+  uint64_t bytes_in_flight;
+  /**
+   * :member:`max_tx_udp_payload_size` is the maximum size of UDP
+   * datagram payload that this endpoint transmits.  It is used by
+   * congestion controller to compute congestion window.
+   */
+  size_t max_tx_udp_payload_size;
+  /**
+   * :member:`delivery_rate_sec` is the current sending rate measured
+   * in byte per second.
+   */
+  uint64_t delivery_rate_sec;
+  /**
+   * :member:`pacing_rate` is the current packet sending rate computed
+   * by a congestion controller.  0 if a congestion controller does
+   * not set pacing rate.  Even if this value is set to 0, the library
+   * paces packets.
+   */
+  double pacing_rate;
+  /**
+   * :member:`send_quantum` is the maximum size of a data aggregate
+   * scheduled and transmitted together.
+   */
+  size_t send_quantum;
+} ngtcp2_conn_stat;
+
+#endif /* NGTCP2_CONN_STAT_H */

--- a/lib/ngtcp2_qlog.c
+++ b/lib/ngtcp2_qlog.c
@@ -31,6 +31,7 @@
 #include "ngtcp2_conv.h"
 #include "ngtcp2_net.h"
 #include "ngtcp2_unreachable.h"
+#include "ngtcp2_conn_stat.h"
 
 void ngtcp2_qlog_init(ngtcp2_qlog *qlog, ngtcp2_qlog_write write,
                       ngtcp2_tstamp ts, void *user_data) {

--- a/lib/ngtcp2_rst.c
+++ b/lib/ngtcp2_rst.c
@@ -29,6 +29,7 @@
 #include "ngtcp2_rtb.h"
 #include "ngtcp2_cc.h"
 #include "ngtcp2_macro.h"
+#include "ngtcp2_conn_stat.h"
 
 void ngtcp2_rs_init(ngtcp2_rs *rs) {
   rs->interval = UINT64_MAX;

--- a/lib/ngtcp2_rst.h
+++ b/lib/ngtcp2_rst.h
@@ -34,6 +34,7 @@
 #include "ngtcp2_window_filter.h"
 
 typedef struct ngtcp2_rtb_entry ngtcp2_rtb_entry;
+typedef struct ngtcp2_conn_stat ngtcp2_conn_stat;
 
 /**
  * @struct

--- a/lib/ngtcp2_rtb.h
+++ b/lib/ngtcp2_rtb.h
@@ -43,6 +43,7 @@ typedef struct ngtcp2_qlog ngtcp2_qlog;
 typedef struct ngtcp2_strm ngtcp2_strm;
 typedef struct ngtcp2_rst ngtcp2_rst;
 typedef struct ngtcp2_cc ngtcp2_cc;
+typedef struct ngtcp2_conn_stat ngtcp2_conn_stat;
 
 /* NGTCP2_FRAME_CHAIN_BINDER_FLAG_NONE indicates that no flag is
    set. */


### PR DESCRIPTION
ngtcp2_conn_stat includes internal data structure and not suitable for public use.  We will provide some kind of connection information like struct tcp_info at some point, but it will be something different from ngtcp2_conn_stat.