### PR TITLE
Remove odcid from ngtcp2_qlog_settings

### DIFF
--- a/examples/h09server.cc
+++ b/examples/h09server.cc
@@ -730,7 +730,6 @@ int Handler::init(const Endpoint &ep, const Address &local_addr,
       return -1;
     }
     settings.qlog.write = ::write_qlog;
-    settings.qlog.odcid = *scid;
   }
   if (!config.preferred_versions.empty()) {
     settings.preferred_versions = config.preferred_versions.data();

--- a/examples/server.cc
+++ b/examples/server.cc
@@ -1462,7 +1462,6 @@ int Handler::init(const Endpoint &ep, const Address &local_addr,
       return -1;
     }
     settings.qlog.write = ::write_qlog;
-    settings.qlog.odcid = *scid;
   }
   if (!config.preferred_versions.empty()) {
     settings.preferred_versions = config.preferred_versions.data();

--- a/lib/includes/ngtcp2/ngtcp2.h
+++ b/lib/includes/ngtcp2/ngtcp2.h
@@ -1742,12 +1742,6 @@ typedef void (*ngtcp2_qlog_write)(void *user_data, uint32_t flags,
  */
 typedef struct ngtcp2_qlog_settings {
   /**
-   * :member:`odcid` is Original Destination Connection ID sent by
-   * client.  It is used as group_id.  Client ignores this field and
-   * uses dcid parameter passed to `ngtcp2_conn_client_new()`.
-   */
-  ngtcp2_cid odcid;
-  /**
    * :member:`write` is a callback function to write qlog.  Setting
    * ``NULL`` disables qlog.
    */

--- a/lib/ngtcp2_conn.c
+++ b/lib/ngtcp2_conn.c
@@ -1351,8 +1351,13 @@ static int conn_new(ngtcp2_conn **pconn, const ngtcp2_cid *dcid,
 
   conn_reset_ecn_validation_state(*pconn);
 
-  ngtcp2_qlog_start(&(*pconn)->qlog, server ? &settings->qlog.odcid : dcid,
-                    server);
+  ngtcp2_qlog_start(
+      &(*pconn)->qlog,
+      server ? ((*pconn)->local.transport_params.retry_scid_present
+                    ? &(*pconn)->local.transport_params.retry_scid
+                    : &(*pconn)->local.transport_params.original_dcid)
+             : dcid,
+      server);
 
   return 0;
 


### PR DESCRIPTION
Remove odcid from ngtcp2_qlog_settings.  group_id is deduced from local ngtcp2_transport_params if a local endpoint is server.