### PR TITLE
Add old_path parameter to ngtcp2_path_validation

### DIFF
--- a/examples/client.cc
+++ b/examples/client.cc
@@ -508,6 +508,7 @@ int update_key(ngtcp2_conn *conn, uint8_t *rx_secret, uint8_t *tx_secret,
 
 namespace {
 int path_validation(ngtcp2_conn *conn, uint32_t flags, const ngtcp2_path *path,
+                    const ngtcp2_path *old_path,
                     ngtcp2_path_validation_result res, void *user_data) {
   if (!config.quiet) {
     debug::path_validation(path, res);

--- a/examples/h09client.cc
+++ b/examples/h09client.cc
@@ -466,6 +466,7 @@ int update_key(ngtcp2_conn *conn, uint8_t *rx_secret, uint8_t *tx_secret,
 
 namespace {
 int path_validation(ngtcp2_conn *conn, uint32_t flags, const ngtcp2_path *path,
+                    const ngtcp2_path *old_path,
                     ngtcp2_path_validation_result res, void *user_data) {
   if (!config.quiet) {
     debug::path_validation(path, res);

--- a/examples/h09server.cc
+++ b/examples/h09server.cc
@@ -570,10 +570,43 @@ int update_key(ngtcp2_conn *conn, uint8_t *rx_secret, uint8_t *tx_secret,
 
 namespace {
 int path_validation(ngtcp2_conn *conn, uint32_t flags, const ngtcp2_path *path,
+                    const ngtcp2_path *old_path,
                     ngtcp2_path_validation_result res, void *user_data) {
   if (!config.quiet) {
     debug::path_validation(path, res);
   }
+
+  if (res != NGTCP2_PATH_VALIDATION_RESULT_SUCCESS ||
+      ngtcp2_addr_eq(&path->remote, &old_path->remote)) {
+    return 0;
+  }
+
+  std::array<uint8_t, NGTCP2_CRYPTO_MAX_REGULAR_TOKENLEN> token;
+  auto t = std::chrono::duration_cast<std::chrono::nanoseconds>(
+               std::chrono::system_clock::now().time_since_epoch())
+               .count();
+
+  auto tokenlen = ngtcp2_crypto_generate_regular_token(
+      token.data(), config.static_secret.data(), config.static_secret.size(),
+      path->remote.addr, path->remote.addrlen, t);
+  if (tokenlen < 0) {
+    if (!config.quiet) {
+      std::cerr << "Unable to generate token" << std::endl;
+    }
+
+    return 0;
+  }
+
+  if (auto rv = ngtcp2_conn_submit_new_token(conn, token.data(), tokenlen);
+      rv != 0) {
+    if (!config.quiet) {
+      std::cerr << "ngtcp2_conn_submit_new_token: " << ngtcp2_strerror(rv)
+                << std::endl;
+    }
+
+    return NGTCP2_ERR_CALLBACK_FAILURE;
+  }
+
   return 0;
 }
 } // namespace

--- a/lib/includes/ngtcp2/ngtcp2.h
+++ b/lib/includes/ngtcp2/ngtcp2.h
@@ -3018,7 +3018,9 @@ typedef int (*ngtcp2_update_key)(
  * the application the outcome of path validation.  |flags| is zero or
  * more of :macro:`NGTCP2_PATH_VALIDATION_FLAG_*
  * <NGTCP2_PATH_VALIDATION_FLAG_NONE>`.  |path| is the path that was
- * validated.  If |res| is
+ * validated.  |old_path| is the path that is previsouly used before
+ * the endpoint has migrated to |path| if |old_path| is not NULL.  If
+ * |res| is
  * :enum:`ngtcp2_path_validation_result.NGTCP2_PATH_VALIDATION_RESULT_SUCCESS`,
  * the path validation succeeded.  If |res| is
  * :enum:`ngtcp2_path_validation_result.NGTCP2_PATH_VALIDATION_RESULT_FAILURE`,
@@ -3030,6 +3032,7 @@ typedef int (*ngtcp2_update_key)(
  */
 typedef int (*ngtcp2_path_validation)(ngtcp2_conn *conn, uint32_t flags,
                                       const ngtcp2_path *path,
+                                      const ngtcp2_path *old_path,
                                       ngtcp2_path_validation_result res,
                                       void *user_data);
 
@@ -5490,6 +5493,13 @@ NGTCP2_EXTERN ngtcp2_addr *ngtcp2_addr_init(ngtcp2_addr *dest,
 NGTCP2_EXTERN void ngtcp2_addr_copy_byte(ngtcp2_addr *dest,
                                          const ngtcp2_sockaddr *addr,
                                          ngtcp2_socklen addrlen);
+
+/**
+ * @function
+ *
+ * `ngtcp2_addr_eq` returns nonzero if |a| equals |b|.
+ */
+NGTCP2_EXTERN int ngtcp2_addr_eq(const ngtcp2_addr *a, const ngtcp2_addr *b);
 
 /**
  * @function

--- a/lib/ngtcp2_addr.h
+++ b/lib/ngtcp2_addr.h
@@ -38,11 +38,6 @@
  */
 void ngtcp2_addr_copy(ngtcp2_addr *dest, const ngtcp2_addr *src);
 
-/*
- * ngtcp2_addr_eq returns nonzero if |a| equals |b|.
- */
-int ngtcp2_addr_eq(const ngtcp2_addr *a, const ngtcp2_addr *b);
-
 /* NGTCP2_ADDR_COMPARE_FLAG_NONE indicates that no flag set. */
 #define NGTCP2_ADDR_COMPARE_FLAG_NONE 0x0u
 /* NGTCP2_ADDR_COMPARE_FLAG_ADDR indicates IP addresses do not

--- a/lib/ngtcp2_conn.c
+++ b/lib/ngtcp2_conn.c
@@ -278,8 +278,12 @@ static int conn_call_path_validation(ngtcp2_conn *conn, const ngtcp2_pv *pv,
     flags |= NGTCP2_PATH_VALIDATION_FLAG_PREFERRED_ADDR;
   }
 
-  rv = conn->callbacks.path_validation(conn, flags, &pv->dcid.ps.path, res,
-                                       conn->user_data);
+  rv = conn->callbacks.path_validation(
+      conn, flags, &pv->dcid.ps.path,
+      (pv->flags & NGTCP2_PV_FLAG_FALLBACK_ON_FAILURE)
+          ? &pv->fallback_dcid.ps.path
+          : NULL,
+      res, conn->user_data);
   if (rv != 0) {
     return NGTCP2_ERR_CALLBACK_FAILURE;
   }


### PR DESCRIPTION
Add old_path parameter to ngtcp2_path_validation to allow server to send NEW_TOKEN if a remote address changes.