### PR TITLE
Add tests for ngtcp2_conn_create_ack_frame

### DIFF
--- a/lib/ngtcp2_conn.h
+++ b/lib/ngtcp2_conn.h
@@ -1162,4 +1162,26 @@ int ngtcp2_conn_set_remote_transport_params(
 int ngtcp2_conn_set_early_remote_transport_params(
     ngtcp2_conn *conn, const ngtcp2_transport_params *params);
 
+/*
+ * ngtcp2_conn_create_ack_frame creates ACK frame, and assigns its
+ * pointer to |*pfr| if there are any received packets to acknowledge.
+ * If there are no packets to acknowledge, this function returns 0,
+ * and |*pfr| is untouched.  The caller is advised to set |*pfr| to
+ * NULL before calling this function, and check it after this function
+ * returns.
+ *
+ * Call ngtcp2_acktr_commit_ack after a created ACK frame is
+ * successfully serialized into a packet.
+ *
+ * This function returns 0 if it succeeds, or one of the following
+ * negative error codes:
+ *
+ * NGTCP2_ERR_NOMEM
+ *     Out of memory.
+ */
+int ngtcp2_conn_create_ack_frame(ngtcp2_conn *conn, ngtcp2_frame **pfr,
+                                 ngtcp2_pktns *pktns, uint8_t type,
+                                 ngtcp2_tstamp ts, ngtcp2_duration ack_delay,
+                                 uint64_t ack_delay_exponent);
+
 #endif /* NGTCP2_CONN_H */

--- a/tests/main.c
+++ b/tests/main.c
@@ -313,6 +313,8 @@ int main(void) {
                    test_ngtcp2_conn_amplification) ||
       !CU_add_test(pSuite, "conn_encode_early_transport_params",
                    test_ngtcp2_conn_encode_early_transport_params) ||
+      !CU_add_test(pSuite, "conn_create_ack_frame",
+                   test_ngtcp2_conn_create_ack_frame) ||
       !CU_add_test(pSuite, "conn_new_failmalloc",
                    test_ngtcp2_conn_new_failmalloc) ||
       !CU_add_test(pSuite, "accept", test_ngtcp2_accept) ||
@@ -327,6 +329,8 @@ int main(void) {
       !CU_add_test(pSuite, "gaptr_is_pushed", test_ngtcp2_gaptr_is_pushed) ||
       !CU_add_test(pSuite, "gaptr_drop_first_gap",
                    test_ngtcp2_gaptr_drop_first_gap) ||
+      !CU_add_test(pSuite, "gaptr_get_first_gep_after",
+                   test_ngtcp2_gaptr_get_first_gap_after) ||
       !CU_add_test(pSuite, "vec_split", test_ngtcp2_vec_split) ||
       !CU_add_test(pSuite, "vec_merge", test_ngtcp2_vec_merge) ||
       !CU_add_test(pSuite, "vec_len_varint", test_ngtcp2_vec_len_varint) ||

--- a/tests/ngtcp2_conn_test.h
+++ b/tests/ngtcp2_conn_test.h
@@ -97,6 +97,7 @@ void test_ngtcp2_conn_server_negotiate_version(void);
 void test_ngtcp2_conn_pmtud_loss(void);
 void test_ngtcp2_conn_amplification(void);
 void test_ngtcp2_conn_encode_early_transport_params(void);
+void test_ngtcp2_conn_create_ack_frame(void);
 void test_ngtcp2_conn_new_failmalloc(void);
 void test_ngtcp2_accept(void);
 void test_ngtcp2_select_version(void);

--- a/tests/ngtcp2_gaptr_test.c
+++ b/tests/ngtcp2_gaptr_test.c
@@ -127,3 +127,55 @@ void test_ngtcp2_gaptr_drop_first_gap(void) {
 
   ngtcp2_gaptr_free(&gaptr);
 }
+
+void test_ngtcp2_gaptr_get_first_gap_after(void) {
+  ngtcp2_gaptr gaptr;
+  const ngtcp2_mem *mem = ngtcp2_mem_default();
+  int rv;
+  ngtcp2_range r;
+
+  ngtcp2_gaptr_init(&gaptr, mem);
+
+  rv = ngtcp2_gaptr_push(&gaptr, 100, 1);
+
+  CU_ASSERT(0 == rv);
+
+  rv = ngtcp2_gaptr_push(&gaptr, 101, 1);
+
+  CU_ASSERT(0 == rv);
+
+  rv = ngtcp2_gaptr_push(&gaptr, 102, 1);
+
+  CU_ASSERT(0 == rv);
+
+  rv = ngtcp2_gaptr_push(&gaptr, 104, 1);
+
+  CU_ASSERT(0 == rv);
+
+  r = ngtcp2_gaptr_get_first_gap_after(&gaptr, 99);
+
+  CU_ASSERT(0 == r.begin);
+  CU_ASSERT(100 == r.end);
+
+  r = ngtcp2_gaptr_get_first_gap_after(&gaptr, 100);
+
+  CU_ASSERT(103 == r.begin);
+  CU_ASSERT(104 == r.end);
+
+  r = ngtcp2_gaptr_get_first_gap_after(&gaptr, 102);
+
+  CU_ASSERT(103 == r.begin);
+  CU_ASSERT(104 == r.end);
+
+  r = ngtcp2_gaptr_get_first_gap_after(&gaptr, 103);
+
+  CU_ASSERT(103 == r.begin);
+  CU_ASSERT(104 == r.end);
+
+  r = ngtcp2_gaptr_get_first_gap_after(&gaptr, UINT64_MAX - 1);
+
+  CU_ASSERT(105 == r.begin);
+  CU_ASSERT(UINT64_MAX == r.end);
+
+  ngtcp2_gaptr_free(&gaptr);
+}

--- a/tests/ngtcp2_gaptr_test.h
+++ b/tests/ngtcp2_gaptr_test.h
@@ -32,5 +32,6 @@
 void test_ngtcp2_gaptr_push(void);
 void test_ngtcp2_gaptr_is_pushed(void);
 void test_ngtcp2_gaptr_drop_first_gap(void);
+void test_ngtcp2_gaptr_get_first_gap_after(void);
 
 #endif /* NGTCP2_GAPTR_TEST_H */


### PR DESCRIPTION
This change adds tests for ngtcp2_conn_create_ack_frame.  With these tests, we identified and fixed the following bugs:

- The invalid ACK frame is generated if the largest packet number in ngtcp2_acktr is the largest acked packet number minus 1.

- The conditions of immediate acknowledgement are updated to follow the RFC.  See https://datatracker.ietf.org/doc/html/rfc9000#section-13.2.1

Fixes #773 