### PR TITLE
Shorten long names related to connection_close_error

### DIFF
--- a/examples/client_base.cc
+++ b/examples/client_base.cc
@@ -48,7 +48,7 @@ ClientBase::ClientBase()
       qlog_(nullptr),
       conn_(nullptr),
       ticket_received_(false) {
-  ngtcp2_connection_close_error_default(&last_error_);
+  ngtcp2_ccerr_default(&last_error_);
 }
 
 ClientBase::~ClientBase() {

--- a/examples/client_base.h
+++ b/examples/client_base.h
@@ -210,7 +210,7 @@ protected:
   TLSClientSession tls_session_;
   FILE *qlog_;
   ngtcp2_conn *conn_;
-  ngtcp2_connection_close_error last_error_;
+  ngtcp2_ccerr last_error_;
   bool ticket_received_;
 };
 

--- a/examples/gtlssimpleclient.c
+++ b/examples/gtlssimpleclient.c
@@ -146,7 +146,7 @@ struct client {
     size_t nwrite;
   } stream;
 
-  ngtcp2_connection_close_error last_error;
+  ngtcp2_ccerr last_error;
 
   ev_io rev;
   ev_timer timer;
@@ -443,11 +443,10 @@ static int client_read(struct client *c) {
       fprintf(stderr, "ngtcp2_conn_read_pkt: %s\n", ngtcp2_strerror(rv));
       if (!c->last_error.error_code) {
         if (rv == NGTCP2_ERR_CRYPTO) {
-          ngtcp2_connection_close_error_set_transport_error_tls_alert(
+          ngtcp2_ccerr_set_tls_alert(
               &c->last_error, ngtcp2_conn_get_tls_alert(c->conn), NULL, 0);
         } else {
-          ngtcp2_connection_close_error_set_transport_error_liberr(
-              &c->last_error, rv, NULL, 0);
+          ngtcp2_ccerr_set_liberr(&c->last_error, rv, NULL, 0);
         }
       }
       return -1;
@@ -536,8 +535,7 @@ static int client_write_streams(struct client *c) {
       default:
         fprintf(stderr, "ngtcp2_conn_writev_stream: %s\n",
                 ngtcp2_strerror((int)nwrite));
-        ngtcp2_connection_close_error_set_transport_error_liberr(
-            &c->last_error, (int)nwrite, NULL, 0);
+        ngtcp2_ccerr_set_liberr(&c->last_error, (int)nwrite, NULL, 0);
         return -1;
       }
     }
@@ -655,7 +653,7 @@ static int client_init(struct client *c) {
 
   memset(c, 0, sizeof(*c));
 
-  ngtcp2_connection_close_error_default(&c->last_error);
+  ngtcp2_ccerr_default(&c->last_error);
 
   c->fd = create_sock((struct sockaddr *)&remote_addr, &remote_addrlen,
                       REMOTE_HOST, REMOTE_PORT);

--- a/examples/server_base.cc
+++ b/examples/server_base.cc
@@ -44,7 +44,7 @@ static ngtcp2_conn *get_conn(ngtcp2_crypto_conn_ref *conn_ref) {
 }
 
 HandlerBase::HandlerBase() : conn_ref_{get_conn, this}, conn_(nullptr) {
-  ngtcp2_connection_close_error_default(&last_error_);
+  ngtcp2_ccerr_default(&last_error_);
 }
 
 HandlerBase::~HandlerBase() {

--- a/examples/server_base.h
+++ b/examples/server_base.h
@@ -189,7 +189,7 @@ protected:
   ngtcp2_crypto_conn_ref conn_ref_;
   TLSServerSession tls_session_;
   ngtcp2_conn *conn_;
-  ngtcp2_connection_close_error last_error_;
+  ngtcp2_ccerr last_error_;
 };
 
 #endif // SERVER_BASE_H

--- a/lib/includes/ngtcp2/ngtcp2.h
+++ b/lib/includes/ngtcp2/ngtcp2.h
@@ -5191,47 +5191,47 @@ ngtcp2_conn_get_early_crypto_ctx(ngtcp2_conn *conn);
 /**
  * @enum
  *
- * :type:`ngtcp2_connection_close_error_code_type` defines connection
- * error code type.
+ * :type:`ngtcp2_ccerr_type` defines connection error type.
  */
-typedef enum ngtcp2_connection_close_error_code_type {
+typedef enum ngtcp2_ccerr_type {
   /**
-   * :enum:`NGTCP2_CONNECTION_CLOSE_ERROR_CODE_TYPE_TRANSPORT`
-   * indicates the error code is QUIC transport error code.
+   * :enum:`NGTCP2_CCERR_TYPE_TRANSPORT` indicates the QUIC transport
+   * error, and the error code is QUIC transport error code.
    */
-  NGTCP2_CONNECTION_CLOSE_ERROR_CODE_TYPE_TRANSPORT,
+  NGTCP2_CCERR_TYPE_TRANSPORT,
   /**
-   * :enum:`NGTCP2_CONNECTION_CLOSE_ERROR_CODE_TYPE_APPLICATION`
-   * indicates the error code is application error code.
+   * :enum:`NGTCP2_CCERR_TYPE_APPLICATION` indicates an application
+   * error, and the error code is application error code.
    */
-  NGTCP2_CONNECTION_CLOSE_ERROR_CODE_TYPE_APPLICATION,
+  NGTCP2_CCERR_TYPE_APPLICATION,
   /**
-   * :enum:`NGTCP2_CONNECTION_CLOSE_ERROR_CODE_TYPE_TRANSPORT_VERSION_NEGOTIATION`
-   * is a special case of QUIC transport error, and it indicates that
-   * client receives Version Negotiation packet.
+   * :enum:`NGTCP2_CCERR_TYPE_VERSION_NEGOTIATION` is a special case
+   * of QUIC transport error, and it indicates that client receives
+   * Version Negotiation packet.
    */
-  NGTCP2_CONNECTION_CLOSE_ERROR_CODE_TYPE_TRANSPORT_VERSION_NEGOTIATION,
+  NGTCP2_CCERR_TYPE_VERSION_NEGOTIATION,
   /**
-   * :enum:`NGTCP2_CONNECTION_CLOSE_ERROR_CODE_TYPE_TRANSPORT_IDLE_CLOSE`
-   * is a special case of QUIC transport error, and it indicates that
-   * connection is closed because of idle timeout.
+   * :enum:`NGTCP2_CCERR_TYPE_IDLE_CLOSE` is a special case of QUIC
+   * transport error, and it indicates that connection is closed
+   * because of idle timeout.
    */
-  NGTCP2_CONNECTION_CLOSE_ERROR_CODE_TYPE_TRANSPORT_IDLE_CLOSE
-} ngtcp2_connection_close_error_code_type;
+  NGTCP2_CCERR_TYPE_IDLE_CLOSE
+} ngtcp2_ccerr_type;
 
 /**
  * @struct
  *
- * :type:`ngtcp2_connection_close_error` contains connection
- * error code, its type, and the optional reason phrase.
+ * :type:`ngtcp2_ccerr` contains connection error code, its type, and
+ * the optional reason phrase.
  */
-typedef struct ngtcp2_connection_close_error {
+typedef struct ngtcp2_ccerr {
   /**
-   * :member:`type` is the type of :member:`error_code`.
+   * :member:`type` is the type of this error.
    */
-  ngtcp2_connection_close_error_code_type type;
+  ngtcp2_ccerr_type type;
   /**
    * :member:`error_code` is the error code for connection closure.
+   * Its interpretation depends on :member:`type`.
    */
   uint64_t error_code;
   /**
@@ -5252,103 +5252,97 @@ typedef struct ngtcp2_connection_close_error {
    * :member:`reason`.
    */
   size_t reasonlen;
-} ngtcp2_connection_close_error;
+} ngtcp2_ccerr;
 
 /**
  * @function
  *
- * `ngtcp2_connection_close_error_default` initializes |ccerr| with
- * the default values.  It sets the following fields:
+ * `ngtcp2_ccerr_default` initializes |ccerr| with the default values.
+ * It sets the following fields:
  *
- * - :member:`type <ngtcp2_connection_close_error.type>` =
- *   :enum:`ngtcp2_connection_close_error_code_type.NGTCP2_CONNECTION_CLOSE_ERROR_CODE_TYPE_TRANSPORT`
- * - :member:`error_code <ngtcp2_connection_close_error.error_code>` =
+ * - :member:`type <ngtcp2_ccerr.type>` =
+ *   :enum:`ngtcp2_ccerr_type.NGTCP2_CCERR_TYPE_TRANSPORT`
+ * - :member:`error_code <ngtcp2_ccerr.error_code>` =
  *   :macro:`NGTCP2_NO_ERROR`.
- * - :member:`frame_type <ngtcp2_connection_close_error.frame_type>` =
- *   0
- * - :member:`reason <ngtcp2_connection_close_error.reason>` = NULL
- * - :member:`reasonlen <ngtcp2_connection_close_error.reasonlen>` = 0
+ * - :member:`frame_type <ngtcp2_ccerr.frame_type>` = 0
+ * - :member:`reason <ngtcp2_ccerr.reason>` = NULL
+ * - :member:`reasonlen <ngtcp2_ccerr.reasonlen>` = 0
  */
-NGTCP2_EXTERN void
-ngtcp2_connection_close_error_default(ngtcp2_connection_close_error *ccerr);
+NGTCP2_EXTERN void ngtcp2_ccerr_default(ngtcp2_ccerr *ccerr);
 
 /**
  * @function
  *
- * `ngtcp2_connection_close_error_set_transport_error` sets
- * :member:`ccerr->type <ngtcp2_connection_close_error.type>` to
- * :enum:`ngtcp2_connection_close_error_code_type.NGTCP2_CONNECTION_CLOSE_ERROR_CODE_TYPE_TRANSPORT`,
- * and :member:`ccerr->error_code
- * <ngtcp2_connection_close_error.error_code>` to |error_code|.
- * |reason| is the reason phrase of length |reasonlen|.  This function
- * does not make a copy of the reason phrase.
+ * `ngtcp2_ccerr_set_transport_error` sets :member:`ccerr->type
+ * <ngtcp2_ccerr.type>` to
+ * :enum:`ngtcp2_ccerr_type.NGTCP2_CCERR_TYPE_TRANSPORT`, and
+ * :member:`ccerr->error_code <ngtcp2_ccerr.error_code>` to
+ * |error_code|.  |reason| is the reason phrase of length |reasonlen|.
+ * This function does not make a copy of the reason phrase.
  */
-NGTCP2_EXTERN void ngtcp2_connection_close_error_set_transport_error(
-    ngtcp2_connection_close_error *ccerr, uint64_t error_code,
-    const uint8_t *reason, size_t reasonlen);
+NGTCP2_EXTERN void ngtcp2_ccerr_set_transport_error(ngtcp2_ccerr *ccerr,
+                                                    uint64_t error_code,
+                                                    const uint8_t *reason,
+                                                    size_t reasonlen);
 
 /**
  * @function
  *
- * `ngtcp2_connection_close_error_set_transport_error_liberr` sets
- * type and error_code based on |liberr|.
+ * `ngtcp2_ccerr_set_liberr` sets type and error_code based on
+ * |liberr|.
  *
  * If |liberr| is :macro:`NGTCP2_ERR_RECV_VERSION_NEGOTIATION`,
- * :member:`ccerr->type <ngtcp2_connection_close_error.type>` is set
- * to
- * :enum:`ngtcp2_connection_close_error_code_type.NGTCP2_CONNECTION_CLOSE_ERROR_CODE_TYPE_TRANSPORT_VERSION_NEGOTIATION`,
- * and :member:`ccerr->error_code
- * <ngtcp2_connection_close_error.error_code>` to
+ * :member:`ccerr->type <ngtcp2_ccerr.type>` is set to
+ * :enum:`ngtcp2_ccerr_type.NGTCP2_CCERR_TYPE_VERSION_NEGOTIATION`,
+ * and :member:`ccerr->error_code <ngtcp2_ccerr.error_code>` to
  * :macro:`NGTCP2_NO_ERROR`.  If |liberr| is
  * :macro:`NGTCP2_ERR_IDLE_CLOSE`, :member:`ccerr->type
- * <ngtcp2_connection_close_error.type>` is set to
- * :enum:`ngtcp2_connection_close_error_code_type.NGTCP2_CONNECTION_CLOSE_ERROR_CODE_TYPE_TRANSPORT_IDLE_CLOSE`,
- * and :member:`ccerr->error_code
- * <ngtcp2_connection_close_error.error_code>` to
+ * <ngtcp2_ccerr.type>` is set to
+ * :enum:`ngtcp2_ccerr_type.NGTCP2_CCERR_TYPE_IDLE_CLOSE`, and
+ * :member:`ccerr->error_code <ngtcp2_ccerr.error_code>` to
  * :macro:`NGTCP2_NO_ERROR`.  Otherwise, :member:`ccerr->type
- * <ngtcp2_connection_close_error.type>` is set to
- * :enum:`ngtcp2_connection_close_error_code_type.NGTCP2_CONNECTION_CLOSE_ERROR_CODE_TYPE_TRANSPORT`,
- * and :member:`ccerr->error_code
- * <ngtcp2_connection_close_error.error_code>` is set to an error code
- * inferred by |liberr| (see
+ * <ngtcp2_ccerr.type>` is set to
+ * :enum:`ngtcp2_ccerr_type.NGTCP2_CCERR_TYPE_TRANSPORT`, and
+ * :member:`ccerr->error_code <ngtcp2_ccerr.error_code>` is set to an
+ * error code inferred by |liberr| (see
  * `ngtcp2_err_infer_quic_transport_error_code`).  |reason| is the
  * reason phrase of length |reasonlen|.  This function does not make a
  * copy of the reason phrase.
  */
-NGTCP2_EXTERN void ngtcp2_connection_close_error_set_transport_error_liberr(
-    ngtcp2_connection_close_error *ccerr, int liberr, const uint8_t *reason,
-    size_t reasonlen);
+NGTCP2_EXTERN void ngtcp2_ccerr_set_liberr(ngtcp2_ccerr *ccerr, int liberr,
+                                           const uint8_t *reason,
+                                           size_t reasonlen);
 
 /**
  * @function
  *
- * `ngtcp2_connection_close_error_set_transport_error_tls_alert` sets
- * :member:`ccerr->type <ngtcp2_connection_close_error.type>` to
- * :enum:`ngtcp2_connection_close_error_code_type.NGTCP2_CONNECTION_CLOSE_ERROR_CODE_TYPE_TRANSPORT`,
- * and :member:`ccerr->error_code
- * <ngtcp2_connection_close_error.error_code>` to bitwise-OR of
- * :macro:`NGTCP2_CRYPTO_ERROR` and |tls_alert|.  |reason| is the
+ * `ngtcp2_ccerr_set_tls_alert` sets :member:`ccerr->type
+ * <ngtcp2_ccerr.type>` to
+ * :enum:`ngtcp2_ccerr_type.NGTCP2_CCERR_TYPE_TRANSPORT`, and
+ * :member:`ccerr->error_code <ngtcp2_ccerr.error_code>` to bitwise-OR
+ * of :macro:`NGTCP2_CRYPTO_ERROR` and |tls_alert|.  |reason| is the
  * reason phrase of length |reasonlen|.  This function does not make a
  * copy of the reason phrase.
  */
-NGTCP2_EXTERN void ngtcp2_connection_close_error_set_transport_error_tls_alert(
-    ngtcp2_connection_close_error *ccerr, uint8_t tls_alert,
-    const uint8_t *reason, size_t reasonlen);
+NGTCP2_EXTERN void ngtcp2_ccerr_set_tls_alert(ngtcp2_ccerr *ccerr,
+                                              uint8_t tls_alert,
+                                              const uint8_t *reason,
+                                              size_t reasonlen);
 
 /**
  * @function
  *
- * `ngtcp2_connection_close_error_set_application_error` sets
- * :member:`ccerr->type <ngtcp2_connection_close_error.type>` to
- * :enum:`ngtcp2_connection_close_error_code_type.NGTCP2_CONNECTION_CLOSE_ERROR_CODE_TYPE_APPLICATION`,
- * and :member:`ccerr->error_code
- * <ngtcp2_connection_close_error.error_code>` to |error_code|.
- * |reason| is the reason phrase of length |reasonlen|.  This function
- * does not make a copy of the reason phrase.
+ * `ngtcp2_ccerr_set_application_error` sets :member:`ccerr->type
+ * <ngtcp2_ccerr.type>` to
+ * :enum:`ngtcp2_ccerr_type.NGTCP2_CCERR_TYPE_APPLICATION`, and
+ * :member:`ccerr->error_code <ngtcp2_ccerr.error_code>` to
+ * |error_code|.  |reason| is the reason phrase of length |reasonlen|.
+ * This function does not make a copy of the reason phrase.
  */
-NGTCP2_EXTERN void ngtcp2_connection_close_error_set_application_error(
-    ngtcp2_connection_close_error *ccerr, uint64_t error_code,
-    const uint8_t *reason, size_t reasonlen);
+NGTCP2_EXTERN void ngtcp2_ccerr_set_application_error(ngtcp2_ccerr *ccerr,
+                                                      uint64_t error_code,
+                                                      const uint8_t *reason,
+                                                      size_t reasonlen);
 
 /**
  * @function
@@ -5369,13 +5363,13 @@ NGTCP2_EXTERN void ngtcp2_connection_close_error_set_application_error(
  * If |pi| is not ``NULL``, this function stores packet metadata in it
  * if it succeeds.  The metadata includes ECN markings.
  *
- * If :member:`ccerr->type <ngtcp2_connection_close_error.type>` ==
- * :enum:`ngtcp2_connection_close_error_code_type.NGTCP2_CONNECTION_CLOSE_ERROR_CODE_TYPE_TRANSPORT`,
- * this function sends CONNECTION_CLOSE (type 0x1c) frame.  If
- * :member:`ccerr->type <ngtcp2_connection_close_error.type>` ==
- * :enum:`ngtcp2_connection_close_error_code_type.NGTCP2_CONNECTION_CLOSE_ERROR_CODE_TYPE_APPLICATION`,
- * it sends CONNECTION_CLOSE (type 0x1d) frame.  Otherwise, it does
- * not produce any data, and returns 0.
+ * If :member:`ccerr->type <ngtcp2_ccerr.type>` ==
+ * :enum:`ngtcp2_ccerr_type.NGTCP2_CCERR_TYPE_TRANSPORT`, this
+ * function sends CONNECTION_CLOSE (type 0x1c) frame.  If
+ * :member:`ccerr->type <ngtcp2_ccerr.type>` ==
+ * :enum:`ngtcp2_ccerr_type.NGTCP2_CCERR_TYPE_APPLICATION`, it sends
+ * CONNECTION_CLOSE (type 0x1d) frame.  Otherwise, it does not produce
+ * any data, and returns 0.
  *
  * This function must not be called from inside the callback
  * functions.
@@ -5401,17 +5395,16 @@ NGTCP2_EXTERN void ngtcp2_connection_close_error_set_application_error(
 NGTCP2_EXTERN ngtcp2_ssize ngtcp2_conn_write_connection_close_versioned(
     ngtcp2_conn *conn, ngtcp2_path *path, int pkt_info_version,
     ngtcp2_pkt_info *pi, uint8_t *dest, size_t destlen,
-    const ngtcp2_connection_close_error *ccerr, ngtcp2_tstamp ts);
+    const ngtcp2_ccerr *ccerr, ngtcp2_tstamp ts);
 
 /**
  * @function
  *
- * `ngtcp2_conn_get_connection_close_error` stores the received
- * connection close error in |ccerr|.
+ * `ngtcp2_conn_get_ccerr` stores the received connection close error
+ * in |ccerr|.
  */
-NGTCP2_EXTERN void
-ngtcp2_conn_get_connection_close_error(ngtcp2_conn *conn,
-                                       ngtcp2_connection_close_error *ccerr);
+NGTCP2_EXTERN void ngtcp2_conn_get_ccerr(ngtcp2_conn *conn,
+                                         ngtcp2_ccerr *ccerr);
 
 /**
  * @function

--- a/lib/ngtcp2_conn.h
+++ b/lib/ngtcp2_conn.h
@@ -120,10 +120,10 @@ typedef enum {
    packets sent in NGTCP2_ECN_STATE_TESTING period. */
 #define NGTCP2_ECN_MAX_NUM_VALIDATION_PKTS 10
 
-/* NGTCP2_CONNECTION_CLOSE_ERROR_MAX_REASONLEN is the maximum length
-   of reason phrase to remember.  If the received reason phrase is
-   longer than this value, it is truncated. */
-#define NGTCP2_CONNECTION_CLOSE_ERROR_MAX_REASONLEN 1024
+/* NGTCP2_CCERR_MAX_REASONLEN is the maximum length of reason phrase
+   to remember.  If the received reason phrase is longer than this
+   value, it is truncated. */
+#define NGTCP2_CCERR_MAX_REASONLEN 1024
 
 /* NGTCP2_WRITE_PKT_FLAG_NONE indicates that no flag is set. */
 #define NGTCP2_WRITE_PKT_FLAG_NONE 0x00u
@@ -496,7 +496,7 @@ struct ngtcp2_conn {
     /* path_challenge stores received PATH_CHALLENGE data. */
     ngtcp2_static_ringbuf_path_challenge path_challenge;
     /* ccerr is the received connection close error. */
-    ngtcp2_connection_close_error ccerr;
+    ngtcp2_ccerr ccerr;
   } rx;
 
   struct {

--- a/tests/main.c
+++ b/tests/main.c
@@ -303,8 +303,7 @@ int main(void) {
       !CU_add_test(pSuite, "conn_buffer_pkt", test_ngtcp2_conn_buffer_pkt) ||
       !CU_add_test(pSuite, "conn_handshake_timeout",
                    test_ngtcp2_conn_handshake_timeout) ||
-      !CU_add_test(pSuite, "conn_get_connection_close_error",
-                   test_ngtcp2_conn_get_connection_close_error) ||
+      !CU_add_test(pSuite, "conn_get_ccerr", test_ngtcp2_conn_get_ccerr) ||
       !CU_add_test(pSuite, "conn_version_negotiation",
                    test_ngtcp2_conn_version_negotiation) ||
       !CU_add_test(pSuite, "conn_server_negotiate_version",

--- a/tests/ngtcp2_conn_test.c
+++ b/tests/ngtcp2_conn_test.c
@@ -7375,7 +7375,7 @@ void test_ngtcp2_conn_write_connection_close(void) {
   ngtcp2_crypto_aead_ctx aead_ctx = {0};
   ngtcp2_crypto_cipher_ctx hp_ctx = {0};
   ngtcp2_crypto_ctx crypto_ctx;
-  ngtcp2_connection_close_error ccerr;
+  ngtcp2_ccerr ccerr;
 
   /* Client only Initial key */
   setup_handshake_client(&conn);
@@ -7384,8 +7384,8 @@ void test_ngtcp2_conn_write_connection_close(void) {
 
   CU_ASSERT(spktlen > 0);
 
-  ngtcp2_connection_close_error_set_transport_error(&ccerr, NGTCP2_NO_ERROR,
-                                                    (const uint8_t *)"foo", 3);
+  ngtcp2_ccerr_set_transport_error(&ccerr, NGTCP2_NO_ERROR,
+                                   (const uint8_t *)"foo", 3);
 
   spktlen = ngtcp2_conn_write_connection_close(conn, NULL, NULL, buf,
                                                sizeof(buf), &ccerr, 0);
@@ -7414,7 +7414,7 @@ void test_ngtcp2_conn_write_connection_close(void) {
   ngtcp2_conn_install_tx_handshake_key(conn, &aead_ctx, null_iv,
                                        sizeof(null_iv), &hp_ctx);
 
-  ngtcp2_connection_close_error_set_transport_error_liberr(&ccerr, 0, NULL, 0);
+  ngtcp2_ccerr_set_liberr(&ccerr, 0, NULL, 0);
 
   spktlen = ngtcp2_conn_write_connection_close(conn, NULL, NULL, buf,
                                                sizeof(buf), &ccerr, 0);
@@ -7444,8 +7444,7 @@ void test_ngtcp2_conn_write_connection_close(void) {
 
   conn->state = NGTCP2_CS_POST_HANDSHAKE;
 
-  ngtcp2_connection_close_error_set_transport_error(&ccerr, NGTCP2_NO_ERROR,
-                                                    NULL, 0);
+  ngtcp2_ccerr_set_transport_error(&ccerr, NGTCP2_NO_ERROR, NULL, 0);
 
   spktlen = ngtcp2_conn_write_connection_close(conn, NULL, NULL, buf,
                                                sizeof(buf), &ccerr, 0);
@@ -7473,8 +7472,7 @@ void test_ngtcp2_conn_write_connection_close(void) {
   /* Client has confirmed handshake */
   setup_default_client(&conn);
 
-  ngtcp2_connection_close_error_set_transport_error(&ccerr, NGTCP2_NO_ERROR,
-                                                    NULL, 0);
+  ngtcp2_ccerr_set_transport_error(&ccerr, NGTCP2_NO_ERROR, NULL, 0);
 
   spktlen = ngtcp2_conn_write_connection_close(conn, NULL, NULL, buf,
                                                sizeof(buf), &ccerr, 0);
@@ -7508,8 +7506,7 @@ void test_ngtcp2_conn_write_connection_close(void) {
   ngtcp2_conn_install_tx_handshake_key(conn, &aead_ctx, null_iv,
                                        sizeof(null_iv), &hp_ctx);
 
-  ngtcp2_connection_close_error_set_transport_error(&ccerr, NGTCP2_NO_ERROR,
-                                                    NULL, 0);
+  ngtcp2_ccerr_set_transport_error(&ccerr, NGTCP2_NO_ERROR, NULL, 0);
 
   spktlen = ngtcp2_conn_write_connection_close(conn, NULL, NULL, buf,
                                                sizeof(buf), &ccerr, 0);
@@ -7557,8 +7554,7 @@ void test_ngtcp2_conn_write_connection_close(void) {
 
   conn->state = NGTCP2_CS_POST_HANDSHAKE;
 
-  ngtcp2_connection_close_error_set_transport_error(&ccerr, NGTCP2_NO_ERROR,
-                                                    NULL, 0);
+  ngtcp2_ccerr_set_transport_error(&ccerr, NGTCP2_NO_ERROR, NULL, 0);
 
   spktlen = ngtcp2_conn_write_connection_close(conn, NULL, NULL, buf,
                                                sizeof(buf), &ccerr, 0);
@@ -7595,8 +7591,7 @@ void test_ngtcp2_conn_write_connection_close(void) {
   /* Server has confirmed handshake */
   setup_default_server(&conn);
 
-  ngtcp2_connection_close_error_set_transport_error(&ccerr, NGTCP2_NO_ERROR,
-                                                    NULL, 0);
+  ngtcp2_ccerr_set_transport_error(&ccerr, NGTCP2_NO_ERROR, NULL, 0);
 
   spktlen = ngtcp2_conn_write_connection_close(conn, NULL, NULL, buf,
                                                sizeof(buf), &ccerr, 0);
@@ -7623,7 +7618,7 @@ void test_ngtcp2_conn_write_application_close(void) {
   ngtcp2_crypto_cipher_ctx hp_ctx = {0};
   uint64_t app_err_code = 0;
   ngtcp2_crypto_ctx crypto_ctx;
-  ngtcp2_connection_close_error ccerr;
+  ngtcp2_ccerr ccerr;
 
   /* Client only Initial key */
   setup_handshake_client(&conn);
@@ -7632,8 +7627,8 @@ void test_ngtcp2_conn_write_application_close(void) {
 
   CU_ASSERT(spktlen > 0);
 
-  ngtcp2_connection_close_error_set_application_error(
-      &ccerr, app_err_code, (const uint8_t *)"foo", 3);
+  ngtcp2_ccerr_set_application_error(&ccerr, app_err_code,
+                                     (const uint8_t *)"foo", 3);
 
   spktlen = ngtcp2_conn_write_connection_close(conn, NULL, NULL, buf,
                                                sizeof(buf), &ccerr, 0);
@@ -7662,8 +7657,7 @@ void test_ngtcp2_conn_write_application_close(void) {
   ngtcp2_conn_install_tx_handshake_key(conn, &aead_ctx, null_iv,
                                        sizeof(null_iv), &hp_ctx);
 
-  ngtcp2_connection_close_error_set_application_error(&ccerr, app_err_code,
-                                                      NULL, 0);
+  ngtcp2_ccerr_set_application_error(&ccerr, app_err_code, NULL, 0);
 
   spktlen = ngtcp2_conn_write_connection_close(conn, NULL, NULL, buf,
                                                sizeof(buf), &ccerr, 0);
@@ -7693,8 +7687,7 @@ void test_ngtcp2_conn_write_application_close(void) {
 
   conn->state = NGTCP2_CS_POST_HANDSHAKE;
 
-  ngtcp2_connection_close_error_set_application_error(&ccerr, app_err_code,
-                                                      NULL, 0);
+  ngtcp2_ccerr_set_application_error(&ccerr, app_err_code, NULL, 0);
 
   spktlen = ngtcp2_conn_write_connection_close(conn, NULL, NULL, buf,
                                                sizeof(buf), &ccerr, 0);
@@ -7722,8 +7715,7 @@ void test_ngtcp2_conn_write_application_close(void) {
   /* Client has confirmed handshake */
   setup_default_client(&conn);
 
-  ngtcp2_connection_close_error_set_application_error(&ccerr, app_err_code,
-                                                      NULL, 0);
+  ngtcp2_ccerr_set_application_error(&ccerr, app_err_code, NULL, 0);
 
   spktlen = ngtcp2_conn_write_connection_close(conn, NULL, NULL, buf,
                                                sizeof(buf), &ccerr, 0);
@@ -7757,8 +7749,7 @@ void test_ngtcp2_conn_write_application_close(void) {
   ngtcp2_conn_install_tx_handshake_key(conn, &aead_ctx, null_iv,
                                        sizeof(null_iv), &hp_ctx);
 
-  ngtcp2_connection_close_error_set_application_error(&ccerr, app_err_code,
-                                                      NULL, 0);
+  ngtcp2_ccerr_set_application_error(&ccerr, app_err_code, NULL, 0);
 
   spktlen = ngtcp2_conn_write_connection_close(conn, NULL, NULL, buf,
                                                sizeof(buf), &ccerr, 0);
@@ -7804,8 +7795,7 @@ void test_ngtcp2_conn_write_application_close(void) {
   ngtcp2_conn_install_tx_key(conn, null_secret, sizeof(null_secret), &aead_ctx,
                              null_iv, sizeof(null_iv), &hp_ctx);
 
-  ngtcp2_connection_close_error_set_application_error(&ccerr, app_err_code,
-                                                      NULL, 0);
+  ngtcp2_ccerr_set_application_error(&ccerr, app_err_code, NULL, 0);
 
   spktlen = ngtcp2_conn_write_connection_close(conn, NULL, NULL, buf,
                                                sizeof(buf), &ccerr, 0);
@@ -7842,8 +7832,7 @@ void test_ngtcp2_conn_write_application_close(void) {
   /* Server has confirmed handshake */
   setup_default_server(&conn);
 
-  ngtcp2_connection_close_error_set_application_error(&ccerr, app_err_code,
-                                                      NULL, 0);
+  ngtcp2_ccerr_set_application_error(&ccerr, app_err_code, NULL, 0);
 
   spktlen = ngtcp2_conn_write_connection_close(conn, NULL, NULL, buf,
                                                sizeof(buf), &ccerr, 0);
@@ -9139,7 +9128,7 @@ void test_ngtcp2_conn_handshake_timeout(void) {
   ngtcp2_conn_del(conn);
 }
 
-void test_ngtcp2_conn_get_connection_close_error(void) {
+void test_ngtcp2_conn_get_ccerr(void) {
   ngtcp2_conn *conn;
   uint8_t buf[2048];
   ngtcp2_frame frs[2];
@@ -9148,7 +9137,7 @@ void test_ngtcp2_conn_get_connection_close_error(void) {
   ngtcp2_tstamp t = 0;
   int64_t pkt_num = 0;
   int rv;
-  ngtcp2_connection_close_error ccerr;
+  ngtcp2_ccerr ccerr;
 
   memset(reason, 'a', sizeof(reason));
 
@@ -9164,8 +9153,7 @@ void test_ngtcp2_conn_get_connection_close_error(void) {
   frs[1].type = NGTCP2_FRAME_CONNECTION_CLOSE;
   frs[1].connection_close.error_code = NGTCP2_PROTOCOL_VIOLATION;
   frs[1].connection_close.frame_type = 1000000007;
-  frs[1].connection_close.reasonlen =
-      NGTCP2_CONNECTION_CLOSE_ERROR_MAX_REASONLEN + 1;
+  frs[1].connection_close.reasonlen = NGTCP2_CCERR_MAX_REASONLEN + 1;
   frs[1].connection_close.reason = reason;
 
   pktlen = write_pkt(buf, sizeof(buf), &conn->oscid, ++pkt_num, frs,
@@ -9175,13 +9163,13 @@ void test_ngtcp2_conn_get_connection_close_error(void) {
 
   CU_ASSERT(NGTCP2_ERR_DRAINING == rv);
 
-  ngtcp2_conn_get_connection_close_error(conn, &ccerr);
+  ngtcp2_conn_get_ccerr(conn, &ccerr);
 
   CU_ASSERT(NGTCP2_PROTOCOL_VIOLATION == ccerr.error_code);
-  CU_ASSERT(NGTCP2_CONNECTION_CLOSE_ERROR_CODE_TYPE_TRANSPORT == ccerr.type);
+  CU_ASSERT(NGTCP2_CCERR_TYPE_TRANSPORT == ccerr.type);
   CU_ASSERT(1000000007 == ccerr.frame_type);
   CU_ASSERT(0 == memcmp(reason, ccerr.reason, ccerr.reasonlen));
-  CU_ASSERT(NGTCP2_CONNECTION_CLOSE_ERROR_MAX_REASONLEN == ccerr.reasonlen);
+  CU_ASSERT(NGTCP2_CCERR_MAX_REASONLEN == ccerr.reasonlen);
 
   ngtcp2_conn_del(conn);
 }

--- a/tests/ngtcp2_conn_test.h
+++ b/tests/ngtcp2_conn_test.h
@@ -91,7 +91,7 @@ void test_ngtcp2_conn_get_scid(void);
 void test_ngtcp2_conn_stream_close(void);
 void test_ngtcp2_conn_buffer_pkt(void);
 void test_ngtcp2_conn_handshake_timeout(void);
-void test_ngtcp2_conn_get_connection_close_error(void);
+void test_ngtcp2_conn_get_ccerr(void);
 void test_ngtcp2_conn_version_negotiation(void);
 void test_ngtcp2_conn_server_negotiate_version(void);
 void test_ngtcp2_conn_pmtud_loss(void);


### PR DESCRIPTION
- ngtcp2_connection_close_error_code_type -> ngtcp2_ccerr_code_type
- NGTCP2_CONNECTION_CLOSE_ERROR_CODE_* -> NGTCP2_CCERR_CODE_TYPE_*
- ngtcp2_connection_close_error -> ngtcp2_ccerr
- ngtcp2_connection_close_error_default -> ngtcp2_ccerr_default
- ngtcp2_connection_close_error_set_transport_error -> ngtcp2_ccerr_set_transport_error
- ngtcp2_connection_close_error_set_transport_error_liberr -> ngtcp2_ccerr_set_liberr
- ngtcp2_connection_close_error_set_transport_error_tls_alert -> ngtcp2_ccerr_set_tls_alert
- ngtcp2_connection_close_error_set_application_error -> ngtcp2_ccerr_set_application_error
- ngtcp2_conn_get_connection_close_error -> ngtcp2_conn_get_ccerr