### PR TITLE
Clang has __popcnt for ARM

### DIFF
--- a/lib/ngtcp2_ringbuf.c
+++ b/lib/ngtcp2_ringbuf.c
@@ -31,7 +31,7 @@
 
 #include "ngtcp2_macro.h"
 
-#if defined(_MSC_VER) && defined(_M_ARM64)
+#if defined(_MSC_VER) && !defined(__clang__) && (defined(_M_ARM) || defined(_M_ARM64))
 unsigned int __popcnt(unsigned int x) {
   unsigned int c = 0;
   for (; x; ++c) {


### PR DESCRIPTION
When building on Windows with clang for ARM targets, `__popcnt` is defined.