### PR TITLE
Do no start wev watcher when pacing timer is set

### DIFF
--- a/examples/client.cc
+++ b/examples/client.cc
@@ -949,6 +949,8 @@ int Client::on_write() {
     if (tx_.send_blocked) {
       return 0;
     }
+
+    ev_io_stop(loop_, &wev_);
   }
 
   if (auto rv = write_streams(); rv != 0) {
@@ -1060,7 +1062,6 @@ int Client::write_streams() {
     if (nwrite == 0) {
       // We are congestion limited.
       ngtcp2_conn_update_pkt_tx_time(conn_, ts);
-      ev_io_stop(loop_, &wev_);
       return 0;
     }
 
@@ -1085,7 +1086,6 @@ int Client::write_streams() {
 
     if (++pktcnt == max_pktcnt) {
       ngtcp2_conn_update_pkt_tx_time(conn_, ts);
-      start_wev_endpoint(ep);
       return 0;
     }
   }

--- a/examples/h09client.cc
+++ b/examples/h09client.cc
@@ -892,6 +892,8 @@ int Client::on_write() {
     if (tx_.send_blocked) {
       return 0;
     }
+
+    ev_io_stop(loop_, &wev_);
   }
 
   if (auto rv = write_streams(); rv != 0) {
@@ -973,7 +975,6 @@ int Client::write_streams() {
     if (nwrite == 0) {
       // We are congestion limited.
       ngtcp2_conn_update_pkt_tx_time(conn_, ts);
-      ev_io_stop(loop_, &wev_);
       return 0;
     }
 
@@ -998,7 +999,6 @@ int Client::write_streams() {
 
     if (++pktcnt == max_pktcnt) {
       ngtcp2_conn_update_pkt_tx_time(conn_, ts);
-      start_wev_endpoint(ep);
       return 0;
     }
   }

--- a/examples/server.cc
+++ b/examples/server.cc
@@ -1612,6 +1612,8 @@ int Handler::on_write() {
     }
   }
 
+  ev_io_stop(loop_, &wev_);
+
   if (auto rv = write_streams(); rv != 0) {
     return rv;
   }
@@ -1731,12 +1733,8 @@ int Handler::write_streams() {
                           data + nsent, datalen - nsent, gso_size);
 
           start_wev_endpoint(ep);
-          ngtcp2_conn_update_pkt_tx_time(conn_, ts);
-          return 0;
         }
       }
-
-      ev_io_stop(loop_, &wev_);
 
       // We are congestion limited.
       ngtcp2_conn_update_pkt_tx_time(conn_, ts);
@@ -1784,9 +1782,9 @@ int Handler::write_streams() {
 
           on_send_blocked(ep, ps.path.local, ps.path.remote, pi.ecn, data,
                           nwrite, 0);
-        }
 
-        start_wev_endpoint(ep);
+          start_wev_endpoint(ep);
+        }
       }
 
       ngtcp2_conn_update_pkt_tx_time(conn_, ts);
@@ -1806,9 +1804,10 @@ int Handler::write_streams() {
 
         on_send_blocked(ep, ps.path.local, ps.path.remote, pi.ecn, data + nsent,
                         datalen - nsent, gso_size);
+
+        start_wev_endpoint(ep);
       }
 
-      start_wev_endpoint(ep);
       ngtcp2_conn_update_pkt_tx_time(conn_, ts);
       return 0;
     }


### PR DESCRIPTION
Do no start wev watcher when pacing timer is set.

There are still 2 cases that wev watcher is explicitly enabled:

- when signaling write event
- UDP write is blocked

Fixes #693