### PR TITLE
Remove NGTCP2_PV_FLAG_MTU_PROBE

### DIFF
--- a/lib/ngtcp2_conn.c
+++ b/lib/ngtcp2_conn.c
@@ -4898,10 +4898,6 @@ static int conn_on_path_validation_failed(ngtcp2_conn *conn, ngtcp2_pv *pv,
     }
   }
 
-  if (pv->flags & NGTCP2_PV_FLAG_MTU_PROBE) {
-    return NGTCP2_ERR_NO_VIABLE_PATH;
-  }
-
   if (pv->flags & NGTCP2_PV_FLAG_FALLBACK_ON_FAILURE) {
     ngtcp2_dcid_copy(&conn->dcid.current, &pv->fallback_dcid);
     conn_reset_congestion_state(conn, ts);
@@ -5961,9 +5957,8 @@ static int conn_recv_path_response(ngtcp2_conn *conn, ngtcp2_path_response *fr,
 
       /* Validate path again */
       rv = ngtcp2_pv_new(&npv, &pv->dcid, timeout,
-                         NGTCP2_PV_FLAG_FALLBACK_ON_FAILURE |
-                             NGTCP2_PV_FLAG_MTU_PROBE,
-                         &conn->log, conn->mem);
+                         NGTCP2_PV_FLAG_FALLBACK_ON_FAILURE, &conn->log,
+                         conn->mem);
       if (rv != 0) {
         return rv;
       }

--- a/lib/ngtcp2_pv.h
+++ b/lib/ngtcp2_pv.h
@@ -76,10 +76,6 @@ void ngtcp2_pv_entry_init(ngtcp2_pv_entry *pvent, const uint8_t *data,
    fallback DCID.  If path validation succeeds, fallback DCID is
    retired if it does not equal to the current DCID. */
 #define NGTCP2_PV_FLAG_FALLBACK_ON_FAILURE 0x04u
-/* NGTCP2_PV_FLAG_MTU_PROBE indicates that a validation must probe
-   least MTU that QUIC requires, which is 1200 bytes.  If it fails, a
-   path is not viable. */
-#define NGTCP2_PV_FLAG_MTU_PROBE 0x08u
 /* NGTCP2_PV_FLAG_PREFERRED_ADDR indicates that client is migrating to
    server's preferred address.  This flag is only used by client. */
 #define NGTCP2_PV_FLAG_PREFERRED_ADDR 0x10u


### PR DESCRIPTION
NGTCP2_PV_FLAG_MTU_PROBE was introduced to deal with the second path validation due to amplification limit.  If the path validation with that flag failed, ngtcp2 returns NGTCP2_ERR_NO_VIALBE_PATH.  But we have always the fallback path when this second path validation is performed.  We can just fallback to the old path when the 2nd validation failed, which removes the need to return NGTCP2_ERR_NO_VIALBE_PATH and NGTCP2_PV_FLAG_MTU_PROBE flag.