### PR TITLE
Update doc

### DIFF
--- a/lib/includes/ngtcp2/ngtcp2.h
+++ b/lib/includes/ngtcp2/ngtcp2.h
@@ -4232,9 +4232,7 @@ ngtcp2_conn_get_local_transport_params(ngtcp2_conn *conn);
  * @function
  *
  * `ngtcp2_conn_encode_local_transport_params` encodes the local QUIC
- * transport parameters in |dest| of length |destlen|.  This is
- * equivalent to calling `ngtcp2_conn_get_local_transport_params` and
- * then `ngtcp2_encode_transport_params`.
+ * transport parameters in |dest| of length |destlen|.
  *
  * This function returns the number of written, or one of the
  * following negative error codes:


### PR DESCRIPTION
Stop saying that ngtcp2_conn_encode_local_transport_params is equivalent to ngtcp2_conn_get_local_transport_params + ngtcp2_encode_transport_params.  Latter may drop some fields because of ngtcp2_transport_params versioning.