### PR TITLE
Make the key update feature be supported by QUIC v2.

### DIFF
--- a/crypto/shared.h
+++ b/crypto/shared.h
@@ -171,7 +171,7 @@ int ngtcp2_crypto_derive_packet_protection_key(uint8_t *key, uint8_t *iv,
 int ngtcp2_crypto_update_traffic_secret(uint8_t *dest,
                                         const ngtcp2_crypto_md *md,
                                         const uint8_t *secret,
-                                        size_t secretlen);
+                                        size_t secretlen, uint32_t version);
 
 /**
  * @function


### PR DESCRIPTION
There was only "quicv2 ku" HKDF label which was missing.