### PR TITLE
interop: Disable PMTUD for zerortt test

### DIFF
--- a/interop/run_endpoint.sh
+++ b/interop/run_endpoint.sh
@@ -45,7 +45,7 @@ if [ "$ROLE" == "client" ]; then
         "v2")
             CLIENT_ARGS="$CLIENT_ARGS --available-versions v2,v1"
             ;;
-        "ecn")
+        "ecn"|"zerortt")
             CLIENT_ARGS="$CLIENT_ARGS --no-pmtud"
             ;;
     esac


### PR DESCRIPTION
interop zerortt test fails if client sends any data (it counts literary QUIC packet payload size, not just STREAM frame) more than 0.5 * file name length * the number of files.  Sending client PMTUD packets exceeds this threshold.