### PR TITLE
Rename ngtcp2_conn_handshake_completed

### DIFF
--- a/crypto/boringssl/boringssl.c
+++ b/crypto/boringssl/boringssl.c
@@ -438,7 +438,7 @@ int ngtcp2_crypto_read_write_crypto_data(ngtcp2_conn *conn,
       return 0;
     }
 
-    ngtcp2_conn_handshake_completed(conn);
+    ngtcp2_conn_tls_handshake_completed(conn);
   }
 
   rv = SSL_process_quic_post_handshake(ssl);

--- a/crypto/gnutls/gnutls.c
+++ b/crypto/gnutls/gnutls.c
@@ -474,7 +474,7 @@ int ngtcp2_crypto_read_write_crypto_data(ngtcp2_conn *conn,
       return -1;
     }
 
-    ngtcp2_conn_handshake_completed(conn);
+    ngtcp2_conn_tls_handshake_completed(conn);
   }
 
   return 0;

--- a/crypto/openssl/openssl.c
+++ b/crypto/openssl/openssl.c
@@ -623,7 +623,7 @@ int ngtcp2_crypto_read_write_crypto_data(ngtcp2_conn *conn,
       }
     }
 
-    ngtcp2_conn_handshake_completed(conn);
+    ngtcp2_conn_tls_handshake_completed(conn);
   }
 
   rv = SSL_process_quic_post_handshake(ssl);

--- a/crypto/picotls/picotls.c
+++ b/crypto/picotls/picotls.c
@@ -409,7 +409,7 @@ int ngtcp2_crypto_read_write_crypto_data(ngtcp2_conn *conn,
   }
 
   if (rv == 0) {
-    ngtcp2_conn_handshake_completed(conn);
+    ngtcp2_conn_tls_handshake_completed(conn);
   }
 
   rv = 0;

--- a/crypto/wolfssl/wolfssl.c
+++ b/crypto/wolfssl/wolfssl.c
@@ -332,7 +332,7 @@ int ngtcp2_crypto_read_write_crypto_data(ngtcp2_conn *conn,
     }
 
     DEBUG_MSG("WOLFSSL: handshake done\n");
-    ngtcp2_conn_handshake_completed(conn);
+    ngtcp2_conn_tls_handshake_completed(conn);
   }
 
   rv = wolfSSL_process_quic_post_handshake(ssl);

--- a/lib/includes/ngtcp2/ngtcp2.h
+++ b/lib/includes/ngtcp2/ngtcp2.h
@@ -3766,12 +3766,12 @@ NGTCP2_EXTERN ngtcp2_ssize ngtcp2_conn_write_pkt_versioned(
 /**
  * @function
  *
- * `ngtcp2_conn_handshake_completed` tells |conn| that the TLS stack
- * declares TLS handshake completion.  This does not mean QUIC
+ * `ngtcp2_conn_tls_handshake_completed` tells |conn| that the TLS
+ * stack declares TLS handshake completion.  This does not mean QUIC
  * handshake has completed.  The library needs extra conditions to be
  * met.
  */
-NGTCP2_EXTERN void ngtcp2_conn_handshake_completed(ngtcp2_conn *conn);
+NGTCP2_EXTERN void ngtcp2_conn_tls_handshake_completed(ngtcp2_conn *conn);
 
 /**
  * @function

--- a/lib/ngtcp2_conn.c
+++ b/lib/ngtcp2_conn.c
@@ -68,7 +68,7 @@ static int bidi_stream(int64_t stream_id) { return (stream_id & 0x2) == 0; }
  * completed.
  */
 static int conn_is_handshake_completed(ngtcp2_conn *conn) {
-  return (conn->flags & NGTCP2_CONN_FLAG_HANDSHAKE_COMPLETED) &&
+  return (conn->flags & NGTCP2_CONN_FLAG_TLS_HANDSHAKE_COMPLETED) &&
          conn->pktns.crypto.rx.ckm && conn->pktns.crypto.tx.ckm;
 }
 
@@ -10438,8 +10438,8 @@ static ngtcp2_ssize conn_client_write_handshake(ngtcp2_conn *conn,
   return spktlen + early_spktlen;
 }
 
-void ngtcp2_conn_handshake_completed(ngtcp2_conn *conn) {
-  conn->flags |= NGTCP2_CONN_FLAG_HANDSHAKE_COMPLETED;
+void ngtcp2_conn_tls_handshake_completed(ngtcp2_conn *conn) {
+  conn->flags |= NGTCP2_CONN_FLAG_TLS_HANDSHAKE_COMPLETED;
   if (conn->server) {
     conn->flags |= NGTCP2_CONN_FLAG_HANDSHAKE_CONFIRMED;
   }

--- a/lib/ngtcp2_conn.h
+++ b/lib/ngtcp2_conn.h
@@ -159,14 +159,14 @@ void ngtcp2_path_challenge_entry_init(ngtcp2_path_challenge_entry *pcent,
 
 /* NGTCP2_CONN_FLAG_NONE indicates that no flag is set. */
 #define NGTCP2_CONN_FLAG_NONE 0x00u
-/* NGTCP2_CONN_FLAG_HANDSHAKE_COMPLETED is set when TLS stack declares
-   that TLS handshake has completed.  The condition of this
+/* NGTCP2_CONN_FLAG_TLS_HANDSHAKE_COMPLETED is set when TLS stack
+   declares that TLS handshake has completed.  The condition of this
    declaration varies between TLS implementations and this flag does
    not indicate the completion of QUIC handshake.  Some
    implementations declare TLS handshake completion as server when
    they write off Server Finished and before deriving application rx
    secret. */
-#define NGTCP2_CONN_FLAG_HANDSHAKE_COMPLETED 0x01u
+#define NGTCP2_CONN_FLAG_TLS_HANDSHAKE_COMPLETED 0x01u
 /* NGTCP2_CONN_FLAG_INITIAL_PKT_PROCESSED is set when the first
    Initial packet has successfully been processed. */
 #define NGTCP2_CONN_FLAG_INITIAL_PKT_PROCESSED 0x02u

--- a/tests/ngtcp2_conn_test.c
+++ b/tests/ngtcp2_conn_test.c
@@ -695,7 +695,7 @@ setup_default_server_settings(ngtcp2_conn **pconn, const ngtcp2_path *path,
                              &aead_ctx, null_iv, sizeof(null_iv), &hp_ctx);
   (*pconn)->state = NGTCP2_CS_POST_HANDSHAKE;
   (*pconn)->flags |= NGTCP2_CONN_FLAG_INITIAL_PKT_PROCESSED |
-                     NGTCP2_CONN_FLAG_HANDSHAKE_COMPLETED |
+                     NGTCP2_CONN_FLAG_TLS_HANDSHAKE_COMPLETED |
                      NGTCP2_CONN_FLAG_HANDSHAKE_COMPLETED_HANDLED |
                      NGTCP2_CONN_FLAG_HANDSHAKE_CONFIRMED;
   (*pconn)->dcid.current.flags |= NGTCP2_DCID_FLAG_PATH_VALIDATED;
@@ -760,7 +760,7 @@ static void setup_default_client(ngtcp2_conn **pconn) {
                              &aead_ctx, null_iv, sizeof(null_iv), &hp_ctx);
   (*pconn)->state = NGTCP2_CS_POST_HANDSHAKE;
   (*pconn)->flags |= NGTCP2_CONN_FLAG_INITIAL_PKT_PROCESSED |
-                     NGTCP2_CONN_FLAG_HANDSHAKE_COMPLETED |
+                     NGTCP2_CONN_FLAG_TLS_HANDSHAKE_COMPLETED |
                      NGTCP2_CONN_FLAG_HANDSHAKE_COMPLETED_HANDLED |
                      NGTCP2_CONN_FLAG_HANDSHAKE_CONFIRMED;
   (*pconn)->dcid.current.flags |= NGTCP2_DCID_FLAG_PATH_VALIDATED;
@@ -6637,7 +6637,7 @@ void test_ngtcp2_conn_handshake_loss(void) {
                              null_iv, sizeof(null_iv), &hp_ctx);
   ngtcp2_conn_install_tx_key(conn, null_secret, sizeof(null_secret), &aead_ctx,
                              null_iv, sizeof(null_iv), &hp_ctx);
-  ngtcp2_conn_handshake_completed(conn);
+  ngtcp2_conn_tls_handshake_completed(conn);
 
   /* This will send Handshake ACK and CRYPTO */
   spktlen = ngtcp2_conn_write_pkt(conn, NULL, NULL, buf, sizeof(buf), ++t);
@@ -8433,7 +8433,7 @@ void test_ngtcp2_conn_early_data_sync_stream_data_limit(void) {
 
   CU_ASSERT(0 == rv);
 
-  ngtcp2_conn_handshake_completed(conn);
+  ngtcp2_conn_tls_handshake_completed(conn);
   spktlen = ngtcp2_conn_write_pkt(conn, NULL, NULL, buf, sizeof(buf), ++t);
 
   CU_ASSERT(0 < spktlen);
@@ -8561,7 +8561,7 @@ void test_ngtcp2_conn_early_data_rejected(void) {
 
   CU_ASSERT(0 == rv);
 
-  ngtcp2_conn_handshake_completed(conn);
+  ngtcp2_conn_tls_handshake_completed(conn);
   ngtcp2_conn_early_data_rejected(conn);
   spktlen = ngtcp2_conn_write_pkt(conn, NULL, NULL, buf, sizeof(buf), ++t);
 


### PR DESCRIPTION
Rename ngtcp2_conn_handshake_completed to
ngtcp2_conn_tls_handshake_completed as it tells the ngtcp2_conn that TLS handshake has completed rather than QUIC one.  The internal flag name is also adjusted to adopt this change.