### PR TITLE
Add NGTCP2_PATH_VALIDATION_FLAG_NEW_TOKEN

### DIFF
--- a/examples/h09server.cc
+++ b/examples/h09server.cc
@@ -577,7 +577,7 @@ int path_validation(ngtcp2_conn *conn, uint32_t flags, const ngtcp2_path *path,
   }
 
   if (res != NGTCP2_PATH_VALIDATION_RESULT_SUCCESS ||
-      ngtcp2_addr_eq(&path->remote, &old_path->remote)) {
+      !(flags & NGTCP2_PATH_VALIDATION_FLAG_NEW_TOKEN)) {
     return 0;
   }
 

--- a/examples/server.cc
+++ b/examples/server.cc
@@ -943,7 +943,7 @@ int path_validation(ngtcp2_conn *conn, uint32_t flags, const ngtcp2_path *path,
   }
 
   if (res != NGTCP2_PATH_VALIDATION_RESULT_SUCCESS ||
-      ngtcp2_addr_eq(&path->remote, &old_path->remote)) {
+      !(flags & NGTCP2_PATH_VALIDATION_FLAG_NEW_TOKEN)) {
     return 0;
   }
 

--- a/lib/includes/ngtcp2/ngtcp2.h
+++ b/lib/includes/ngtcp2/ngtcp2.h
@@ -3011,6 +3011,15 @@ typedef int (*ngtcp2_update_key)(
 #define NGTCP2_PATH_VALIDATION_FLAG_PREFERRED_ADDR 0x01u
 
 /**
+ * @macro
+ *
+ * :macro:`NGTCP2_PATH_VALIDATION_FLAG_NEW_TOKEN` indicates that
+ * server should send NEW_TOKEN for the new remote address.  This flag
+ * is only set for server.
+ */
+#define NGTCP2_PATH_VALIDATION_FLAG_NEW_TOKEN 0x02u
+
+/**
  * @functypedef
  *
  * :type:`ngtcp2_path_validation` is a callback function which tells


### PR DESCRIPTION
Add NGTCP2_PATH_VALIDATION_FLAG_NEW_TOKEN to indicate that server should send NEW_TOKEN for the new remote address.