### PR TITLE
Rename ngtcp2_crypto_level to ngtcp2_encryption_level

### DIFF
--- a/crypto/boringssl/boringssl.c
+++ b/crypto/boringssl/boringssl.c
@@ -394,15 +394,17 @@ int ngtcp2_crypto_hp_mask(uint8_t *dest, const ngtcp2_crypto_cipher *hp,
   }
 }
 
-int ngtcp2_crypto_read_write_crypto_data(ngtcp2_conn *conn,
-                                         ngtcp2_crypto_level crypto_level,
-                                         const uint8_t *data, size_t datalen) {
+int ngtcp2_crypto_read_write_crypto_data(
+    ngtcp2_conn *conn, ngtcp2_encryption_level encryption_level,
+    const uint8_t *data, size_t datalen) {
   SSL *ssl = ngtcp2_conn_get_tls_native_handle(conn);
   int rv;
   int err;
 
   if (SSL_provide_quic_data(
-          ssl, ngtcp2_crypto_boringssl_from_ngtcp2_crypto_level(crypto_level),
+          ssl,
+          ngtcp2_crypto_boringssl_from_ngtcp2_encryption_level(
+              encryption_level),
           data, datalen) != 1) {
     return -1;
   }
@@ -485,33 +487,34 @@ int ngtcp2_crypto_set_local_transport_params(void *tls, const uint8_t *buf,
   return 0;
 }
 
-ngtcp2_crypto_level ngtcp2_crypto_boringssl_from_ssl_encryption_level(
+ngtcp2_encryption_level ngtcp2_crypto_boringssl_from_ssl_encryption_level(
     enum ssl_encryption_level_t ssl_level) {
   switch (ssl_level) {
   case ssl_encryption_initial:
-    return NGTCP2_CRYPTO_LEVEL_INITIAL;
+    return NGTCP2_ENCRYPTION_LEVEL_INITIAL;
   case ssl_encryption_early_data:
-    return NGTCP2_CRYPTO_LEVEL_EARLY;
+    return NGTCP2_ENCRYPTION_LEVEL_0RTT;
   case ssl_encryption_handshake:
-    return NGTCP2_CRYPTO_LEVEL_HANDSHAKE;
+    return NGTCP2_ENCRYPTION_LEVEL_HANDSHAKE;
   case ssl_encryption_application:
-    return NGTCP2_CRYPTO_LEVEL_APPLICATION;
+    return NGTCP2_ENCRYPTION_LEVEL_1RTT;
   default:
     assert(0);
     abort();
   }
 }
 
-enum ssl_encryption_level_t ngtcp2_crypto_boringssl_from_ngtcp2_crypto_level(
-    ngtcp2_crypto_level crypto_level) {
-  switch (crypto_level) {
-  case NGTCP2_CRYPTO_LEVEL_INITIAL:
+enum ssl_encryption_level_t
+ngtcp2_crypto_boringssl_from_ngtcp2_encryption_level(
+    ngtcp2_encryption_level encryption_level) {
+  switch (encryption_level) {
+  case NGTCP2_ENCRYPTION_LEVEL_INITIAL:
     return ssl_encryption_initial;
-  case NGTCP2_CRYPTO_LEVEL_HANDSHAKE:
+  case NGTCP2_ENCRYPTION_LEVEL_HANDSHAKE:
     return ssl_encryption_handshake;
-  case NGTCP2_CRYPTO_LEVEL_APPLICATION:
+  case NGTCP2_ENCRYPTION_LEVEL_1RTT:
     return ssl_encryption_application;
-  case NGTCP2_CRYPTO_LEVEL_EARLY:
+  case NGTCP2_ENCRYPTION_LEVEL_0RTT:
     return ssl_encryption_early_data;
   default:
     assert(0);
@@ -544,7 +547,7 @@ static int set_read_secret(SSL *ssl, enum ssl_encryption_level_t bssl_level,
                            size_t secretlen) {
   ngtcp2_crypto_conn_ref *conn_ref = SSL_get_app_data(ssl);
   ngtcp2_conn *conn = conn_ref->get_conn(conn_ref);
-  ngtcp2_crypto_level level =
+  ngtcp2_encryption_level level =
       ngtcp2_crypto_boringssl_from_ssl_encryption_level(bssl_level);
   (void)cipher;
 
@@ -561,7 +564,7 @@ static int set_write_secret(SSL *ssl, enum ssl_encryption_level_t bssl_level,
                             size_t secretlen) {
   ngtcp2_crypto_conn_ref *conn_ref = SSL_get_app_data(ssl);
   ngtcp2_conn *conn = conn_ref->get_conn(conn_ref);
-  ngtcp2_crypto_level level =
+  ngtcp2_encryption_level level =
       ngtcp2_crypto_boringssl_from_ssl_encryption_level(bssl_level);
   (void)cipher;
 
@@ -577,7 +580,7 @@ static int add_handshake_data(SSL *ssl, enum ssl_encryption_level_t bssl_level,
                               const uint8_t *data, size_t datalen) {
   ngtcp2_crypto_conn_ref *conn_ref = SSL_get_app_data(ssl);
   ngtcp2_conn *conn = conn_ref->get_conn(conn_ref);
-  ngtcp2_crypto_level level =
+  ngtcp2_encryption_level level =
       ngtcp2_crypto_boringssl_from_ssl_encryption_level(bssl_level);
   int rv;
 

--- a/crypto/includes/ngtcp2/ngtcp2_crypto.h
+++ b/crypto/includes/ngtcp2/ngtcp2_crypto.h
@@ -351,21 +351,22 @@ ngtcp2_crypto_hp_mask_cb(uint8_t *dest, const ngtcp2_crypto_cipher *hp,
  * `ngtcp2_crypto_packet_protection_ivlen(ctx->aead)
  * <ngtcp2_crypto_packet_protection_ivlen>` where ctx is obtained by
  * `ngtcp2_crypto_ctx_tls` (or `ngtcp2_crypto_ctx_tls_early` if
- * |level| == :enum:`ngtcp2_crypto_level.NGTCP2_CRYPTO_LEVEL_EARLY`).
+ * |level| ==
+ * :enum:`ngtcp2_encryption_level.NGTCP2_ENCRYPTION_LEVEL_0RTT`).
  *
  * In the first call of this function, it calls
  * `ngtcp2_conn_set_crypto_ctx` (or `ngtcp2_conn_set_early_crypto_ctx`
  * if |level| ==
- * :enum:`ngtcp2_crypto_level.NGTCP2_CRYPTO_LEVEL_EARLY`) to set
- * negotiated AEAD and message digest algorithm.  After the successful
- * call of this function, application can use
+ * :enum:`ngtcp2_encryption_level.NGTCP2_ENCRYPTION_LEVEL_0RTT`) to
+ * set negotiated AEAD and message digest algorithm.  After the
+ * successful call of this function, application can use
  * `ngtcp2_conn_get_crypto_ctx` (or `ngtcp2_conn_get_early_crypto_ctx`
  * if |level| ==
- * :enum:`ngtcp2_crypto_level.NGTCP2_CRYPTO_LEVEL_EARLY`) to get
- * :type:`ngtcp2_crypto_ctx`.
+ * :enum:`ngtcp2_encryption_level.NGTCP2_ENCRYPTION_LEVEL_0RTT`) to
+ * get :type:`ngtcp2_crypto_ctx`.
  *
  * If |conn| is initialized as client, and |level| is
- * :enum:`ngtcp2_crypto_level.NGTCP2_CRYPTO_LEVEL_APPLICATION`, this
+ * :enum:`ngtcp2_encryption_level.NGTCP2_ENCRYPTION_LEVEL_1RTT`, this
  * function retrieves a remote QUIC transport parameters extension
  * from an object obtained by `ngtcp2_conn_get_tls_native_handle` and
  * sets it to |conn| by calling
@@ -375,7 +376,7 @@ ngtcp2_crypto_hp_mask_cb(uint8_t *dest, const ngtcp2_crypto_cipher *hp,
  */
 NGTCP2_EXTERN int ngtcp2_crypto_derive_and_install_rx_key(
     ngtcp2_conn *conn, uint8_t *key, uint8_t *iv, uint8_t *hp,
-    ngtcp2_crypto_level level, const uint8_t *secret, size_t secretlen);
+    ngtcp2_encryption_level level, const uint8_t *secret, size_t secretlen);
 
 /**
  * @function
@@ -398,21 +399,22 @@ NGTCP2_EXTERN int ngtcp2_crypto_derive_and_install_rx_key(
  * `ngtcp2_crypto_packet_protection_ivlen(ctx->aead)
  * <ngtcp2_crypto_packet_protection_ivlen>` where ctx is obtained by
  * `ngtcp2_crypto_ctx_tls` (or `ngtcp2_crypto_ctx_tls_early` if
- * |level| == :enum:`ngtcp2_crypto_level.NGTCP2_CRYPTO_LEVEL_EARLY`).
+ * |level| ==
+ * :enum:`ngtcp2_encryption_level.NGTCP2_ENCRYPTION_LEVEL_0RTT`).
  *
  * In the first call of this function, it calls
  * `ngtcp2_conn_set_crypto_ctx` (or `ngtcp2_conn_set_early_crypto_ctx`
  * if |level| ==
- * :enum:`ngtcp2_crypto_level.NGTCP2_CRYPTO_LEVEL_EARLY`) to set
- * negotiated AEAD and message digest algorithm.  After the successful
- * call of this function, application can use
+ * :enum:`ngtcp2_encryption_level.NGTCP2_ENCRYPTION_LEVEL_0RTT`) to
+ * set negotiated AEAD and message digest algorithm.  After the
+ * successful call of this function, application can use
  * `ngtcp2_conn_get_crypto_ctx` (or `ngtcp2_conn_get_early_crypto_ctx`
  * if |level| ==
- * :enum:`ngtcp2_crypto_level.NGTCP2_CRYPTO_LEVEL_EARLY`) to get
- * :type:`ngtcp2_crypto_ctx`.
+ * :enum:`ngtcp2_encryption_level.NGTCP2_ENCRYPTION_LEVEL_0RTT`) to
+ * get :type:`ngtcp2_crypto_ctx`.
  *
  * If |conn| is initialized as server, and |level| is
- * :enum:`ngtcp2_crypto_level.NGTCP2_CRYPTO_LEVEL_APPLICATION`, this
+ * :enum:`ngtcp2_encryption_level.NGTCP2_ENCRYPTION_LEVEL_1RTT`, this
  * function retrieves a remote QUIC transport parameters extension
  * from an object obtained by `ngtcp2_conn_get_tls_native_handle` and
  * sets it to |conn| by calling
@@ -422,7 +424,7 @@ NGTCP2_EXTERN int ngtcp2_crypto_derive_and_install_rx_key(
  */
 NGTCP2_EXTERN int ngtcp2_crypto_derive_and_install_tx_key(
     ngtcp2_conn *conn, uint8_t *key, uint8_t *iv, uint8_t *hp,
-    ngtcp2_crypto_level level, const uint8_t *secret, size_t secretlen);
+    ngtcp2_encryption_level level, const uint8_t *secret, size_t secretlen);
 
 /**
  * @function
@@ -539,11 +541,11 @@ NGTCP2_EXTERN int ngtcp2_crypto_recv_client_initial_cb(ngtcp2_conn *conn,
  * @function
  *
  * `ngtcp2_crypto_read_write_crypto_data` reads CRYPTO data |data| of
- * length |datalen| in encryption level |crypto_level| and may feed
- * outgoing CRYPTO data to |conn|.  This function can drive handshake.
- * This function can be also used after handshake completes.  It is
- * allowed to call this function with |datalen| == 0.  In this case,
- * no additional read operation is done.
+ * length |datalen| in encryption level |encryption_level| and may
+ * feed outgoing CRYPTO data to |conn|.  This function can drive
+ * handshake.  This function can be also used after handshake
+ * completes.  It is allowed to call this function with |datalen| ==
+ * 0.  In this case, no additional read operation is done.
  *
  * This function returns 0 if it succeeds, or a negative error code.
  * The generic error code is -1 if a specific error code is not
@@ -553,7 +555,7 @@ NGTCP2_EXTERN int ngtcp2_crypto_recv_client_initial_cb(ngtcp2_conn *conn,
  */
 NGTCP2_EXTERN int
 ngtcp2_crypto_read_write_crypto_data(ngtcp2_conn *conn,
-                                     ngtcp2_crypto_level crypto_level,
+                                     ngtcp2_encryption_level encryption_level,
                                      const uint8_t *data, size_t datalen);
 
 /**
@@ -570,8 +572,8 @@ ngtcp2_crypto_read_write_crypto_data(ngtcp2_conn *conn,
  * codes.
  */
 NGTCP2_EXTERN int ngtcp2_crypto_recv_crypto_data_cb(
-    ngtcp2_conn *conn, ngtcp2_crypto_level crypto_level, uint64_t offset,
-    const uint8_t *data, size_t datalen, void *user_data);
+    ngtcp2_conn *conn, ngtcp2_encryption_level encryption_level,
+    uint64_t offset, const uint8_t *data, size_t datalen, void *user_data);
 
 /**
  * @function

--- a/crypto/includes/ngtcp2/ngtcp2_crypto_boringssl.h
+++ b/crypto/includes/ngtcp2/ngtcp2_crypto_boringssl.h
@@ -37,23 +37,23 @@ extern "C" {
  * @function
  *
  * `ngtcp2_crypto_boringssl_from_ssl_encryption_level` translates
- * |ssl_level| to :type:`ngtcp2_crypto_level`.  This function is only
- * available for BoringSSL backend.
+ * |ssl_level| to :type:`ngtcp2_encryption_level`.  This function is
+ * only available for BoringSSL backend.
  */
-NGTCP2_EXTERN ngtcp2_crypto_level
+NGTCP2_EXTERN ngtcp2_encryption_level
 ngtcp2_crypto_boringssl_from_ssl_encryption_level(
     enum ssl_encryption_level_t ssl_level);
 
 /**
  * @function
  *
- * `ngtcp2_crypto_boringssl_from_ngtcp2_crypto_level` translates
- * |crypto_level| to ssl_encryption_level_t.  This function is only
- * available for BoringSSL backend.
+ * `ngtcp2_crypto_boringssl_from_ngtcp2_encryption_level` translates
+ * |encryption_level| to ssl_encryption_level_t.  This function is
+ * only available for BoringSSL backend.
  */
 NGTCP2_EXTERN enum ssl_encryption_level_t
-ngtcp2_crypto_boringssl_from_ngtcp2_crypto_level(
-    ngtcp2_crypto_level crypto_level);
+ngtcp2_crypto_boringssl_from_ngtcp2_encryption_level(
+    ngtcp2_encryption_level encryption_level);
 
 /**
  * @function

--- a/crypto/includes/ngtcp2/ngtcp2_crypto_gnutls.h
+++ b/crypto/includes/ngtcp2/ngtcp2_crypto_gnutls.h
@@ -37,22 +37,23 @@ extern "C" {
  * @function
  *
  * `ngtcp2_crypto_gnutls_from_gnutls_record_encryption_level`
- * translates |gtls_level| to :type:`ngtcp2_crypto_level`.  This
+ * translates |gtls_level| to :type:`ngtcp2_encryption_level`.  This
  * function is only available for GnuTLS backend.
  */
-NGTCP2_EXTERN ngtcp2_crypto_level
+NGTCP2_EXTERN ngtcp2_encryption_level
 ngtcp2_crypto_gnutls_from_gnutls_record_encryption_level(
     gnutls_record_encryption_level_t gtls_level);
 
 /**
  * @function
  *
- * `ngtcp2_crypto_gnutls_from_ngtcp2_crypto_level` translates
- * |crypto_level| to gnutls_record_encryption_level_t.  This function
- * is only available for GnuTLS backend.
+ * `ngtcp2_crypto_gnutls_from_ngtcp2_encryption_level` translates
+ * |encryption_level| to gnutls_record_encryption_level_t.  This
+ * function is only available for GnuTLS backend.
  */
 NGTCP2_EXTERN gnutls_record_encryption_level_t
-ngtcp2_crypto_gnutls_from_ngtcp2_level(ngtcp2_crypto_level crypto_level);
+ngtcp2_crypto_gnutls_from_ngtcp2_encryption_level(
+    ngtcp2_encryption_level encryption_level);
 
 /**
  * @function

--- a/crypto/includes/ngtcp2/ngtcp2_crypto_openssl.h
+++ b/crypto/includes/ngtcp2/ngtcp2_crypto_openssl.h
@@ -65,23 +65,23 @@ extern "C" {
  * @function
  *
  * `ngtcp2_crypto_openssl_from_ossl_encryption_level` translates
- * |ossl_level| to :type:`ngtcp2_crypto_level`.  This function is only
- * available for OpenSSL backend.
+ * |ossl_level| to :type:`ngtcp2_encryption_level`.  This function is
+ * only available for OpenSSL backend.
  */
-NGTCP2_EXTERN ngtcp2_crypto_level
+NGTCP2_EXTERN ngtcp2_encryption_level
 ngtcp2_crypto_openssl_from_ossl_encryption_level(
     OSSL_ENCRYPTION_LEVEL ossl_level);
 
 /**
  * @function
  *
- * `ngtcp2_crypto_openssl_from_ngtcp2_crypto_level` translates
- * |crypto_level| to OSSL_ENCRYPTION_LEVEL.  This function is only
+ * `ngtcp2_crypto_openssl_from_ngtcp2_encryption_level` translates
+ * |encryption_level| to OSSL_ENCRYPTION_LEVEL.  This function is only
  * available for OpenSSL backend.
  */
 NGTCP2_EXTERN OSSL_ENCRYPTION_LEVEL
-ngtcp2_crypto_openssl_from_ngtcp2_crypto_level(
-    ngtcp2_crypto_level crypto_level);
+ngtcp2_crypto_openssl_from_ngtcp2_encryption_level(
+    ngtcp2_encryption_level encryption_level);
 
 /**
  * @function

--- a/crypto/includes/ngtcp2/ngtcp2_crypto_picotls.h
+++ b/crypto/includes/ngtcp2/ngtcp2_crypto_picotls.h
@@ -65,21 +65,21 @@ ngtcp2_crypto_picotls_ctx_init(ngtcp2_crypto_picotls_ctx *cptls);
  * @function
  *
  * `ngtcp2_crypto_picotls_from_epoch` translates |epoch| to
- * :type:`ngtcp2_crypto_level`.  This function is only available for
- * Picotls backend.
+ * :type:`ngtcp2_encryption_level`.  This function is only available
+ * for Picotls backend.
  */
-NGTCP2_EXTERN ngtcp2_crypto_level
+NGTCP2_EXTERN ngtcp2_encryption_level
 ngtcp2_crypto_picotls_from_epoch(size_t epoch);
 
 /**
  * @function
  *
- * `ngtcp2_crypto_picotls_from_ngtcp2_crypto_level` translates
- * |crypto_level| to epoch.  This function is only available for
+ * `ngtcp2_crypto_picotls_from_ngtcp2_encryption_level` translates
+ * |encryption_level| to epoch.  This function is only available for
  * Picotls backend.
  */
-NGTCP2_EXTERN size_t ngtcp2_crypto_picotls_from_ngtcp2_crypto_level(
-    ngtcp2_crypto_level crypto_level);
+NGTCP2_EXTERN size_t ngtcp2_crypto_picotls_from_ngtcp2_encryption_level(
+    ngtcp2_encryption_level encryption_level);
 
 /**
  * @function

--- a/crypto/includes/ngtcp2/ngtcp2_crypto_wolfssl.h
+++ b/crypto/includes/ngtcp2/ngtcp2_crypto_wolfssl.h
@@ -39,23 +39,23 @@ extern "C" {
  * @function
  *
  * `ngtcp2_crypto_wolfssl_from_wolfssl_encryption_level` translates
- * |wolfssl_level| to :type:`ngtcp2_crypto_level`.  This function is only
- * available for wolfSSL backend.
+ * |wolfssl_level| to :type:`ngtcp2_encryption_level`.  This function
+ * is only available for wolfSSL backend.
  */
-NGTCP2_EXTERN ngtcp2_crypto_level
+NGTCP2_EXTERN ngtcp2_encryption_level
 ngtcp2_crypto_wolfssl_from_wolfssl_encryption_level(
     WOLFSSL_ENCRYPTION_LEVEL wolfssl_level);
 
 /**
  * @function
  *
- * `ngtcp2_crypto_wolfssl_from_ngtcp2_crypto_level` translates
- * |crypto_level| to WOLFSSL_ENCRYPTION_LEVEL.  This function is only
- * available for wolfSSL backend.
+ * `ngtcp2_crypto_wolfssl_from_ngtcp2_encryption_level` translates
+ * |encryption_level| to WOLFSSL_ENCRYPTION_LEVEL.  This function is
+ * only available for wolfSSL backend.
  */
 NGTCP2_EXTERN WOLFSSL_ENCRYPTION_LEVEL
-ngtcp2_crypto_wolfssl_from_ngtcp2_crypto_level(
-    ngtcp2_crypto_level crypto_level);
+ngtcp2_crypto_wolfssl_from_ngtcp2_encryption_level(
+    ngtcp2_encryption_level encryption_level);
 
 /**
  * @function

--- a/crypto/openssl/openssl.c
+++ b/crypto/openssl/openssl.c
@@ -591,15 +591,16 @@ int ngtcp2_crypto_hp_mask(uint8_t *dest, const ngtcp2_crypto_cipher *hp,
   return 0;
 }
 
-int ngtcp2_crypto_read_write_crypto_data(ngtcp2_conn *conn,
-                                         ngtcp2_crypto_level crypto_level,
-                                         const uint8_t *data, size_t datalen) {
+int ngtcp2_crypto_read_write_crypto_data(
+    ngtcp2_conn *conn, ngtcp2_encryption_level encryption_level,
+    const uint8_t *data, size_t datalen) {
   SSL *ssl = ngtcp2_conn_get_tls_native_handle(conn);
   int rv;
   int err;
 
   if (SSL_provide_quic_data(
-          ssl, ngtcp2_crypto_openssl_from_ngtcp2_crypto_level(crypto_level),
+          ssl,
+          ngtcp2_crypto_openssl_from_ngtcp2_encryption_level(encryption_level),
           data, datalen) != 1) {
     return -1;
   }
@@ -670,17 +671,17 @@ int ngtcp2_crypto_set_local_transport_params(void *tls, const uint8_t *buf,
   return 0;
 }
 
-ngtcp2_crypto_level ngtcp2_crypto_openssl_from_ossl_encryption_level(
+ngtcp2_encryption_level ngtcp2_crypto_openssl_from_ossl_encryption_level(
     OSSL_ENCRYPTION_LEVEL ossl_level) {
   switch (ossl_level) {
   case ssl_encryption_initial:
-    return NGTCP2_CRYPTO_LEVEL_INITIAL;
+    return NGTCP2_ENCRYPTION_LEVEL_INITIAL;
   case ssl_encryption_early_data:
-    return NGTCP2_CRYPTO_LEVEL_EARLY;
+    return NGTCP2_ENCRYPTION_LEVEL_0RTT;
   case ssl_encryption_handshake:
-    return NGTCP2_CRYPTO_LEVEL_HANDSHAKE;
+    return NGTCP2_ENCRYPTION_LEVEL_HANDSHAKE;
   case ssl_encryption_application:
-    return NGTCP2_CRYPTO_LEVEL_APPLICATION;
+    return NGTCP2_ENCRYPTION_LEVEL_1RTT;
   default:
     assert(0);
     abort(); /* if NDEBUG is set */
@@ -688,16 +689,16 @@ ngtcp2_crypto_level ngtcp2_crypto_openssl_from_ossl_encryption_level(
 }
 
 OSSL_ENCRYPTION_LEVEL
-ngtcp2_crypto_openssl_from_ngtcp2_crypto_level(
-    ngtcp2_crypto_level crypto_level) {
-  switch (crypto_level) {
-  case NGTCP2_CRYPTO_LEVEL_INITIAL:
+ngtcp2_crypto_openssl_from_ngtcp2_encryption_level(
+    ngtcp2_encryption_level encryption_level) {
+  switch (encryption_level) {
+  case NGTCP2_ENCRYPTION_LEVEL_INITIAL:
     return ssl_encryption_initial;
-  case NGTCP2_CRYPTO_LEVEL_HANDSHAKE:
+  case NGTCP2_ENCRYPTION_LEVEL_HANDSHAKE:
     return ssl_encryption_handshake;
-  case NGTCP2_CRYPTO_LEVEL_APPLICATION:
+  case NGTCP2_ENCRYPTION_LEVEL_1RTT:
     return ssl_encryption_application;
-  case NGTCP2_CRYPTO_LEVEL_EARLY:
+  case NGTCP2_ENCRYPTION_LEVEL_0RTT:
     return ssl_encryption_early_data;
   default:
     assert(0);
@@ -730,7 +731,7 @@ static int set_encryption_secrets(SSL *ssl, OSSL_ENCRYPTION_LEVEL ossl_level,
                                   const uint8_t *tx_secret, size_t secretlen) {
   ngtcp2_crypto_conn_ref *conn_ref = SSL_get_app_data(ssl);
   ngtcp2_conn *conn = conn_ref->get_conn(conn_ref);
-  ngtcp2_crypto_level level =
+  ngtcp2_encryption_level level =
       ngtcp2_crypto_openssl_from_ossl_encryption_level(ossl_level);
 
   if (rx_secret &&
@@ -752,7 +753,7 @@ static int add_handshake_data(SSL *ssl, OSSL_ENCRYPTION_LEVEL ossl_level,
                               const uint8_t *data, size_t datalen) {
   ngtcp2_crypto_conn_ref *conn_ref = SSL_get_app_data(ssl);
   ngtcp2_conn *conn = conn_ref->get_conn(conn_ref);
-  ngtcp2_crypto_level level =
+  ngtcp2_encryption_level level =
       ngtcp2_crypto_openssl_from_ossl_encryption_level(ossl_level);
   int rv;
 

--- a/examples/client.cc
+++ b/examples/client.cc
@@ -236,14 +236,14 @@ void Client::disconnect() {
 }
 
 namespace {
-int recv_crypto_data(ngtcp2_conn *conn, ngtcp2_crypto_level crypto_level,
-                     uint64_t offset, const uint8_t *data, size_t datalen,
-                     void *user_data) {
+int recv_crypto_data(ngtcp2_conn *conn,
+                     ngtcp2_encryption_level encryption_level, uint64_t offset,
+                     const uint8_t *data, size_t datalen, void *user_data) {
   if (!config.quiet && !config.no_quic_dump) {
-    debug::print_crypto_data(crypto_level, data, datalen);
+    debug::print_crypto_data(encryption_level, data, datalen);
   }
 
-  return ngtcp2_crypto_recv_crypto_data_cb(conn, crypto_level, offset, data,
+  return ngtcp2_crypto_recv_crypto_data_cb(conn, encryption_level, offset, data,
                                            datalen, user_data);
 }
 } // namespace
@@ -601,8 +601,9 @@ int recv_new_token(ngtcp2_conn *conn, const uint8_t *token, size_t tokenlen,
 } // namespace
 
 namespace {
-int recv_rx_key(ngtcp2_conn *conn, ngtcp2_crypto_level level, void *user_data) {
-  if (level != NGTCP2_CRYPTO_LEVEL_APPLICATION) {
+int recv_rx_key(ngtcp2_conn *conn, ngtcp2_encryption_level level,
+                void *user_data) {
+  if (level != NGTCP2_ENCRYPTION_LEVEL_1RTT) {
     return 0;
   }
 

--- a/examples/debug.cc
+++ b/examples/debug.cc
@@ -59,25 +59,25 @@ bool packet_lost(double prob) {
   return p < prob;
 }
 
-void print_crypto_data(ngtcp2_crypto_level crypto_level, const uint8_t *data,
-                       size_t datalen) {
-  const char *crypto_level_str;
-  switch (crypto_level) {
-  case NGTCP2_CRYPTO_LEVEL_INITIAL:
-    crypto_level_str = "Initial";
+void print_crypto_data(ngtcp2_encryption_level encryption_level,
+                       const uint8_t *data, size_t datalen) {
+  const char *encryption_level_str;
+  switch (encryption_level) {
+  case NGTCP2_ENCRYPTION_LEVEL_INITIAL:
+    encryption_level_str = "Initial";
     break;
-  case NGTCP2_CRYPTO_LEVEL_HANDSHAKE:
-    crypto_level_str = "Handshake";
+  case NGTCP2_ENCRYPTION_LEVEL_HANDSHAKE:
+    encryption_level_str = "Handshake";
     break;
-  case NGTCP2_CRYPTO_LEVEL_APPLICATION:
-    crypto_level_str = "Application";
+  case NGTCP2_ENCRYPTION_LEVEL_1RTT:
+    encryption_level_str = "1-RTT";
     break;
   default:
     assert(0);
     abort();
   }
   fprintf(outfile, "Ordered CRYPTO data in %s crypto level\n",
-          crypto_level_str);
+          encryption_level_str);
   util::hexdump(outfile, data, datalen);
 }
 
@@ -279,13 +279,13 @@ void print_http_response_headers(int64_t stream_id, const nghttp3_nv *nva,
   }
 }
 
-std::string_view secret_title(ngtcp2_crypto_level level) {
+std::string_view secret_title(ngtcp2_encryption_level level) {
   switch (level) {
-  case NGTCP2_CRYPTO_LEVEL_EARLY:
+  case NGTCP2_ENCRYPTION_LEVEL_0RTT:
     return "early_traffic"sv;
-  case NGTCP2_CRYPTO_LEVEL_HANDSHAKE:
+  case NGTCP2_ENCRYPTION_LEVEL_HANDSHAKE:
     return "handshake_traffic"sv;
-  case NGTCP2_CRYPTO_LEVEL_APPLICATION:
+  case NGTCP2_ENCRYPTION_LEVEL_1RTT:
     return "application_traffic"sv;
   default:
     assert(0);

--- a/examples/debug.h
+++ b/examples/debug.h
@@ -50,8 +50,8 @@ int handshake_confirmed(ngtcp2_conn *conn, void *user_data);
 
 bool packet_lost(double prob);
 
-void print_crypto_data(ngtcp2_crypto_level crypto_level, const uint8_t *data,
-                       size_t datalen);
+void print_crypto_data(ngtcp2_encryption_level encryption_level,
+                       const uint8_t *data, size_t datalen);
 
 void print_stream_data(int64_t stream_id, const uint8_t *data, size_t datalen);
 
@@ -115,7 +115,7 @@ void print_http_request_headers(int64_t stream_id, const nghttp3_nv *nva,
 void print_http_response_headers(int64_t stream_id, const nghttp3_nv *nva,
                                  size_t nvlen);
 
-std::string_view secret_title(ngtcp2_crypto_level level);
+std::string_view secret_title(ngtcp2_encryption_level level);
 
 } // namespace debug
 

--- a/examples/h09client.cc
+++ b/examples/h09client.cc
@@ -230,14 +230,14 @@ void Client::disconnect() {
 }
 
 namespace {
-int recv_crypto_data(ngtcp2_conn *conn, ngtcp2_crypto_level crypto_level,
-                     uint64_t offset, const uint8_t *data, size_t datalen,
-                     void *user_data) {
+int recv_crypto_data(ngtcp2_conn *conn,
+                     ngtcp2_encryption_level encryption_level, uint64_t offset,
+                     const uint8_t *data, size_t datalen, void *user_data) {
   if (!config.quiet && !config.no_quic_dump) {
-    debug::print_crypto_data(crypto_level, data, datalen);
+    debug::print_crypto_data(encryption_level, data, datalen);
   }
 
-  return ngtcp2_crypto_recv_crypto_data_cb(conn, crypto_level, offset, data,
+  return ngtcp2_crypto_recv_crypto_data_cb(conn, encryption_level, offset, data,
                                            datalen, user_data);
 }
 } // namespace

--- a/examples/h09server.cc
+++ b/examples/h09server.cc
@@ -433,14 +433,14 @@ int do_hp_mask(uint8_t *dest, const ngtcp2_crypto_cipher *hp,
 } // namespace
 
 namespace {
-int recv_crypto_data(ngtcp2_conn *conn, ngtcp2_crypto_level crypto_level,
-                     uint64_t offset, const uint8_t *data, size_t datalen,
-                     void *user_data) {
+int recv_crypto_data(ngtcp2_conn *conn,
+                     ngtcp2_encryption_level encryption_level, uint64_t offset,
+                     const uint8_t *data, size_t datalen, void *user_data) {
   if (!config.quiet && !config.no_quic_dump) {
-    debug::print_crypto_data(crypto_level, data, datalen);
+    debug::print_crypto_data(encryption_level, data, datalen);
   }
 
-  return ngtcp2_crypto_recv_crypto_data_cb(conn, crypto_level, offset, data,
+  return ngtcp2_crypto_recv_crypto_data_cb(conn, encryption_level, offset, data,
                                            datalen, user_data);
 }
 } // namespace

--- a/examples/server.cc
+++ b/examples/server.cc
@@ -742,14 +742,14 @@ int do_hp_mask(uint8_t *dest, const ngtcp2_crypto_cipher *hp,
 } // namespace
 
 namespace {
-int recv_crypto_data(ngtcp2_conn *conn, ngtcp2_crypto_level crypto_level,
-                     uint64_t offset, const uint8_t *data, size_t datalen,
-                     void *user_data) {
+int recv_crypto_data(ngtcp2_conn *conn,
+                     ngtcp2_encryption_level encryption_level, uint64_t offset,
+                     const uint8_t *data, size_t datalen, void *user_data) {
   if (!config.quiet && !config.no_quic_dump) {
-    debug::print_crypto_data(crypto_level, data, datalen);
+    debug::print_crypto_data(encryption_level, data, datalen);
   }
 
-  return ngtcp2_crypto_recv_crypto_data_cb(conn, crypto_level, offset, data,
+  return ngtcp2_crypto_recv_crypto_data_cb(conn, encryption_level, offset, data,
                                            datalen, user_data);
 }
 } // namespace
@@ -1353,8 +1353,9 @@ int Handler::extend_max_stream_data(int64_t stream_id, uint64_t max_data) {
 }
 
 namespace {
-int recv_tx_key(ngtcp2_conn *conn, ngtcp2_crypto_level level, void *user_data) {
-  if (level != NGTCP2_CRYPTO_LEVEL_APPLICATION) {
+int recv_tx_key(ngtcp2_conn *conn, ngtcp2_encryption_level level,
+                void *user_data) {
+  if (level != NGTCP2_ENCRYPTION_LEVEL_1RTT) {
     return 0;
   }
 

--- a/lib/includes/ngtcp2/ngtcp2.h
+++ b/lib/includes/ngtcp2/ngtcp2.h
@@ -2449,28 +2449,28 @@ typedef int (*ngtcp2_recv_client_initial)(ngtcp2_conn *conn,
 /**
  * @enum
  *
- * :type:`ngtcp2_crypto_level` is encryption level.
+ * :type:`ngtcp2_encryption_level` is QUIC encryption level.
  */
-typedef enum ngtcp2_crypto_level {
+typedef enum ngtcp2_encryption_level {
   /**
-   * :enum:`NGTCP2_CRYPTO_LEVEL_INITIAL` is Initial encryption level.
-   */
-  NGTCP2_CRYPTO_LEVEL_INITIAL,
-  /**
-   * :enum:`NGTCP2_CRYPTO_LEVEL_HANDSHAKE` is Handshake encryption
+   * :enum:`NGTCP2_ENCRYPTION_LEVEL_INITIAL` is Initial encryption
    * level.
    */
-  NGTCP2_CRYPTO_LEVEL_HANDSHAKE,
+  NGTCP2_ENCRYPTION_LEVEL_INITIAL,
   /**
-   * :enum:`NGTCP2_CRYPTO_LEVEL_APPLICATION` is 1-RTT encryption
+   * :enum:`NGTCP2_ENCRYPTION_LEVEL_HANDSHAKE` is Handshake encryption
    * level.
    */
-  NGTCP2_CRYPTO_LEVEL_APPLICATION,
+  NGTCP2_ENCRYPTION_LEVEL_HANDSHAKE,
   /**
-   * :enum:`NGTCP2_CRYPTO_LEVEL_EARLY` is 0-RTT encryption level.
+   * :enum:`NGTCP2_ENCRYPTION_LEVEL_1RTT` is 1-RTT encryption level.
    */
-  NGTCP2_CRYPTO_LEVEL_EARLY
-} ngtcp2_crypto_level;
+  NGTCP2_ENCRYPTION_LEVEL_1RTT,
+  /**
+   * :enum:`NGTCP2_ENCRYPTION_LEVEL_0RTT` is 0-RTT encryption level.
+   */
+  NGTCP2_ENCRYPTION_LEVEL_0RTT
+} ngtcp2_encryption_level;
 
 /**
  * @functypedef
@@ -2484,7 +2484,7 @@ typedef enum ngtcp2_crypto_level {
  * in the increasing order of |offset|.  |datalen| is always strictly
  * greater than 0.  |crypto_level| indicates the encryption level
  * where this data is received.  Crypto data can never be received in
- * :enum:`ngtcp2_crypto_level.NGTCP2_CRYPTO_LEVEL_EARLY`.
+ * :enum:`ngtcp2_encryption_level.NGTCP2_ENCRYPTION_LEVEL_0RTT`.
  *
  * The application should provide the given data to TLS stack.
  *
@@ -2508,7 +2508,7 @@ typedef enum ngtcp2_crypto_level {
  * return immediately.
  */
 typedef int (*ngtcp2_recv_crypto_data)(ngtcp2_conn *conn,
-                                       ngtcp2_crypto_level crypto_level,
+                                       ngtcp2_encryption_level encryption_level,
                                        uint64_t offset, const uint8_t *data,
                                        size_t datalen, void *user_data);
 
@@ -3245,7 +3245,7 @@ typedef int (*ngtcp2_version_negotiation)(ngtcp2_conn *conn, uint32_t version,
  * :macro:`NGTCP2_ERR_CALLBACK_FAILURE` makes the library call return
  * immediately.
  */
-typedef int (*ngtcp2_recv_key)(ngtcp2_conn *conn, ngtcp2_crypto_level level,
+typedef int (*ngtcp2_recv_key)(ngtcp2_conn *conn, ngtcp2_encryption_level level,
                                void *user_data);
 
 /**
@@ -3508,14 +3508,14 @@ typedef struct ngtcp2_callbacks {
    * :member:`recv_rx_key` is a callback function which is invoked
    * when a new key for decrypting packets is installed during QUIC
    * cryptographic handshake.  It is not called for
-   * :enum:`ngtcp2_crypto_level.NGTCP2_CRYPTO_LEVEL_INITIAL`.
+   * :enum:`ngtcp2_encryption_level.NGTCP2_ENCRYPTION_LEVEL_INITIAL`.
    */
   ngtcp2_recv_key recv_rx_key;
   /**
    * :member:`recv_tx_key` is a callback function which is invoked
    * when a new key for encrypting packets is installed during QUIC
    * cryptographic handshake.  It is not called for
-   * :enum:`ngtcp2_crypto_level.NGTCP2_CRYPTO_LEVEL_INITIAL`.
+   * :enum:`ngtcp2_encryption_level.NGTCP2_ENCRYPTION_LEVEL_INITIAL`.
    */
   ngtcp2_recv_key recv_tx_key;
   /**
@@ -4868,7 +4868,7 @@ NGTCP2_EXTERN void ngtcp2_conn_get_conn_info_versioned(ngtcp2_conn *conn,
  */
 NGTCP2_EXTERN int
 ngtcp2_conn_submit_crypto_data(ngtcp2_conn *conn,
-                               ngtcp2_crypto_level crypto_level,
+                               ngtcp2_encryption_level encryption_level,
                                const uint8_t *data, const size_t datalen);
 
 /**


### PR DESCRIPTION
Rename ngtcp2_crypto_level to ngtcp2_encryption_level.  This commit also renames the following names:

- NGTCP2_CRYPTO_LEVEL_INITIAL -> NGTCP2_ENCRYPTION_LEVEL_INITIAL
- NGTCP2_CRYPTO_LEVEL_HANDSHAKE -> NGTCP2_ENCRYPTION_LEVEL_HANDSHAKE
- NGTCP2_CRYPTO_LEVEL_APPLICATION -> NGTCP2_ENCRYPTION_LEVEL_1RTT
- NGTCP2_CRYPTO_LEVEL_EARLY -> NGTCP2_ENCRYPTION_LEVEL_0RTT