### PR TITLE
Rename NGTCP2_CONN_FLAG_CONN_ID_NEGOTIATED

### DIFF
--- a/lib/ngtcp2_conn.h
+++ b/lib/ngtcp2_conn.h
@@ -167,9 +167,9 @@ void ngtcp2_path_challenge_entry_init(ngtcp2_path_challenge_entry *pcent,
    they write off Server Finished and before deriving application rx
    secret. */
 #define NGTCP2_CONN_FLAG_HANDSHAKE_COMPLETED 0x01u
-/* NGTCP2_CONN_FLAG_CONN_ID_NEGOTIATED is set if connection ID is
-   negotiated.  This is only used for client. */
-#define NGTCP2_CONN_FLAG_CONN_ID_NEGOTIATED 0x02u
+/* NGTCP2_CONN_FLAG_INITIAL_PKT_PROCESSED is set when the first
+   Initial packet has successfully been processed. */
+#define NGTCP2_CONN_FLAG_INITIAL_PKT_PROCESSED 0x02u
 /* NGTCP2_CONN_FLAG_TRANSPORT_PARAM_RECVED is set if transport
    parameters are received. */
 #define NGTCP2_CONN_FLAG_TRANSPORT_PARAM_RECVED 0x04u

--- a/tests/ngtcp2_conn_test.c
+++ b/tests/ngtcp2_conn_test.c
@@ -693,7 +693,7 @@ setup_default_server_settings(ngtcp2_conn **pconn, const ngtcp2_path *path,
   ngtcp2_conn_install_tx_key(*pconn, null_secret, sizeof(null_secret),
                              &aead_ctx, null_iv, sizeof(null_iv), &hp_ctx);
   (*pconn)->state = NGTCP2_CS_POST_HANDSHAKE;
-  (*pconn)->flags |= NGTCP2_CONN_FLAG_CONN_ID_NEGOTIATED |
+  (*pconn)->flags |= NGTCP2_CONN_FLAG_INITIAL_PKT_PROCESSED |
                      NGTCP2_CONN_FLAG_HANDSHAKE_COMPLETED |
                      NGTCP2_CONN_FLAG_HANDSHAKE_COMPLETED_HANDLED |
                      NGTCP2_CONN_FLAG_HANDSHAKE_CONFIRMED;
@@ -758,7 +758,7 @@ static void setup_default_client(ngtcp2_conn **pconn) {
   ngtcp2_conn_install_tx_key(*pconn, null_secret, sizeof(null_secret),
                              &aead_ctx, null_iv, sizeof(null_iv), &hp_ctx);
   (*pconn)->state = NGTCP2_CS_POST_HANDSHAKE;
-  (*pconn)->flags |= NGTCP2_CONN_FLAG_CONN_ID_NEGOTIATED |
+  (*pconn)->flags |= NGTCP2_CONN_FLAG_INITIAL_PKT_PROCESSED |
                      NGTCP2_CONN_FLAG_HANDSHAKE_COMPLETED |
                      NGTCP2_CONN_FLAG_HANDSHAKE_COMPLETED_HANDLED |
                      NGTCP2_CONN_FLAG_HANDSHAKE_CONFIRMED;


### PR DESCRIPTION
Rename NGTCP2_CONN_FLAG_CONN_ID_NEGOTIATED to
NGTCP2_CONN_FLAG_INITIAL_PKT_PROCESSED.