### PR TITLE
Remove ngtcp2_conn_get_max_local_streams_uni

### DIFF
--- a/examples/client.cc
+++ b/examples/client.cc
@@ -1989,7 +1989,7 @@ int Client::setup_httpconn() {
     return 0;
   }
 
-  if (ngtcp2_conn_get_max_local_streams_uni(conn_) < 3) {
+  if (ngtcp2_conn_get_streams_uni_left(conn_) < 3) {
     std::cerr << "peer does not allow at least 3 unidirectional streams."
               << std::endl;
     return -1;

--- a/examples/server.cc
+++ b/examples/server.cc
@@ -1235,7 +1235,7 @@ int Handler::setup_httpconn() {
     return 0;
   }
 
-  if (ngtcp2_conn_get_max_local_streams_uni(conn_) < 3) {
+  if (ngtcp2_conn_get_streams_uni_left(conn_) < 3) {
     std::cerr << "peer does not allow at least 3 unidirectional streams."
               << std::endl;
     return -1;

--- a/lib/includes/ngtcp2/ngtcp2.h
+++ b/lib/includes/ngtcp2/ngtcp2.h
@@ -5039,14 +5039,6 @@ NGTCP2_EXTERN int ngtcp2_conn_initiate_migration(ngtcp2_conn *conn,
 /**
  * @function
  *
- * `ngtcp2_conn_get_max_local_streams_uni` returns the cumulative
- * number of streams which local endpoint can open.
- */
-NGTCP2_EXTERN uint64_t ngtcp2_conn_get_max_local_streams_uni(ngtcp2_conn *conn);
-
-/**
- * @function
- *
  * `ngtcp2_conn_get_max_data_left` returns the number of bytes that
  * this local endpoint can send in this connection.
  */

--- a/lib/ngtcp2_conn.c
+++ b/lib/ngtcp2_conn.c
@@ -13375,10 +13375,6 @@ int ngtcp2_conn_initiate_migration(ngtcp2_conn *conn, const ngtcp2_path *path,
   return conn_call_activate_dcid(conn, &pv->dcid);
 }
 
-uint64_t ngtcp2_conn_get_max_local_streams_uni(ngtcp2_conn *conn) {
-  return conn->local.uni.max_streams;
-}
-
 uint64_t ngtcp2_conn_get_max_data_left(ngtcp2_conn *conn) {
   return conn->tx.max_offset - conn->tx.offset;
 }


### PR DESCRIPTION
Remove ngtcp2_conn_get_max_local_streams_uni.  The only use case for this function is fulfilled by ngtcp2_conn_get_streams_uni_left. ngtcp2_conn_get_max_local_streams_uni is actually hard to use because caller needs to remember the number of the opened streams.