### PR TITLE
Rework transport parameters

### DIFF
--- a/doc/source/programmers-guide.rst
+++ b/doc/source/programmers-guide.rst
@@ -121,9 +121,11 @@ value.  It could be any timestamp which increases monotonically, and
 actual value does not matter.
 
 :type:`ngtcp2_transport_params` contains QUIC transport parameters
-which is sent to a remote endpoint during handshake.  All fields must
-be set.  Application should call `ngtcp2_transport_params_default()`
-to set the default values.
+which is sent to a remote endpoint during handshake.  Application
+should call `ngtcp2_transport_params_default()` to set the default
+values.  Server must set
+:member:`ngtcp2_transport_params.original_dcid` and set
+:member:`ngtcp2_transport_params.original_dcid_present` to nonzero.
 
 Client application has to supply Connection IDs to
 `ngtcp2_conn_client_new()`.  The *dcid* parameter is the destination

--- a/examples/h09server.cc
+++ b/examples/h09server.cc
@@ -762,6 +762,8 @@ int Handler::init(const Endpoint &ep, const Address &local_addr,
     params.original_dcid = *scid;
   }
 
+  params.original_dcid_present = 1;
+
   if (util::generate_secure_random(params.stateless_reset_token,
                                    sizeof(params.stateless_reset_token)) != 0) {
     std::cerr << "Could not generate stateless reset token" << std::endl;

--- a/examples/server.cc
+++ b/examples/server.cc
@@ -1493,6 +1493,8 @@ int Handler::init(const Endpoint &ep, const Address &local_addr,
     params.original_dcid = *scid;
   }
 
+  params.original_dcid_present = 1;
+
   if (util::generate_secure_random(params.stateless_reset_token,
                                    sizeof(params.stateless_reset_token)) != 0) {
     std::cerr << "Could not generate stateless reset token" << std::endl;

--- a/examples/tls_server_session_boringssl.cc
+++ b/examples/tls_server_session_boringssl.cc
@@ -66,8 +66,7 @@ int TLSServerSession::init(const TLSServerContext &tls_ctx,
   params.initial_max_data = config.max_data;
 
   auto quic_early_data_ctxlen = ngtcp2_encode_transport_params(
-      quic_early_data_ctx.data(), quic_early_data_ctx.size(),
-      NGTCP2_TRANSPORT_PARAMS_TYPE_ENCRYPTED_EXTENSIONS, &params);
+      quic_early_data_ctx.data(), quic_early_data_ctx.size(), &params);
   if (quic_early_data_ctxlen < 0) {
     std::cerr << "ngtcp2_encode_transport_params: "
               << ngtcp2_strerror(quic_early_data_ctxlen) << std::endl;

--- a/lib/ngtcp2_crypto.c
+++ b/lib/ngtcp2_crypto.c
@@ -153,8 +153,8 @@ static uint8_t *write_cid_param(uint8_t *p, ngtcp2_transport_param_id id,
 static const uint8_t empty_address[16];
 
 ngtcp2_ssize ngtcp2_encode_transport_params_versioned(
-    uint8_t *dest, size_t destlen, ngtcp2_transport_params_type exttype,
-    int transport_params_version, const ngtcp2_transport_params *params) {
+    uint8_t *dest, size_t destlen, int transport_params_version,
+    const ngtcp2_transport_params *params) {
   uint8_t *p;
   size_t len = 0;
   /* For some reason, gcc 7.3.0 requires this initialization. */
@@ -167,42 +167,37 @@ ngtcp2_ssize ngtcp2_encode_transport_params_versioned(
   params = ngtcp2_transport_params_convert_to_latest(
       &paramsbuf, transport_params_version, params);
 
-  switch (exttype) {
-  case NGTCP2_TRANSPORT_PARAMS_TYPE_CLIENT_HELLO:
-    break;
-  case NGTCP2_TRANSPORT_PARAMS_TYPE_ENCRYPTED_EXTENSIONS:
+  if (params->original_dcid_present) {
     len +=
         cid_paramlen(NGTCP2_TRANSPORT_PARAM_ORIGINAL_DESTINATION_CONNECTION_ID,
                      &params->original_dcid);
-
-    if (params->stateless_reset_token_present) {
-      len +=
-          ngtcp2_put_uvarintlen(NGTCP2_TRANSPORT_PARAM_STATELESS_RESET_TOKEN) +
-          ngtcp2_put_uvarintlen(NGTCP2_STATELESS_RESET_TOKENLEN) +
-          NGTCP2_STATELESS_RESET_TOKENLEN;
-    }
-    if (params->preferred_address_present) {
-      assert(params->preferred_address.cid.datalen >= NGTCP2_MIN_CIDLEN);
-      assert(params->preferred_address.cid.datalen <= NGTCP2_MAX_CIDLEN);
-      preferred_addrlen = 4 /* ipv4Address */ + 2 /* ipv4Port */ +
-                          16 /* ipv6Address */ + 2 /* ipv6Port */
-                          + 1 +
-                          params->preferred_address.cid.datalen /* CID */ +
-                          NGTCP2_STATELESS_RESET_TOKENLEN;
-      len += ngtcp2_put_uvarintlen(NGTCP2_TRANSPORT_PARAM_PREFERRED_ADDRESS) +
-             ngtcp2_put_uvarintlen(preferred_addrlen) + preferred_addrlen;
-    }
-    if (params->retry_scid_present) {
-      len += cid_paramlen(NGTCP2_TRANSPORT_PARAM_RETRY_SOURCE_CONNECTION_ID,
-                          &params->retry_scid);
-    }
-    break;
-  default:
-    return NGTCP2_ERR_INVALID_ARGUMENT;
   }
 
-  len += cid_paramlen(NGTCP2_TRANSPORT_PARAM_INITIAL_SOURCE_CONNECTION_ID,
-                      &params->initial_scid);
+  if (params->stateless_reset_token_present) {
+    len += ngtcp2_put_uvarintlen(NGTCP2_TRANSPORT_PARAM_STATELESS_RESET_TOKEN) +
+           ngtcp2_put_uvarintlen(NGTCP2_STATELESS_RESET_TOKENLEN) +
+           NGTCP2_STATELESS_RESET_TOKENLEN;
+  }
+
+  if (params->preferred_address_present) {
+    assert(params->preferred_address.cid.datalen >= NGTCP2_MIN_CIDLEN);
+    assert(params->preferred_address.cid.datalen <= NGTCP2_MAX_CIDLEN);
+    preferred_addrlen = 4 /* ipv4Address */ + 2 /* ipv4Port */ +
+                        16 /* ipv6Address */ + 2 /* ipv6Port */
+                        + 1 + params->preferred_address.cid.datalen /* CID */ +
+                        NGTCP2_STATELESS_RESET_TOKENLEN;
+    len += ngtcp2_put_uvarintlen(NGTCP2_TRANSPORT_PARAM_PREFERRED_ADDRESS) +
+           ngtcp2_put_uvarintlen(preferred_addrlen) + preferred_addrlen;
+  }
+  if (params->retry_scid_present) {
+    len += cid_paramlen(NGTCP2_TRANSPORT_PARAM_RETRY_SOURCE_CONNECTION_ID,
+                        &params->retry_scid);
+  }
+
+  if (params->initial_scid_present) {
+    len += cid_paramlen(NGTCP2_TRANSPORT_PARAM_INITIAL_SOURCE_CONNECTION_ID,
+                        &params->initial_scid);
+  }
 
   if (params->initial_max_stream_data_bidi_local) {
     len += varint_paramlen(
@@ -283,56 +278,59 @@ ngtcp2_ssize ngtcp2_encode_transport_params_versioned(
 
   p = dest;
 
-  if (exttype == NGTCP2_TRANSPORT_PARAMS_TYPE_ENCRYPTED_EXTENSIONS) {
+  if (params->original_dcid_present) {
     p = write_cid_param(
         p, NGTCP2_TRANSPORT_PARAM_ORIGINAL_DESTINATION_CONNECTION_ID,
         &params->original_dcid);
-
-    if (params->stateless_reset_token_present) {
-      p = ngtcp2_put_uvarint(p, NGTCP2_TRANSPORT_PARAM_STATELESS_RESET_TOKEN);
-      p = ngtcp2_put_uvarint(p, sizeof(params->stateless_reset_token));
-      p = ngtcp2_cpymem(p, params->stateless_reset_token,
-                        sizeof(params->stateless_reset_token));
-    }
-    if (params->preferred_address_present) {
-      p = ngtcp2_put_uvarint(p, NGTCP2_TRANSPORT_PARAM_PREFERRED_ADDRESS);
-      p = ngtcp2_put_uvarint(p, preferred_addrlen);
-
-      if (params->preferred_address.ipv4_present) {
-        sa_in = &params->preferred_address.ipv4;
-        p = ngtcp2_cpymem(p, &sa_in->sin_addr, sizeof(sa_in->sin_addr));
-        p = ngtcp2_put_uint16(p, sa_in->sin_port);
-      } else {
-        p = ngtcp2_cpymem(p, empty_address, sizeof(sa_in->sin_addr));
-        p = ngtcp2_put_uint16(p, 0);
-      }
-
-      if (params->preferred_address.ipv6_present) {
-        sa_in6 = &params->preferred_address.ipv6;
-        p = ngtcp2_cpymem(p, &sa_in6->sin6_addr, sizeof(sa_in6->sin6_addr));
-        p = ngtcp2_put_uint16(p, sa_in6->sin6_port);
-      } else {
-        p = ngtcp2_cpymem(p, empty_address, sizeof(sa_in6->sin6_addr));
-        p = ngtcp2_put_uint16(p, 0);
-      }
-
-      *p++ = (uint8_t)params->preferred_address.cid.datalen;
-      if (params->preferred_address.cid.datalen) {
-        p = ngtcp2_cpymem(p, params->preferred_address.cid.data,
-                          params->preferred_address.cid.datalen);
-      }
-      p = ngtcp2_cpymem(
-          p, params->preferred_address.stateless_reset_token,
-          sizeof(params->preferred_address.stateless_reset_token));
-    }
-    if (params->retry_scid_present) {
-      p = write_cid_param(p, NGTCP2_TRANSPORT_PARAM_RETRY_SOURCE_CONNECTION_ID,
-                          &params->retry_scid);
-    }
   }
 
-  p = write_cid_param(p, NGTCP2_TRANSPORT_PARAM_INITIAL_SOURCE_CONNECTION_ID,
-                      &params->initial_scid);
+  if (params->stateless_reset_token_present) {
+    p = ngtcp2_put_uvarint(p, NGTCP2_TRANSPORT_PARAM_STATELESS_RESET_TOKEN);
+    p = ngtcp2_put_uvarint(p, sizeof(params->stateless_reset_token));
+    p = ngtcp2_cpymem(p, params->stateless_reset_token,
+                      sizeof(params->stateless_reset_token));
+  }
+
+  if (params->preferred_address_present) {
+    p = ngtcp2_put_uvarint(p, NGTCP2_TRANSPORT_PARAM_PREFERRED_ADDRESS);
+    p = ngtcp2_put_uvarint(p, preferred_addrlen);
+
+    if (params->preferred_address.ipv4_present) {
+      sa_in = &params->preferred_address.ipv4;
+      p = ngtcp2_cpymem(p, &sa_in->sin_addr, sizeof(sa_in->sin_addr));
+      p = ngtcp2_put_uint16(p, sa_in->sin_port);
+    } else {
+      p = ngtcp2_cpymem(p, empty_address, sizeof(sa_in->sin_addr));
+      p = ngtcp2_put_uint16(p, 0);
+    }
+
+    if (params->preferred_address.ipv6_present) {
+      sa_in6 = &params->preferred_address.ipv6;
+      p = ngtcp2_cpymem(p, &sa_in6->sin6_addr, sizeof(sa_in6->sin6_addr));
+      p = ngtcp2_put_uint16(p, sa_in6->sin6_port);
+    } else {
+      p = ngtcp2_cpymem(p, empty_address, sizeof(sa_in6->sin6_addr));
+      p = ngtcp2_put_uint16(p, 0);
+    }
+
+    *p++ = (uint8_t)params->preferred_address.cid.datalen;
+    if (params->preferred_address.cid.datalen) {
+      p = ngtcp2_cpymem(p, params->preferred_address.cid.data,
+                        params->preferred_address.cid.datalen);
+    }
+    p = ngtcp2_cpymem(p, params->preferred_address.stateless_reset_token,
+                      sizeof(params->preferred_address.stateless_reset_token));
+  }
+
+  if (params->retry_scid_present) {
+    p = write_cid_param(p, NGTCP2_TRANSPORT_PARAM_RETRY_SOURCE_CONNECTION_ID,
+                        &params->retry_scid);
+  }
+
+  if (params->initial_scid_present) {
+    p = write_cid_param(p, NGTCP2_TRANSPORT_PARAM_INITIAL_SOURCE_CONNECTION_ID,
+                        &params->initial_scid);
+  }
 
   if (params->initial_max_stream_data_bidi_local) {
     p = write_varint_param(
@@ -518,27 +516,19 @@ static int decode_cid_param(ngtcp2_cid *pdest, const uint8_t **pp,
   return 0;
 }
 
-int ngtcp2_decode_transport_params_versioned(
-    int transport_params_version, ngtcp2_transport_params *dest, uint32_t flags,
-    ngtcp2_transport_params_type exttype, const uint8_t *data, size_t datalen) {
+int ngtcp2_decode_transport_params_versioned(int transport_params_version,
+                                             ngtcp2_transport_params *dest,
+                                             const uint8_t *data,
+                                             size_t datalen) {
   const uint8_t *p, *end, *lend;
   size_t len;
   uint64_t param_type;
   uint64_t valuelen;
   int rv;
-  int initial_scid_present = 0;
-  int original_dcid_present = 0;
   ngtcp2_sockaddr_in *sa_in;
   ngtcp2_sockaddr_in6 *sa_in6;
   uint32_t version;
-  int ignore_missing_required_fields =
-      flags &
-      NGTCP2_TRANSPORT_PARAMS_DECODE_FLAG_IGNORE_MISSING_REQUIRED_FIELDS;
   ngtcp2_transport_params *params, paramsbuf;
-
-  if (!ignore_missing_required_fields && datalen == 0) {
-    return NGTCP2_ERR_REQUIRED_TRANSPORT_PARAM;
-  }
 
   if (transport_params_version == NGTCP2_TRANSPORT_PARAMS_VERSION) {
     params = dest;
@@ -548,6 +538,8 @@ int ngtcp2_decode_transport_params_versioned(
 
   /* Set default values */
   memset(params, 0, sizeof(*params));
+  params->original_dcid_present = 0;
+  params->initial_scid_present = 0;
   params->initial_max_streams_bidi = 0;
   params->initial_max_streams_uni = 0;
   params->initial_max_stream_data_bidi_local = 0;
@@ -630,9 +622,6 @@ int ngtcp2_decode_transport_params_versioned(
       }
       break;
     case NGTCP2_TRANSPORT_PARAM_STATELESS_RESET_TOKEN:
-      if (exttype != NGTCP2_TRANSPORT_PARAMS_TYPE_ENCRYPTED_EXTENSIONS) {
-        return NGTCP2_ERR_MALFORMED_TRANSPORT_PARAM;
-      }
       if (decode_varint(&valuelen, &p, end) != 0) {
         return NGTCP2_ERR_MALFORMED_TRANSPORT_PARAM;
       }
@@ -657,9 +646,6 @@ int ngtcp2_decode_transport_params_versioned(
       }
       break;
     case NGTCP2_TRANSPORT_PARAM_PREFERRED_ADDRESS:
-      if (exttype != NGTCP2_TRANSPORT_PARAMS_TYPE_ENCRYPTED_EXTENSIONS) {
-        return NGTCP2_ERR_MALFORMED_TRANSPORT_PARAM;
-      }
       if (decode_varint(&valuelen, &p, end) != 0) {
         return NGTCP2_ERR_MALFORMED_TRANSPORT_PARAM;
       }
@@ -724,19 +710,13 @@ int ngtcp2_decode_transport_params_versioned(
       params->disable_active_migration = 1;
       break;
     case NGTCP2_TRANSPORT_PARAM_ORIGINAL_DESTINATION_CONNECTION_ID:
-      if (exttype != NGTCP2_TRANSPORT_PARAMS_TYPE_ENCRYPTED_EXTENSIONS) {
-        return NGTCP2_ERR_MALFORMED_TRANSPORT_PARAM;
-      }
       rv = decode_cid_param(&params->original_dcid, &p, end);
       if (rv != 0) {
         return rv;
       }
-      original_dcid_present = 1;
+      params->original_dcid_present = 1;
       break;
     case NGTCP2_TRANSPORT_PARAM_RETRY_SOURCE_CONNECTION_ID:
-      if (exttype != NGTCP2_TRANSPORT_PARAMS_TYPE_ENCRYPTED_EXTENSIONS) {
-        return NGTCP2_ERR_MALFORMED_TRANSPORT_PARAM;
-      }
       rv = decode_cid_param(&params->retry_scid, &p, end);
       if (rv != 0) {
         return rv;
@@ -748,7 +728,7 @@ int ngtcp2_decode_transport_params_versioned(
       if (rv != 0) {
         return rv;
       }
-      initial_scid_present = 1;
+      params->initial_scid_present = 1;
       break;
     case NGTCP2_TRANSPORT_PARAM_MAX_ACK_DELAY:
       if (decode_varint_param(&params->max_ack_delay, &p, end) != 0) {
@@ -824,13 +804,6 @@ int ngtcp2_decode_transport_params_versioned(
     return NGTCP2_ERR_MALFORMED_TRANSPORT_PARAM;
   }
 
-  if (!ignore_missing_required_fields &&
-      (!initial_scid_present ||
-       (exttype == NGTCP2_TRANSPORT_PARAMS_TYPE_ENCRYPTED_EXTENSIONS &&
-        !original_dcid_present))) {
-    return NGTCP2_ERR_REQUIRED_TRANSPORT_PARAM;
-  }
-
   if (transport_params_version != NGTCP2_TRANSPORT_PARAMS_VERSION) {
     ngtcp2_transport_params_convert_to_old(transport_params_version, dest,
                                            params);
@@ -870,14 +843,12 @@ static int transport_params_copy_new(ngtcp2_transport_params **pdest,
 }
 
 int ngtcp2_decode_transport_params_new(ngtcp2_transport_params **pparams,
-                                       uint32_t flags,
-                                       ngtcp2_transport_params_type exttype,
                                        const uint8_t *data, size_t datalen,
                                        const ngtcp2_mem *mem) {
   int rv;
   ngtcp2_transport_params params;
 
-  rv = ngtcp2_decode_transport_params(&params, flags, exttype, data, datalen);
+  rv = ngtcp2_decode_transport_params(&params, data, datalen);
   if (rv < 0) {
     return rv;
   }

--- a/lib/ngtcp2_log.c
+++ b/lib/ngtcp2_log.c
@@ -594,7 +594,7 @@ void ngtcp2_log_rx_sr(ngtcp2_log *log, const ngtcp2_pkt_stateless_reset *sr) {
       sr->randlen);
 }
 
-void ngtcp2_log_remote_tp(ngtcp2_log *log, uint8_t exttype,
+void ngtcp2_log_remote_tp(ngtcp2_log *log,
                           const ngtcp2_transport_params *params) {
   uint8_t token[NGTCP2_STATELESS_RESET_TOKENLEN * 2 + 1];
   uint8_t addr[16 * 2 + 7 + 1];
@@ -609,79 +609,79 @@ void ngtcp2_log_remote_tp(ngtcp2_log *log, uint8_t exttype,
     return;
   }
 
-  if (exttype == NGTCP2_TRANSPORT_PARAMS_TYPE_ENCRYPTED_EXTENSIONS) {
-    if (params->stateless_reset_token_present) {
-      log->log_printf(log->user_data,
-                      (NGTCP2_LOG_TP " stateless_reset_token=0x%s"),
-                      NGTCP2_LOG_TP_HD_FIELDS,
-                      (const char *)ngtcp2_encode_hex(
-                          token, params->stateless_reset_token,
-                          sizeof(params->stateless_reset_token)));
-    }
+  if (params->stateless_reset_token_present) {
+    log->log_printf(
+        log->user_data, (NGTCP2_LOG_TP " stateless_reset_token=0x%s"),
+        NGTCP2_LOG_TP_HD_FIELDS,
+        (const char *)ngtcp2_encode_hex(token, params->stateless_reset_token,
+                                        sizeof(params->stateless_reset_token)));
+  }
 
-    if (params->preferred_address_present) {
-      if (params->preferred_address.ipv4_present) {
-        sa_in = &params->preferred_address.ipv4;
-
-        log->log_printf(log->user_data,
-                        (NGTCP2_LOG_TP " preferred_address.ipv4_addr=%s"),
-                        NGTCP2_LOG_TP_HD_FIELDS,
-                        (const char *)ngtcp2_encode_ipv4(
-                            addr, (const uint8_t *)&sa_in->sin_addr));
-        log->log_printf(log->user_data,
-                        (NGTCP2_LOG_TP " preferred_address.ipv4_port=%u"),
-                        NGTCP2_LOG_TP_HD_FIELDS, ngtcp2_ntohs(sa_in->sin_port));
-      }
-
-      if (params->preferred_address.ipv6_present) {
-        sa_in6 = &params->preferred_address.ipv6;
-
-        log->log_printf(log->user_data,
-                        (NGTCP2_LOG_TP " preferred_address.ipv6_addr=%s"),
-                        NGTCP2_LOG_TP_HD_FIELDS,
-                        (const char *)ngtcp2_encode_ipv6(
-                            addr, (const uint8_t *)&sa_in6->sin6_addr));
-        log->log_printf(
-            log->user_data, (NGTCP2_LOG_TP " preferred_address.ipv6_port=%u"),
-            NGTCP2_LOG_TP_HD_FIELDS, ngtcp2_ntohs(sa_in6->sin6_port));
-      }
+  if (params->preferred_address_present) {
+    if (params->preferred_address.ipv4_present) {
+      sa_in = &params->preferred_address.ipv4;
 
       log->log_printf(log->user_data,
-                      (NGTCP2_LOG_TP " preferred_address.cid=0x%s"),
+                      (NGTCP2_LOG_TP " preferred_address.ipv4_addr=%s"),
                       NGTCP2_LOG_TP_HD_FIELDS,
-                      (const char *)ngtcp2_encode_hex(
-                          cid, params->preferred_address.cid.data,
-                          params->preferred_address.cid.datalen));
-      log->log_printf(
-          log->user_data,
-          (NGTCP2_LOG_TP " preferred_address.stateless_reset_token=0x%s"),
-          NGTCP2_LOG_TP_HD_FIELDS,
-          (const char *)ngtcp2_encode_hex(
-              token, params->preferred_address.stateless_reset_token,
-              sizeof(params->preferred_address.stateless_reset_token)));
+                      (const char *)ngtcp2_encode_ipv4(
+                          addr, (const uint8_t *)&sa_in->sin_addr));
+      log->log_printf(log->user_data,
+                      (NGTCP2_LOG_TP " preferred_address.ipv4_port=%u"),
+                      NGTCP2_LOG_TP_HD_FIELDS, ngtcp2_ntohs(sa_in->sin_port));
     }
 
+    if (params->preferred_address.ipv6_present) {
+      sa_in6 = &params->preferred_address.ipv6;
+
+      log->log_printf(log->user_data,
+                      (NGTCP2_LOG_TP " preferred_address.ipv6_addr=%s"),
+                      NGTCP2_LOG_TP_HD_FIELDS,
+                      (const char *)ngtcp2_encode_ipv6(
+                          addr, (const uint8_t *)&sa_in6->sin6_addr));
+      log->log_printf(log->user_data,
+                      (NGTCP2_LOG_TP " preferred_address.ipv6_port=%u"),
+                      NGTCP2_LOG_TP_HD_FIELDS, ngtcp2_ntohs(sa_in6->sin6_port));
+    }
+
+    log->log_printf(
+        log->user_data, (NGTCP2_LOG_TP " preferred_address.cid=0x%s"),
+        NGTCP2_LOG_TP_HD_FIELDS,
+        (const char *)ngtcp2_encode_hex(cid, params->preferred_address.cid.data,
+                                        params->preferred_address.cid.datalen));
+    log->log_printf(
+        log->user_data,
+        (NGTCP2_LOG_TP " preferred_address.stateless_reset_token=0x%s"),
+        NGTCP2_LOG_TP_HD_FIELDS,
+        (const char *)ngtcp2_encode_hex(
+            token, params->preferred_address.stateless_reset_token,
+            sizeof(params->preferred_address.stateless_reset_token)));
+  }
+
+  if (params->original_dcid_present) {
     log->log_printf(
         log->user_data,
         (NGTCP2_LOG_TP " original_destination_connection_id=0x%s"),
         NGTCP2_LOG_TP_HD_FIELDS,
         (const char *)ngtcp2_encode_hex(cid, params->original_dcid.data,
                                         params->original_dcid.datalen));
-
-    if (params->retry_scid_present) {
-      log->log_printf(
-          log->user_data, (NGTCP2_LOG_TP " retry_source_connection_id=0x%s"),
-          NGTCP2_LOG_TP_HD_FIELDS,
-          (const char *)ngtcp2_encode_hex(cid, params->retry_scid.data,
-                                          params->retry_scid.datalen));
-    }
   }
 
-  log->log_printf(
-      log->user_data, (NGTCP2_LOG_TP " initial_source_connection_id=0x%s"),
-      NGTCP2_LOG_TP_HD_FIELDS,
-      (const char *)ngtcp2_encode_hex(cid, params->initial_scid.data,
-                                      params->initial_scid.datalen));
+  if (params->retry_scid_present) {
+    log->log_printf(
+        log->user_data, (NGTCP2_LOG_TP " retry_source_connection_id=0x%s"),
+        NGTCP2_LOG_TP_HD_FIELDS,
+        (const char *)ngtcp2_encode_hex(cid, params->retry_scid.data,
+                                        params->retry_scid.datalen));
+  }
+
+  if (params->initial_scid_present) {
+    log->log_printf(
+        log->user_data, (NGTCP2_LOG_TP " initial_source_connection_id=0x%s"),
+        NGTCP2_LOG_TP_HD_FIELDS,
+        (const char *)ngtcp2_encode_hex(cid, params->initial_scid.data,
+                                        params->initial_scid.datalen));
+  }
 
   log->log_printf(
       log->user_data,

--- a/lib/ngtcp2_log.h
+++ b/lib/ngtcp2_log.h
@@ -100,7 +100,7 @@ void ngtcp2_log_rx_vn(ngtcp2_log *log, const ngtcp2_pkt_hd *hd,
 
 void ngtcp2_log_rx_sr(ngtcp2_log *log, const ngtcp2_pkt_stateless_reset *sr);
 
-void ngtcp2_log_remote_tp(ngtcp2_log *log, uint8_t exttype,
+void ngtcp2_log_remote_tp(ngtcp2_log *log,
                           const ngtcp2_transport_params *params);
 
 void ngtcp2_log_pkt_lost(ngtcp2_log *log, int64_t pkt_num, uint8_t type,

--- a/tests/ngtcp2_conn_test.c
+++ b/tests/ngtcp2_conn_test.c
@@ -269,13 +269,17 @@ static int recv_client_initial_no_remote_transport_params(
 static int recv_client_initial(ngtcp2_conn *conn, const ngtcp2_cid *dcid,
                                void *user_data) {
   ngtcp2_transport_params params;
+  int rv;
 
   recv_client_initial_no_remote_transport_params(conn, dcid, user_data);
 
   ngtcp2_transport_params_default(&params);
   params.initial_scid = conn->dcid.current.cid;
-  params.original_dcid = conn->rcid;
-  ngtcp2_conn_set_remote_transport_params(conn, &params);
+  params.initial_scid_present = 1;
+
+  rv = ngtcp2_conn_set_remote_transport_params(conn, &params);
+
+  CU_ASSERT(0 == rv);
 
   return 0;
 }
@@ -553,6 +557,7 @@ static void server_default_transport_params(ngtcp2_transport_params *params) {
   size_t i;
 
   memset(params, 0, sizeof(*params));
+  params->original_dcid_present = 1;
   params->initial_max_stream_data_bidi_local = 65535;
   params->initial_max_stream_data_bidi_remote = 65535;
   params->initial_max_stream_data_uni = 65535;
@@ -6614,7 +6619,9 @@ void test_ngtcp2_conn_handshake_loss(void) {
   memset(&params, 0, sizeof(params));
   ngtcp2_cid_init(&params.initial_scid, conn->dcid.current.cid.data,
                   conn->dcid.current.cid.datalen);
+  params.initial_scid_present = 1;
   ngtcp2_cid_init(&params.original_dcid, conn->rcid.data, conn->rcid.datalen);
+  params.original_dcid_present = 1;
   params.max_udp_payload_size = 1200;
   params.initial_max_stream_data_bidi_remote = 100 * 1024;
   params.initial_max_data = 100 * 1024;
@@ -7067,7 +7074,9 @@ void test_ngtcp2_conn_set_remote_transport_params(void) {
   params.active_connection_id_limit = NGTCP2_DEFAULT_ACTIVE_CONNECTION_ID_LIMIT;
   params.max_udp_payload_size = 1450;
   params.initial_scid = conn->dcid.current.cid;
+  params.initial_scid_present = 1;
   params.original_dcid = conn->rcid;
+  params.original_dcid_present = 1;
 
   rv = ngtcp2_conn_set_remote_transport_params(conn, &params);
 
@@ -7084,6 +7093,8 @@ void test_ngtcp2_conn_set_remote_transport_params(void) {
   params.active_connection_id_limit = NGTCP2_DEFAULT_ACTIVE_CONNECTION_ID_LIMIT;
   params.max_udp_payload_size = 1450;
   params.initial_scid = conn->dcid.current.cid;
+  params.initial_scid_present = 1;
+  params.original_dcid_present = 1;
 
   rv = ngtcp2_conn_set_remote_transport_params(conn, &params);
 
@@ -7099,7 +7110,9 @@ void test_ngtcp2_conn_set_remote_transport_params(void) {
   memset(&params, 0, sizeof(params));
   params.active_connection_id_limit = NGTCP2_DEFAULT_ACTIVE_CONNECTION_ID_LIMIT;
   params.max_udp_payload_size = 1450;
+  params.initial_scid_present = 1;
   params.original_dcid = conn->rcid;
+  params.original_dcid_present = 1;
 
   rv = ngtcp2_conn_set_remote_transport_params(conn, &params);
 
@@ -7116,7 +7129,9 @@ void test_ngtcp2_conn_set_remote_transport_params(void) {
   params.active_connection_id_limit = NGTCP2_DEFAULT_ACTIVE_CONNECTION_ID_LIMIT;
   params.max_udp_payload_size = 1450;
   params.initial_scid = conn->dcid.current.cid;
+  params.initial_scid_present = 1;
   params.original_dcid = conn->rcid;
+  params.original_dcid_present = 1;
   params.retry_scid_present = 1;
 
   rv = ngtcp2_conn_set_remote_transport_params(conn, &params);
@@ -7136,7 +7151,9 @@ void test_ngtcp2_conn_set_remote_transport_params(void) {
   params.active_connection_id_limit = NGTCP2_DEFAULT_ACTIVE_CONNECTION_ID_LIMIT;
   params.max_udp_payload_size = 1450;
   params.initial_scid = conn->dcid.current.cid;
+  params.initial_scid_present = 1;
   params.original_dcid = conn->rcid;
+  params.original_dcid_present = 1;
   params.retry_scid_present = 1;
   params.retry_scid = dcid;
 
@@ -7157,7 +7174,9 @@ void test_ngtcp2_conn_set_remote_transport_params(void) {
   params.active_connection_id_limit = NGTCP2_DEFAULT_ACTIVE_CONNECTION_ID_LIMIT;
   params.max_udp_payload_size = 1450;
   params.initial_scid = conn->dcid.current.cid;
+  params.initial_scid_present = 1;
   params.original_dcid = conn->rcid;
+  params.original_dcid_present = 1;
 
   rv = ngtcp2_conn_set_remote_transport_params(conn, &params);
 
@@ -7176,7 +7195,9 @@ void test_ngtcp2_conn_set_remote_transport_params(void) {
   params.active_connection_id_limit = NGTCP2_DEFAULT_ACTIVE_CONNECTION_ID_LIMIT;
   params.max_udp_payload_size = 1450;
   params.initial_scid = conn->dcid.current.cid;
+  params.initial_scid_present = 1;
   params.original_dcid = conn->rcid;
+  params.original_dcid_present = 1;
 
   rv = ngtcp2_conn_set_remote_transport_params(conn, &params);
 
@@ -7194,7 +7215,9 @@ void test_ngtcp2_conn_set_remote_transport_params(void) {
   params.active_connection_id_limit = NGTCP2_DEFAULT_ACTIVE_CONNECTION_ID_LIMIT;
   params.max_udp_payload_size = 1450;
   params.initial_scid = conn->dcid.current.cid;
+  params.initial_scid_present = 1;
   params.original_dcid = conn->rcid;
+  params.original_dcid_present = 1;
 
   rv = ngtcp2_conn_set_remote_transport_params(conn, &params);
 
@@ -7217,7 +7240,9 @@ void test_ngtcp2_conn_set_remote_transport_params(void) {
   params.active_connection_id_limit = NGTCP2_DEFAULT_ACTIVE_CONNECTION_ID_LIMIT;
   params.max_udp_payload_size = 1450;
   params.initial_scid = conn->dcid.current.cid;
+  params.initial_scid_present = 1;
   params.original_dcid = conn->rcid;
+  params.original_dcid_present = 1;
   params.version_info_present = 1;
   params.version_info.chosen_version = conn->negotiated_version;
   params.version_info.available_versions = available_versions;
@@ -7249,7 +7274,9 @@ void test_ngtcp2_conn_set_remote_transport_params(void) {
   params.active_connection_id_limit = NGTCP2_DEFAULT_ACTIVE_CONNECTION_ID_LIMIT;
   params.max_udp_payload_size = 1450;
   params.initial_scid = conn->dcid.current.cid;
+  params.initial_scid_present = 1;
   params.original_dcid = conn->rcid;
+  params.original_dcid_present = 1;
   params.version_info_present = 1;
   params.version_info.chosen_version = conn->negotiated_version;
   params.version_info.available_versions = available_versions;
@@ -7281,7 +7308,9 @@ void test_ngtcp2_conn_set_remote_transport_params(void) {
   params.active_connection_id_limit = NGTCP2_DEFAULT_ACTIVE_CONNECTION_ID_LIMIT;
   params.max_udp_payload_size = 1450;
   params.initial_scid = conn->dcid.current.cid;
+  params.initial_scid_present = 1;
   params.original_dcid = conn->rcid;
+  params.original_dcid_present = 1;
   params.version_info_present = 1;
   params.version_info.chosen_version = conn->negotiated_version;
   params.version_info.available_versions = available_versions;
@@ -8378,7 +8407,9 @@ void test_ngtcp2_conn_early_data_sync_stream_data_limit(void) {
   memset(&params, 0, sizeof(params));
   ngtcp2_cid_init(&params.initial_scid, conn->dcid.current.cid.data,
                   conn->dcid.current.cid.datalen);
+  params.initial_scid_present = 1;
   ngtcp2_cid_init(&params.original_dcid, conn->rcid.data, conn->rcid.datalen);
+  params.original_dcid_present = 1;
   params.max_udp_payload_size = 1200;
   params.initial_max_stream_data_bidi_local =
       conn->early.transport_params.initial_max_stream_data_bidi_local;
@@ -8503,7 +8534,9 @@ void test_ngtcp2_conn_early_data_rejected(void) {
   memset(&params, 0, sizeof(params));
   ngtcp2_cid_init(&params.initial_scid, conn->dcid.current.cid.data,
                   conn->dcid.current.cid.datalen);
+  params.initial_scid_present = 1;
   ngtcp2_cid_init(&params.original_dcid, conn->rcid.data, conn->rcid.datalen);
+  params.original_dcid_present = 1;
   params.max_udp_payload_size = 1200;
   params.initial_max_stream_data_bidi_local =
       conn->early.transport_params.initial_max_stream_data_bidi_local;
@@ -9246,6 +9279,7 @@ void test_ngtcp2_conn_version_negotiation(void) {
   ngtcp2_transport_params_default(&remote_params);
   ngtcp2_cid_init(&remote_params.initial_scid, conn->dcid.current.cid.data,
                   conn->dcid.current.cid.datalen);
+  remote_params.initial_scid_present = 1;
   remote_params.version_info_present = 1;
   remote_params.version_info.chosen_version = NGTCP2_PROTO_VER_V1;
   remote_params.version_info.available_versions = available_versions;
@@ -9293,6 +9327,7 @@ void test_ngtcp2_conn_version_negotiation(void) {
   ngtcp2_transport_params_default(&remote_params);
   ngtcp2_cid_init(&remote_params.initial_scid, conn->dcid.current.cid.data,
                   conn->dcid.current.cid.datalen);
+  remote_params.initial_scid_present = 1;
   remote_params.version_info_present = 1;
   remote_params.version_info.chosen_version = NGTCP2_PROTO_VER_V1;
   remote_params.version_info.available_versions =
@@ -9505,10 +9540,7 @@ void test_ngtcp2_conn_encode_early_transport_params(void) {
 
   CU_ASSERT(slen > 0);
 
-  rv = ngtcp2_decode_transport_params(
-      &early_params,
-      NGTCP2_TRANSPORT_PARAMS_DECODE_FLAG_IGNORE_MISSING_REQUIRED_FIELDS,
-      NGTCP2_TRANSPORT_PARAMS_TYPE_ENCRYPTED_EXTENSIONS, buf, (size_t)slen);
+  rv = ngtcp2_decode_transport_params(&early_params, buf, (size_t)slen);
 
   CU_ASSERT(0 == rv);
   CU_ASSERT(1 == early_params.initial_max_streams_bidi);
@@ -9567,10 +9599,7 @@ void test_ngtcp2_conn_encode_early_transport_params(void) {
 
   CU_ASSERT(slen > 0);
 
-  rv = ngtcp2_decode_transport_params(
-      &early_params,
-      NGTCP2_TRANSPORT_PARAMS_DECODE_FLAG_IGNORE_MISSING_REQUIRED_FIELDS,
-      NGTCP2_TRANSPORT_PARAMS_TYPE_ENCRYPTED_EXTENSIONS, buf, (size_t)slen);
+  rv = ngtcp2_decode_transport_params(&early_params, buf, (size_t)slen);
 
   CU_ASSERT(0 == rv);
   CU_ASSERT(params.initial_max_streams_bidi ==
@@ -9678,6 +9707,9 @@ void test_ngtcp2_conn_new_failmalloc(void) {
   settings.available_versions = available_versions;
   settings.available_versionslen = ngtcp2_arraylen(available_versions);
 
+  params.original_dcid = dcid;
+  params.original_dcid_present = 1;
+
   /* server */
   server_default_callbacks(&cb);
 
@@ -9717,6 +9749,8 @@ void test_ngtcp2_conn_new_failmalloc(void) {
   ngtcp2_conn_del(conn);
 
   /* client */
+  ngtcp2_transport_params_default(&params);
+
   client_default_callbacks(&cb);
 
   mc.nmalloc = 0;

--- a/tests/ngtcp2_crypto_test.c
+++ b/tests/ngtcp2_crypto_test.c
@@ -58,214 +58,6 @@ void test_ngtcp2_encode_transport_params(void) {
     ngtcp2_put_uint32be(&available_versions[i], (uint32_t)(0xff000000u + i));
   }
 
-  /* CH, required parameters only */
-  params.max_udp_payload_size = NGTCP2_DEFAULT_MAX_RECV_UDP_PAYLOAD_SIZE;
-  params.ack_delay_exponent = NGTCP2_DEFAULT_ACK_DELAY_EXPONENT;
-  params.max_ack_delay = NGTCP2_DEFAULT_MAX_ACK_DELAY;
-  params.initial_scid = scid;
-
-  len = (ngtcp2_put_uvarintlen(
-             NGTCP2_TRANSPORT_PARAM_INITIAL_SOURCE_CONNECTION_ID) +
-         ngtcp2_put_uvarintlen(params.initial_scid.datalen) +
-         params.initial_scid.datalen);
-
-  nwrite = ngtcp2_encode_transport_params(
-      buf, sizeof(buf), NGTCP2_TRANSPORT_PARAMS_TYPE_CLIENT_HELLO, &params);
-
-  CU_ASSERT((ngtcp2_ssize)len == nwrite);
-
-  rv = ngtcp2_decode_transport_params(
-      &nparams, NGTCP2_TRANSPORT_PARAMS_DECODE_FLAG_NONE,
-      NGTCP2_TRANSPORT_PARAMS_TYPE_CLIENT_HELLO, buf, (size_t)nwrite);
-
-  CU_ASSERT(0 == rv);
-  CU_ASSERT(params.initial_max_stream_data_bidi_local ==
-            nparams.initial_max_stream_data_bidi_local);
-  CU_ASSERT(params.initial_max_stream_data_bidi_remote ==
-            nparams.initial_max_stream_data_bidi_remote);
-  CU_ASSERT(params.initial_max_stream_data_uni ==
-            nparams.initial_max_stream_data_uni);
-  CU_ASSERT(params.initial_max_data == nparams.initial_max_data);
-  CU_ASSERT(params.initial_max_streams_bidi ==
-            nparams.initial_max_streams_bidi);
-  CU_ASSERT(params.initial_max_streams_uni == nparams.initial_max_streams_uni);
-  CU_ASSERT(params.max_idle_timeout == nparams.max_idle_timeout);
-  CU_ASSERT(params.max_udp_payload_size == nparams.max_udp_payload_size);
-  CU_ASSERT(params.ack_delay_exponent == nparams.ack_delay_exponent);
-  CU_ASSERT(params.stateless_reset_token_present ==
-            nparams.stateless_reset_token_present);
-  CU_ASSERT(params.disable_active_migration ==
-            nparams.disable_active_migration);
-  CU_ASSERT(params.max_ack_delay == nparams.max_ack_delay);
-  CU_ASSERT(ngtcp2_cid_eq(&params.initial_scid, &nparams.initial_scid));
-
-  memset(&params, 0, sizeof(params));
-  memset(&nparams, 0, sizeof(nparams));
-
-  /* EE, required parameters only */
-  params.max_udp_payload_size = NGTCP2_DEFAULT_MAX_RECV_UDP_PAYLOAD_SIZE;
-  params.ack_delay_exponent = NGTCP2_DEFAULT_ACK_DELAY_EXPONENT;
-  params.max_ack_delay = NGTCP2_DEFAULT_MAX_ACK_DELAY;
-  params.original_dcid = dcid;
-  params.initial_scid = scid;
-
-  len = (ngtcp2_put_uvarintlen(
-             NGTCP2_TRANSPORT_PARAM_ORIGINAL_DESTINATION_CONNECTION_ID) +
-         ngtcp2_put_uvarintlen(params.original_dcid.datalen) +
-         params.original_dcid.datalen) +
-        (ngtcp2_put_uvarintlen(
-             NGTCP2_TRANSPORT_PARAM_INITIAL_SOURCE_CONNECTION_ID) +
-         ngtcp2_put_uvarintlen(params.initial_scid.datalen) +
-         params.initial_scid.datalen);
-
-  nwrite = ngtcp2_encode_transport_params(
-      buf, sizeof(buf), NGTCP2_TRANSPORT_PARAMS_TYPE_ENCRYPTED_EXTENSIONS,
-      &params);
-
-  CU_ASSERT((ngtcp2_ssize)len == nwrite);
-
-  rv = ngtcp2_decode_transport_params(
-      &nparams, NGTCP2_TRANSPORT_PARAMS_DECODE_FLAG_NONE,
-      NGTCP2_TRANSPORT_PARAMS_TYPE_ENCRYPTED_EXTENSIONS, buf, (size_t)nwrite);
-
-  CU_ASSERT(0 == rv);
-  CU_ASSERT(params.initial_max_stream_data_bidi_local ==
-            nparams.initial_max_stream_data_bidi_local);
-  CU_ASSERT(params.initial_max_stream_data_bidi_remote ==
-            nparams.initial_max_stream_data_bidi_remote);
-  CU_ASSERT(params.initial_max_stream_data_uni ==
-            nparams.initial_max_stream_data_uni);
-  CU_ASSERT(params.initial_max_data == nparams.initial_max_data);
-  CU_ASSERT(params.initial_max_streams_bidi ==
-            nparams.initial_max_streams_bidi);
-  CU_ASSERT(params.initial_max_streams_uni == nparams.initial_max_streams_uni);
-  CU_ASSERT(params.max_idle_timeout == nparams.max_idle_timeout);
-  CU_ASSERT(params.max_udp_payload_size == nparams.max_udp_payload_size);
-  CU_ASSERT(params.stateless_reset_token_present ==
-            nparams.stateless_reset_token_present);
-  CU_ASSERT(params.ack_delay_exponent == nparams.ack_delay_exponent);
-  CU_ASSERT(params.disable_active_migration ==
-            nparams.disable_active_migration);
-  CU_ASSERT(params.max_ack_delay == nparams.max_ack_delay);
-  CU_ASSERT(ngtcp2_cid_eq(&params.original_dcid, &nparams.original_dcid));
-  CU_ASSERT(ngtcp2_cid_eq(&params.initial_scid, &nparams.initial_scid));
-  CU_ASSERT(params.retry_scid_present == nparams.retry_scid_present);
-
-  memset(&params, 0, sizeof(params));
-  memset(&nparams, 0, sizeof(nparams));
-
-  /* CH, all parameters */
-  params.initial_max_stream_data_bidi_local = 1000000007;
-  params.initial_max_stream_data_bidi_remote = 961748941;
-  params.initial_max_stream_data_uni = 982451653;
-  params.initial_max_data = 1000000009;
-  params.initial_max_streams_bidi = 909;
-  params.initial_max_streams_uni = 911;
-  params.max_idle_timeout = 1023 * NGTCP2_MILLISECONDS;
-  params.max_udp_payload_size = 1400;
-  params.ack_delay_exponent = 20;
-  params.disable_active_migration = 1;
-  params.max_ack_delay = 59 * NGTCP2_MILLISECONDS;
-  params.initial_scid = scid;
-  params.active_connection_id_limit = 1000000007;
-  params.max_datagram_frame_size = 65535;
-  params.grease_quic_bit = 1;
-  params.version_info.chosen_version = NGTCP2_PROTO_VER_V1;
-  params.version_info.available_versions = available_versions;
-  params.version_info.available_versionslen = sizeof(available_versions);
-  params.version_info_present = 1;
-
-  len =
-      varint_paramlen(NGTCP2_TRANSPORT_PARAM_INITIAL_MAX_STREAM_DATA_BIDI_LOCAL,
-                      params.initial_max_stream_data_bidi_local) +
-      varint_paramlen(
-          NGTCP2_TRANSPORT_PARAM_INITIAL_MAX_STREAM_DATA_BIDI_REMOTE,
-          params.initial_max_stream_data_bidi_remote) +
-      varint_paramlen(NGTCP2_TRANSPORT_PARAM_INITIAL_MAX_STREAM_DATA_UNI,
-                      params.initial_max_stream_data_uni) +
-      varint_paramlen(NGTCP2_TRANSPORT_PARAM_INITIAL_MAX_DATA,
-                      params.initial_max_data) +
-      varint_paramlen(NGTCP2_TRANSPORT_PARAM_INITIAL_MAX_STREAMS_BIDI,
-                      params.initial_max_streams_bidi) +
-      varint_paramlen(NGTCP2_TRANSPORT_PARAM_INITIAL_MAX_STREAMS_UNI,
-                      params.initial_max_streams_uni) +
-      varint_paramlen(NGTCP2_TRANSPORT_PARAM_MAX_IDLE_TIMEOUT,
-                      params.max_idle_timeout / NGTCP2_MILLISECONDS) +
-      varint_paramlen(NGTCP2_TRANSPORT_PARAM_MAX_UDP_PAYLOAD_SIZE,
-                      params.max_udp_payload_size) +
-      varint_paramlen(NGTCP2_TRANSPORT_PARAM_ACK_DELAY_EXPONENT,
-                      params.ack_delay_exponent) +
-      (ngtcp2_put_uvarintlen(NGTCP2_TRANSPORT_PARAM_DISABLE_ACTIVE_MIGRATION) +
-       ngtcp2_put_uvarintlen(0)) +
-      varint_paramlen(NGTCP2_TRANSPORT_PARAM_MAX_ACK_DELAY,
-                      params.max_ack_delay / NGTCP2_MILLISECONDS) +
-      varint_paramlen(NGTCP2_TRANSPORT_PARAM_ACTIVE_CONNECTION_ID_LIMIT,
-                      params.active_connection_id_limit) +
-      (ngtcp2_put_uvarintlen(
-           NGTCP2_TRANSPORT_PARAM_INITIAL_SOURCE_CONNECTION_ID) +
-       ngtcp2_put_uvarintlen(params.initial_scid.datalen) +
-       params.initial_scid.datalen) +
-      varint_paramlen(NGTCP2_TRANSPORT_PARAM_MAX_DATAGRAM_FRAME_SIZE,
-                      params.max_datagram_frame_size) +
-      (ngtcp2_put_uvarintlen(NGTCP2_TRANSPORT_PARAM_GREASE_QUIC_BIT) +
-       ngtcp2_put_uvarintlen(0)) +
-      (ngtcp2_put_uvarintlen(NGTCP2_TRANSPORT_PARAM_VERSION_INFORMATION) +
-       ngtcp2_put_uvarintlen(sizeof(params.version_info.chosen_version) +
-                             params.version_info.available_versionslen) +
-       sizeof(params.version_info.chosen_version) +
-       params.version_info.available_versionslen);
-
-  nwrite = ngtcp2_encode_transport_params(
-      NULL, 0, NGTCP2_TRANSPORT_PARAMS_TYPE_CLIENT_HELLO, &params);
-
-  CU_ASSERT((ngtcp2_ssize)len == nwrite);
-
-  for (i = 0; i < len; ++i) {
-    nwrite = ngtcp2_encode_transport_params(
-        buf, i, NGTCP2_TRANSPORT_PARAMS_TYPE_CLIENT_HELLO, &params);
-    CU_ASSERT(NGTCP2_ERR_NOBUF == nwrite);
-  }
-  nwrite = ngtcp2_encode_transport_params(
-      buf, i, NGTCP2_TRANSPORT_PARAMS_TYPE_CLIENT_HELLO, &params);
-
-  CU_ASSERT((ngtcp2_ssize)i == nwrite);
-
-  rv = ngtcp2_decode_transport_params(
-      &nparams, NGTCP2_TRANSPORT_PARAMS_DECODE_FLAG_NONE,
-      NGTCP2_TRANSPORT_PARAMS_TYPE_CLIENT_HELLO, buf, (size_t)nwrite);
-
-  CU_ASSERT(0 == rv);
-  CU_ASSERT(params.initial_max_stream_data_bidi_local ==
-            nparams.initial_max_stream_data_bidi_local);
-  CU_ASSERT(params.initial_max_stream_data_bidi_remote ==
-            nparams.initial_max_stream_data_bidi_remote);
-  CU_ASSERT(params.initial_max_stream_data_uni ==
-            nparams.initial_max_stream_data_uni);
-  CU_ASSERT(params.initial_max_data == nparams.initial_max_data);
-  CU_ASSERT(params.initial_max_streams_bidi ==
-            nparams.initial_max_streams_bidi);
-  CU_ASSERT(params.initial_max_streams_uni == nparams.initial_max_streams_uni);
-  CU_ASSERT(params.max_idle_timeout == nparams.max_idle_timeout);
-  CU_ASSERT(params.max_udp_payload_size == nparams.max_udp_payload_size);
-  CU_ASSERT(params.ack_delay_exponent == nparams.ack_delay_exponent);
-  CU_ASSERT(params.disable_active_migration ==
-            nparams.disable_active_migration);
-  CU_ASSERT(params.max_ack_delay == nparams.max_ack_delay);
-  CU_ASSERT(params.active_connection_id_limit ==
-            nparams.active_connection_id_limit);
-  CU_ASSERT(params.max_datagram_frame_size == nparams.max_datagram_frame_size);
-  CU_ASSERT(params.grease_quic_bit == nparams.grease_quic_bit);
-  CU_ASSERT(params.version_info_present == nparams.version_info_present);
-  CU_ASSERT(params.version_info.chosen_version ==
-            nparams.version_info.chosen_version);
-  CU_ASSERT(0 == memcmp(params.version_info.available_versions,
-                        nparams.version_info.available_versions,
-                        params.version_info.available_versionslen));
-
-  memset(&params, 0, sizeof(params));
-  memset(&nparams, 0, sizeof(nparams));
-
-  /* EE, all parameters */
   params.initial_max_stream_data_bidi_local = 1000000007;
   params.initial_max_stream_data_bidi_remote = 961748941;
   params.initial_max_stream_data_uni = 982451653;
@@ -293,7 +85,9 @@ void test_ngtcp2_encode_transport_params(void) {
   params.retry_scid_present = 1;
   params.retry_scid = rcid;
   params.original_dcid = dcid;
+  params.original_dcid_present = 1;
   params.initial_scid = scid;
+  params.initial_scid_present = 1;
   params.active_connection_id_limit = 1073741824;
   params.max_datagram_frame_size = 63;
   params.grease_quic_bit = 1;
@@ -360,25 +154,20 @@ void test_ngtcp2_encode_transport_params(void) {
        sizeof(params.version_info.chosen_version) +
        params.version_info.available_versionslen);
 
-  nwrite = ngtcp2_encode_transport_params(
-      NULL, 0, NGTCP2_TRANSPORT_PARAMS_TYPE_ENCRYPTED_EXTENSIONS, &params);
+  nwrite = ngtcp2_encode_transport_params(NULL, 0, &params);
 
   CU_ASSERT((ngtcp2_ssize)len == nwrite);
 
   for (i = 0; i < len; ++i) {
-    nwrite = ngtcp2_encode_transport_params(
-        buf, i, NGTCP2_TRANSPORT_PARAMS_TYPE_ENCRYPTED_EXTENSIONS, &params);
+    nwrite = ngtcp2_encode_transport_params(buf, i, &params);
 
     CU_ASSERT(NGTCP2_ERR_NOBUF == nwrite);
   }
-  nwrite = ngtcp2_encode_transport_params(
-      buf, i, NGTCP2_TRANSPORT_PARAMS_TYPE_ENCRYPTED_EXTENSIONS, &params);
+  nwrite = ngtcp2_encode_transport_params(buf, i, &params);
 
   CU_ASSERT((ngtcp2_ssize)i == nwrite);
 
-  rv = ngtcp2_decode_transport_params(
-      &nparams, NGTCP2_TRANSPORT_PARAMS_DECODE_FLAG_NONE,
-      NGTCP2_TRANSPORT_PARAMS_TYPE_ENCRYPTED_EXTENSIONS, buf, (size_t)nwrite);
+  rv = ngtcp2_decode_transport_params(&nparams, buf, (size_t)nwrite);
 
   CU_ASSERT(0 == rv);
   CU_ASSERT(params.initial_max_stream_data_bidi_local ==
@@ -421,7 +210,9 @@ void test_ngtcp2_encode_transport_params(void) {
   CU_ASSERT(params.retry_scid_present == nparams.retry_scid_present);
   CU_ASSERT(ngtcp2_cid_eq(&params.retry_scid, &nparams.retry_scid));
   CU_ASSERT(ngtcp2_cid_eq(&params.initial_scid, &nparams.initial_scid));
+  CU_ASSERT(params.initial_scid_present == nparams.initial_scid_present);
   CU_ASSERT(ngtcp2_cid_eq(&params.original_dcid, &nparams.original_dcid));
+  CU_ASSERT(params.original_dcid_present == nparams.original_dcid_present);
   CU_ASSERT(params.active_connection_id_limit ==
             nparams.active_connection_id_limit);
   CU_ASSERT(params.max_datagram_frame_size == nparams.max_datagram_frame_size);
@@ -455,60 +246,6 @@ void test_ngtcp2_decode_transport_params_new(void) {
     ngtcp2_put_uint32be(&available_versions[i], (uint32_t)(0xff000000u + i));
   }
 
-  /* EE, required parameters only */
-  params.max_udp_payload_size = NGTCP2_DEFAULT_MAX_RECV_UDP_PAYLOAD_SIZE;
-  params.ack_delay_exponent = NGTCP2_DEFAULT_ACK_DELAY_EXPONENT;
-  params.max_ack_delay = NGTCP2_DEFAULT_MAX_ACK_DELAY;
-  params.original_dcid = dcid;
-  params.initial_scid = scid;
-
-  len = (ngtcp2_put_uvarintlen(
-             NGTCP2_TRANSPORT_PARAM_ORIGINAL_DESTINATION_CONNECTION_ID) +
-         ngtcp2_put_uvarintlen(params.original_dcid.datalen) +
-         params.original_dcid.datalen) +
-        (ngtcp2_put_uvarintlen(
-             NGTCP2_TRANSPORT_PARAM_INITIAL_SOURCE_CONNECTION_ID) +
-         ngtcp2_put_uvarintlen(params.initial_scid.datalen) +
-         params.initial_scid.datalen);
-
-  nwrite = ngtcp2_encode_transport_params(
-      buf, sizeof(buf), NGTCP2_TRANSPORT_PARAMS_TYPE_ENCRYPTED_EXTENSIONS,
-      &params);
-
-  CU_ASSERT((ngtcp2_ssize)len == nwrite);
-
-  rv = ngtcp2_decode_transport_params_new(
-      &nparams, NGTCP2_TRANSPORT_PARAMS_DECODE_FLAG_NONE,
-      NGTCP2_TRANSPORT_PARAMS_TYPE_ENCRYPTED_EXTENSIONS, buf, (size_t)nwrite,
-      NULL);
-
-  CU_ASSERT(0 == rv);
-  CU_ASSERT(params.initial_max_stream_data_bidi_local ==
-            nparams->initial_max_stream_data_bidi_local);
-  CU_ASSERT(params.initial_max_stream_data_bidi_remote ==
-            nparams->initial_max_stream_data_bidi_remote);
-  CU_ASSERT(params.initial_max_stream_data_uni ==
-            nparams->initial_max_stream_data_uni);
-  CU_ASSERT(params.initial_max_data == nparams->initial_max_data);
-  CU_ASSERT(params.initial_max_streams_bidi ==
-            nparams->initial_max_streams_bidi);
-  CU_ASSERT(params.initial_max_streams_uni == nparams->initial_max_streams_uni);
-  CU_ASSERT(params.max_idle_timeout == nparams->max_idle_timeout);
-  CU_ASSERT(params.max_udp_payload_size == nparams->max_udp_payload_size);
-  CU_ASSERT(params.stateless_reset_token_present ==
-            nparams->stateless_reset_token_present);
-  CU_ASSERT(params.ack_delay_exponent == nparams->ack_delay_exponent);
-  CU_ASSERT(params.disable_active_migration ==
-            nparams->disable_active_migration);
-  CU_ASSERT(params.max_ack_delay == nparams->max_ack_delay);
-  CU_ASSERT(ngtcp2_cid_eq(&params.original_dcid, &nparams->original_dcid));
-  CU_ASSERT(ngtcp2_cid_eq(&params.initial_scid, &nparams->initial_scid));
-  CU_ASSERT(params.retry_scid_present == nparams->retry_scid_present);
-
-  ngtcp2_transport_params_del(nparams, NULL);
-  memset(&params, 0, sizeof(params));
-
-  /* EE, all parameters */
   params.initial_max_stream_data_bidi_local = 1000000007;
   params.initial_max_stream_data_bidi_remote = 961748941;
   params.initial_max_stream_data_uni = 982451653;
@@ -536,7 +273,9 @@ void test_ngtcp2_decode_transport_params_new(void) {
   params.retry_scid_present = 1;
   params.retry_scid = rcid;
   params.original_dcid = dcid;
+  params.original_dcid_present = 1;
   params.initial_scid = scid;
+  params.initial_scid_present = 1;
   params.active_connection_id_limit = 1073741824;
   params.max_datagram_frame_size = 63;
   params.grease_quic_bit = 1;
@@ -603,16 +342,11 @@ void test_ngtcp2_decode_transport_params_new(void) {
        sizeof(params.version_info.chosen_version) +
        params.version_info.available_versionslen);
 
-  nwrite = ngtcp2_encode_transport_params(
-      buf, sizeof(buf), NGTCP2_TRANSPORT_PARAMS_TYPE_ENCRYPTED_EXTENSIONS,
-      &params);
+  nwrite = ngtcp2_encode_transport_params(buf, sizeof(buf), &params);
 
   CU_ASSERT((ngtcp2_ssize)len == nwrite);
 
-  rv = ngtcp2_decode_transport_params_new(
-      &nparams, NGTCP2_TRANSPORT_PARAMS_DECODE_FLAG_NONE,
-      NGTCP2_TRANSPORT_PARAMS_TYPE_ENCRYPTED_EXTENSIONS, buf, (size_t)nwrite,
-      NULL);
+  rv = ngtcp2_decode_transport_params_new(&nparams, buf, (size_t)nwrite, NULL);
 
   CU_ASSERT(0 == rv);
   CU_ASSERT(params.initial_max_stream_data_bidi_local ==
@@ -655,7 +389,9 @@ void test_ngtcp2_decode_transport_params_new(void) {
   CU_ASSERT(params.retry_scid_present == nparams->retry_scid_present);
   CU_ASSERT(ngtcp2_cid_eq(&params.retry_scid, &nparams->retry_scid));
   CU_ASSERT(ngtcp2_cid_eq(&params.initial_scid, &nparams->initial_scid));
+  CU_ASSERT(params.initial_scid_present == nparams->initial_scid_present);
   CU_ASSERT(ngtcp2_cid_eq(&params.original_dcid, &nparams->original_dcid));
+  CU_ASSERT(params.original_dcid_present == nparams->original_dcid_present);
   CU_ASSERT(params.active_connection_id_limit ==
             nparams->active_connection_id_limit);
   CU_ASSERT(params.max_datagram_frame_size == nparams->max_datagram_frame_size);


### PR DESCRIPTION
ngtcp2_transport_params.original_dcid_present and initial_scid_present have been added and they indicate the presence of original_dcid and initial_scid respectively.

server explicitly now has to set
ngtcp2_transport_params.original_dcid_present to nonzero when setting original_dcid.

ngtcp2_transport_params_type and NGTCP2_TRANSPORT_PARAMS_DECODE_FLAGs have been removed.

ngtcp2_decode_transport_params now does not return NGTCP2_ERR_REQUIRED_TRANSPORT_PARAM.  Caller should check original_dcid_present and initial_scid_present instead.

ngtcp2_decode_transport_params now does not fail if it decodes client written transport parameters and it finds parameters that are not allowed for client to produce.  Caller should check original_dcid_present, stateless_reset_token_present, preferred_address_present, and retry_scid_present instead.