### PR TITLE
interop: Set initial rtt to 100ms

### DIFF
--- a/interop/run_endpoint.sh
+++ b/interop/run_endpoint.sh
@@ -29,7 +29,7 @@ if [ "$ROLE" == "client" ]; then
     else
         CLIENT_BIN="/usr/local/bin/h09client"
     fi
-    CLIENT_ARGS="$SERVER 443 --download /downloads -s --no-quic-dump --no-http-dump --exit-on-all-streams-close --qlog-dir $QLOGDIR --cc bbr2"
+    CLIENT_ARGS="$SERVER 443 --download /downloads -s --no-quic-dump --no-http-dump --exit-on-all-streams-close --qlog-dir $QLOGDIR --cc bbr2 --initial-rtt 100ms"
     if [ "$TESTCASE" == "versionnegotiation" ]; then
         CLIENT_ARGS="$CLIENT_ARGS -v 0xaaaaaaaa"
     else
@@ -73,7 +73,7 @@ elif [ "$ROLE" == "server" ]; then
     else
         SERVER_BIN="/usr/local/bin/h09server"
     fi
-    SERVER_ARGS="/certs/priv.key /certs/cert.pem -s -d /www --qlog-dir $QLOGDIR --cc bbr2"
+    SERVER_ARGS="/certs/priv.key /certs/cert.pem -s -d /www --qlog-dir $QLOGDIR --cc bbr2 --initial-rtt 100ms"
     case "$TESTCASE" in
         "retry")
             SERVER_ARGS="$SERVER_ARGS -V"


### PR DESCRIPTION
Set initial rtt to 100ms in interop script to deal with super high packet loss rate.