### PR TITLE
Rename ngtcp2_(encode|decode)_transport_params

### DIFF
--- a/examples/tls_server_session_boringssl.cc
+++ b/examples/tls_server_session_boringssl.cc
@@ -65,10 +65,10 @@ int TLSServerSession::init(const TLSServerContext &tls_ctx,
   params.initial_max_stream_data_uni = config.max_stream_data_uni;
   params.initial_max_data = config.max_data;
 
-  auto quic_early_data_ctxlen = ngtcp2_encode_transport_params(
+  auto quic_early_data_ctxlen = ngtcp2_transport_params_encode(
       quic_early_data_ctx.data(), quic_early_data_ctx.size(), &params);
   if (quic_early_data_ctxlen < 0) {
-    std::cerr << "ngtcp2_encode_transport_params: "
+    std::cerr << "ngtcp2_transport_params_encode: "
               << ngtcp2_strerror(quic_early_data_ctxlen) << std::endl;
     return -1;
   }

--- a/lib/includes/ngtcp2/ngtcp2.h
+++ b/lib/includes/ngtcp2/ngtcp2.h
@@ -2157,7 +2157,7 @@ typedef struct ngtcp2_crypto_ctx {
 /**
  * @function
  *
- * `ngtcp2_encode_transport_params` encodes |params| in |dest| of
+ * `ngtcp2_transport_params_encode` encodes |params| in |dest| of
  * length |destlen|.
  *
  * If |dest| is NULL, and |destlen| is zero, this function just
@@ -2170,14 +2170,14 @@ typedef struct ngtcp2_crypto_ctx {
  * :macro:`NGTCP2_ERR_NOBUF`
  *     Buffer is too small.
  */
-NGTCP2_EXTERN ngtcp2_ssize ngtcp2_encode_transport_params_versioned(
+NGTCP2_EXTERN ngtcp2_ssize ngtcp2_transport_params_encode_versioned(
     uint8_t *dest, size_t destlen, int transport_params_version,
     const ngtcp2_transport_params *params);
 
 /**
  * @function
  *
- * `ngtcp2_decode_transport_params` decodes transport parameters in
+ * `ngtcp2_transport_params_decode` decodes transport parameters in
  * |data| of length |datalen|, and stores the result in the object
  * pointed by |params|.
  *
@@ -2197,17 +2197,17 @@ NGTCP2_EXTERN ngtcp2_ssize ngtcp2_encode_transport_params_versioned(
  *     The input is malformed.
  */
 NGTCP2_EXTERN int
-ngtcp2_decode_transport_params_versioned(int transport_params_version,
+ngtcp2_transport_params_decode_versioned(int transport_params_version,
                                          ngtcp2_transport_params *params,
                                          const uint8_t *data, size_t datalen);
 
 /**
  * @function
  *
- * `ngtcp2_decode_transport_params_new` decodes transport parameters
+ * `ngtcp2_transport_params_decode_new` decodes transport parameters
  * in |data| of length |datalen|, and stores the result in the object
  * allocated dynamically.  The pointer to the allocated object is
- * assigned to |*pparams|.  Unlike `ngtcp2_decode_transport_params`,
+ * assigned to |*pparams|.  Unlike `ngtcp2_transport_params_decode`,
  * all direct and indirect fields are also allocated dynamically if
  * needed.
  *
@@ -2230,7 +2230,7 @@ ngtcp2_decode_transport_params_versioned(int transport_params_version,
  *     Out of memory.
  */
 NGTCP2_EXTERN int
-ngtcp2_decode_transport_params_new(ngtcp2_transport_params **pparams,
+ngtcp2_transport_params_decode_new(ngtcp2_transport_params **pparams,
                                    const uint8_t *data, size_t datalen,
                                    const ngtcp2_mem *mem);
 
@@ -2238,7 +2238,7 @@ ngtcp2_decode_transport_params_new(ngtcp2_transport_params **pparams,
  * @function
  *
  * `ngtcp2_transport_params_del` frees the |params| which must be
- * dynamically allocated by `ngtcp2_decode_transport_params_new`.
+ * dynamically allocated by `ngtcp2_transport_params_decode_new`.
  *
  * |mem| is a memory allocator that allocated |params|.  If |mem| is
  * ``NULL``, the memory allocator returned by `ngtcp2_mem_default()`
@@ -5790,21 +5790,21 @@ NGTCP2_EXTERN uint32_t ngtcp2_select_version(const uint32_t *preferred_versions,
       (CCERR), (TS))
 
 /*
- * `ngtcp2_encode_transport_params` is a wrapper around
- * `ngtcp2_encode_transport_params_versioned` to set the correct
+ * `ngtcp2_transport_params_encode` is a wrapper around
+ * `ngtcp2_transport_params_encode_versioned` to set the correct
  * struct version.
  */
-#define ngtcp2_encode_transport_params(DEST, DESTLEN, PARAMS)                  \
-  ngtcp2_encode_transport_params_versioned(                                    \
+#define ngtcp2_transport_params_encode(DEST, DESTLEN, PARAMS)                  \
+  ngtcp2_transport_params_encode_versioned(                                    \
       (DEST), (DESTLEN), NGTCP2_TRANSPORT_PARAMS_VERSION, (PARAMS))
 
 /*
- * `ngtcp2_decode_transport_params` is a wrapper around
- * `ngtcp2_decode_transport_params_versioned` to set the correct
+ * `ngtcp2_transport_params_decode` is a wrapper around
+ * `ngtcp2_transport_params_decode_versioned` to set the correct
  * struct version.
  */
-#define ngtcp2_decode_transport_params(PARAMS, DATA, DATALEN)                  \
-  ngtcp2_decode_transport_params_versioned(NGTCP2_TRANSPORT_PARAMS_VERSION,    \
+#define ngtcp2_transport_params_decode(PARAMS, DATA, DATALEN)                  \
+  ngtcp2_transport_params_decode_versioned(NGTCP2_TRANSPORT_PARAMS_VERSION,    \
                                            (PARAMS), (DATA), (DATALEN))
 
 /*

--- a/lib/ngtcp2_conn.c
+++ b/lib/ngtcp2_conn.c
@@ -11264,7 +11264,7 @@ int ngtcp2_conn_set_remote_transport_params(
     return NGTCP2_ERR_REQUIRED_TRANSPORT_PARAM;
   }
 
-  /* Assume that ngtcp2_decode_transport_params sets default value if
+  /* Assume that ngtcp2_transport_params_decode sets default value if
      active_connection_id_limit is omitted. */
   if (params->active_connection_id_limit <
       NGTCP2_DEFAULT_ACTIVE_CONNECTION_ID_LIMIT) {
@@ -11365,7 +11365,7 @@ int ngtcp2_conn_decode_remote_transport_params(ngtcp2_conn *conn,
   ngtcp2_transport_params params;
   int rv;
 
-  rv = ngtcp2_decode_transport_params(&params, data, datalen);
+  rv = ngtcp2_transport_params_decode(&params, data, datalen);
   if (rv != 0) {
     return rv;
   }
@@ -11414,7 +11414,7 @@ ngtcp2_ssize ngtcp2_conn_encode_early_transport_params(ngtcp2_conn *conn,
     params.disable_active_migration = src->disable_active_migration;
   }
 
-  return ngtcp2_encode_transport_params(dest, destlen, &params);
+  return ngtcp2_transport_params_encode(dest, destlen, &params);
 }
 
 int ngtcp2_conn_decode_early_transport_params(ngtcp2_conn *conn,
@@ -11423,7 +11423,7 @@ int ngtcp2_conn_decode_early_transport_params(ngtcp2_conn *conn,
   ngtcp2_transport_params params;
   int rv;
 
-  rv = ngtcp2_decode_transport_params(&params, data, datalen);
+  rv = ngtcp2_transport_params_decode(&params, data, datalen);
   if (rv != 0) {
     return rv;
   }
@@ -11574,7 +11574,7 @@ ngtcp2_conn_get_local_transport_params(ngtcp2_conn *conn) {
 ngtcp2_ssize ngtcp2_conn_encode_local_transport_params(ngtcp2_conn *conn,
                                                        uint8_t *dest,
                                                        size_t destlen) {
-  return ngtcp2_encode_transport_params(dest, destlen,
+  return ngtcp2_transport_params_encode(dest, destlen,
                                         &conn->local.transport_params);
 }
 

--- a/lib/ngtcp2_crypto.c
+++ b/lib/ngtcp2_crypto.c
@@ -152,7 +152,7 @@ static uint8_t *write_cid_param(uint8_t *p, ngtcp2_transport_param_id id,
 
 static const uint8_t empty_address[16];
 
-ngtcp2_ssize ngtcp2_encode_transport_params_versioned(
+ngtcp2_ssize ngtcp2_transport_params_encode_versioned(
     uint8_t *dest, size_t destlen, int transport_params_version,
     const ngtcp2_transport_params *params) {
   uint8_t *p;
@@ -516,7 +516,7 @@ static int decode_cid_param(ngtcp2_cid *pdest, const uint8_t **pp,
   return 0;
 }
 
-int ngtcp2_decode_transport_params_versioned(int transport_params_version,
+int ngtcp2_transport_params_decode_versioned(int transport_params_version,
                                              ngtcp2_transport_params *dest,
                                              const uint8_t *data,
                                              size_t datalen) {
@@ -842,13 +842,13 @@ static int transport_params_copy_new(ngtcp2_transport_params **pdest,
   return 0;
 }
 
-int ngtcp2_decode_transport_params_new(ngtcp2_transport_params **pparams,
+int ngtcp2_transport_params_decode_new(ngtcp2_transport_params **pparams,
                                        const uint8_t *data, size_t datalen,
                                        const ngtcp2_mem *mem) {
   int rv;
   ngtcp2_transport_params params;
 
-  rv = ngtcp2_decode_transport_params(&params, data, datalen);
+  rv = ngtcp2_transport_params_decode(&params, data, datalen);
   if (rv < 0) {
     return rv;
   }

--- a/tests/main.c
+++ b/tests/main.c
@@ -175,10 +175,10 @@ int main(void) {
       !CU_add_test(pSuite, "acktr_eviction", test_ngtcp2_acktr_eviction) ||
       !CU_add_test(pSuite, "acktr_forget", test_ngtcp2_acktr_forget) ||
       !CU_add_test(pSuite, "acktr_recv_ack", test_ngtcp2_acktr_recv_ack) ||
-      !CU_add_test(pSuite, "encode_transport_params",
-                   test_ngtcp2_encode_transport_params) ||
-      !CU_add_test(pSuite, "decode_transport_params_new",
-                   test_ngtcp2_decode_transport_params_new) ||
+      !CU_add_test(pSuite, "transport_params_encode",
+                   test_ngtcp2_transport_params_encode) ||
+      !CU_add_test(pSuite, "transport_params_decode_new",
+                   test_ngtcp2_transport_params_decode_new) ||
       !CU_add_test(pSuite, "rtb_add", test_ngtcp2_rtb_add) ||
       !CU_add_test(pSuite, "rtb_recv_ack", test_ngtcp2_rtb_recv_ack) ||
       !CU_add_test(pSuite, "rtb_lost_pkt_ts", test_ngtcp2_rtb_lost_pkt_ts) ||

--- a/tests/ngtcp2_conn_test.c
+++ b/tests/ngtcp2_conn_test.c
@@ -9540,7 +9540,7 @@ void test_ngtcp2_conn_encode_early_transport_params(void) {
 
   CU_ASSERT(slen > 0);
 
-  rv = ngtcp2_decode_transport_params(&early_params, buf, (size_t)slen);
+  rv = ngtcp2_transport_params_decode(&early_params, buf, (size_t)slen);
 
   CU_ASSERT(0 == rv);
   CU_ASSERT(1 == early_params.initial_max_streams_bidi);
@@ -9599,7 +9599,7 @@ void test_ngtcp2_conn_encode_early_transport_params(void) {
 
   CU_ASSERT(slen > 0);
 
-  rv = ngtcp2_decode_transport_params(&early_params, buf, (size_t)slen);
+  rv = ngtcp2_transport_params_decode(&early_params, buf, (size_t)slen);
 
   CU_ASSERT(0 == rv);
   CU_ASSERT(params.initial_max_streams_bidi ==

--- a/tests/ngtcp2_crypto_test.c
+++ b/tests/ngtcp2_crypto_test.c
@@ -37,7 +37,7 @@ static size_t varint_paramlen(ngtcp2_transport_param_id id, uint64_t value) {
   return ngtcp2_put_uvarintlen(id) + ngtcp2_put_uvarintlen(valuelen) + valuelen;
 }
 
-void test_ngtcp2_encode_transport_params(void) {
+void test_ngtcp2_transport_params_encode(void) {
   ngtcp2_transport_params params, nparams;
   uint8_t buf[512];
   ngtcp2_ssize nwrite;
@@ -154,20 +154,20 @@ void test_ngtcp2_encode_transport_params(void) {
        sizeof(params.version_info.chosen_version) +
        params.version_info.available_versionslen);
 
-  nwrite = ngtcp2_encode_transport_params(NULL, 0, &params);
+  nwrite = ngtcp2_transport_params_encode(NULL, 0, &params);
 
   CU_ASSERT((ngtcp2_ssize)len == nwrite);
 
   for (i = 0; i < len; ++i) {
-    nwrite = ngtcp2_encode_transport_params(buf, i, &params);
+    nwrite = ngtcp2_transport_params_encode(buf, i, &params);
 
     CU_ASSERT(NGTCP2_ERR_NOBUF == nwrite);
   }
-  nwrite = ngtcp2_encode_transport_params(buf, i, &params);
+  nwrite = ngtcp2_transport_params_encode(buf, i, &params);
 
   CU_ASSERT((ngtcp2_ssize)i == nwrite);
 
-  rv = ngtcp2_decode_transport_params(&nparams, buf, (size_t)nwrite);
+  rv = ngtcp2_transport_params_decode(&nparams, buf, (size_t)nwrite);
 
   CU_ASSERT(0 == rv);
   CU_ASSERT(params.initial_max_stream_data_bidi_local ==
@@ -225,7 +225,7 @@ void test_ngtcp2_encode_transport_params(void) {
                         params.version_info.available_versionslen));
 }
 
-void test_ngtcp2_decode_transport_params_new(void) {
+void test_ngtcp2_transport_params_decode_new(void) {
   ngtcp2_transport_params params, *nparams;
   uint8_t buf[512];
   ngtcp2_ssize nwrite;
@@ -342,11 +342,11 @@ void test_ngtcp2_decode_transport_params_new(void) {
        sizeof(params.version_info.chosen_version) +
        params.version_info.available_versionslen);
 
-  nwrite = ngtcp2_encode_transport_params(buf, sizeof(buf), &params);
+  nwrite = ngtcp2_transport_params_encode(buf, sizeof(buf), &params);
 
   CU_ASSERT((ngtcp2_ssize)len == nwrite);
 
-  rv = ngtcp2_decode_transport_params_new(&nparams, buf, (size_t)nwrite, NULL);
+  rv = ngtcp2_transport_params_decode_new(&nparams, buf, (size_t)nwrite, NULL);
 
   CU_ASSERT(0 == rv);
   CU_ASSERT(params.initial_max_stream_data_bidi_local ==

--- a/tests/ngtcp2_crypto_test.h
+++ b/tests/ngtcp2_crypto_test.h
@@ -29,7 +29,7 @@
 #  include <config.h>
 #endif /* HAVE_CONFIG_H */
 
-void test_ngtcp2_encode_transport_params(void);
-void test_ngtcp2_decode_transport_params_new(void);
+void test_ngtcp2_transport_params_encode(void);
+void test_ngtcp2_transport_params_decode_new(void);
 
 #endif /* NGTCP2_CRYPTO_TEST_H */


### PR DESCRIPTION
ngtcp2_encode_transport_params has been renamed to ngtcp2_transport_params_encode.

ngtcp2_decode_transport_params has been renamed to ngtcp2_transport_params_decode.

ngtcp2_decode_transport_params_new has been renamed to ngtcp2_transport_params_decode_new.