### PR TITLE
Rename early functions to 0rtt

### DIFF
--- a/crypto/shared.c
+++ b/crypto/shared.c
@@ -250,8 +250,8 @@ int ngtcp2_crypto_derive_and_install_rx_key(ngtcp2_conn *conn, uint8_t *key,
   switch (level) {
   case NGTCP2_ENCRYPTION_LEVEL_0RTT:
     ngtcp2_crypto_ctx_tls_early(&cctx, tls);
-    ngtcp2_conn_set_early_crypto_ctx(conn, &cctx);
-    ctx = ngtcp2_conn_get_early_crypto_ctx(conn);
+    ngtcp2_conn_set_0rtt_crypto_ctx(conn, &cctx);
+    ctx = ngtcp2_conn_get_0rtt_crypto_ctx(conn);
     version = ngtcp2_conn_get_client_chosen_version(conn);
     break;
   case NGTCP2_ENCRYPTION_LEVEL_HANDSHAKE:
@@ -297,7 +297,7 @@ int ngtcp2_crypto_derive_and_install_rx_key(ngtcp2_conn *conn, uint8_t *key,
 
   switch (level) {
   case NGTCP2_ENCRYPTION_LEVEL_0RTT:
-    rv = ngtcp2_conn_install_early_key(conn, &aead_ctx, iv, ivlen, &hp_ctx);
+    rv = ngtcp2_conn_install_0rtt_key(conn, &aead_ctx, iv, ivlen, &hp_ctx);
     if (rv != 0) {
       goto fail;
     }
@@ -394,8 +394,8 @@ int ngtcp2_crypto_derive_and_install_tx_key(ngtcp2_conn *conn, uint8_t *key,
   switch (level) {
   case NGTCP2_ENCRYPTION_LEVEL_0RTT:
     ngtcp2_crypto_ctx_tls_early(&cctx, tls);
-    ngtcp2_conn_set_early_crypto_ctx(conn, &cctx);
-    ctx = ngtcp2_conn_get_early_crypto_ctx(conn);
+    ngtcp2_conn_set_0rtt_crypto_ctx(conn, &cctx);
+    ctx = ngtcp2_conn_get_0rtt_crypto_ctx(conn);
     version = ngtcp2_conn_get_client_chosen_version(conn);
     break;
   case NGTCP2_ENCRYPTION_LEVEL_HANDSHAKE:
@@ -441,7 +441,7 @@ int ngtcp2_crypto_derive_and_install_tx_key(ngtcp2_conn *conn, uint8_t *key,
 
   switch (level) {
   case NGTCP2_ENCRYPTION_LEVEL_0RTT:
-    rv = ngtcp2_conn_install_early_key(conn, &aead_ctx, iv, ivlen, &hp_ctx);
+    rv = ngtcp2_conn_install_0rtt_key(conn, &aead_ctx, iv, ivlen, &hp_ctx);
     if (rv != 0) {
       goto fail;
     }

--- a/doc/source/programmers-guide.rst
+++ b/doc/source/programmers-guide.rst
@@ -308,30 +308,30 @@ from `ngtcp2_conn_get_scid()`.  Association for the initial Connection
 ID which can be obtained by calling
 `ngtcp2_conn_get_client_initial_dcid()` should also be removed.
 
-Dealing with early data
------------------------
+Dealing with 0-RTT (early) data
+-------------------------------
 
 Client application has to remember the subset of the QUIC transport
 parameters received from a server in the previous connection.
-`ngtcp2_conn_encode_early_transport_params` returns the encoded QUIC
-transport parameters that include these values.  When sending early
+`ngtcp2_conn_encode_0rtt_transport_params` returns the encoded QUIC
+transport parameters that include these values.  When sending 0-RTT
 data, the remembered transport parameters should be set via
-`ngtcp2_conn_decode_early_transport_params`.  Then client can open
+`ngtcp2_conn_decode_0rtt_transport_params`.  Then client can open
 streams with `ngtcp2_conn_open_bidi_streams` or
 `ngtcp2_conn_open_uni_stream`.  Note that
-`ngtcp2_conn_decode_early_transport_params` does not invoke neither
+`ngtcp2_conn_decode_0rtt_transport_params` does not invoke neither
 :member:`ngtcp2_callbacks.extend_max_local_streams_bidi` nor
 :member:`ngtcp2_callbacks.extend_max_local_streams_uni`.
 
-Other than that, there is no difference between early data and 1RTT
-data in terms of API usage.
+Other than that, there is no difference between 0-RTT and 1-RTT data
+in terms of API usage.
 
 If early data is rejected by a server, client must call
 `ngtcp2_conn_early_data_rejected`.  All connection states altered
-during early data transmission are undone.  The library does not
-retransmit early data to server as 1RTT data.  If an application
-wishes to resend data, it has to reopen streams and writes data again.
-See `ngtcp2_conn_early_data_rejected`.
+during 0-RTT transmission are undone.  The library does not retransmit
+0-RTT data to server as 1-RTT data.  If an application wishes to
+resend data, it has to reopen streams and writes data again.  See
+`ngtcp2_conn_early_data_rejected`.
 
 Closing streams
 ---------------

--- a/examples/client.cc
+++ b/examples/client.cc
@@ -324,10 +324,10 @@ int Client::handshake_completed() {
 
   if (config.tp_file) {
     std::array<uint8_t, 256> data;
-    auto datalen = ngtcp2_conn_encode_early_transport_params(conn_, data.data(),
-                                                             data.size());
+    auto datalen = ngtcp2_conn_encode_0rtt_transport_params(conn_, data.data(),
+                                                            data.size());
     if (datalen < 0) {
-      std::cerr << "Could not encode early transport parameters: "
+      std::cerr << "Could not encode 0-RTT transport parameters: "
                 << ngtcp2_strerror(datalen) << std::endl;
     } else if (util::write_transport_params(config.tp_file, data.data(),
                                             datalen) != 0) {
@@ -818,11 +818,11 @@ int Client::init(int fd, const Address &local_addr, const Address &remote_addr,
     if (!params) {
       early_data_ = false;
     } else {
-      auto rv = ngtcp2_conn_decode_early_transport_params(
+      auto rv = ngtcp2_conn_decode_0rtt_transport_params(
           conn_, reinterpret_cast<const uint8_t *>(params->data()),
           params->size());
       if (rv != 0) {
-        std::cerr << "ngtcp2_conn_decode_early_transport_params: "
+        std::cerr << "ngtcp2_conn_decode_0rtt_transport_params: "
                   << ngtcp2_strerror(rv) << std::endl;
         early_data_ = false;
       } else if (make_stream_early() != 0) {

--- a/examples/h09client.cc
+++ b/examples/h09client.cc
@@ -314,10 +314,10 @@ int Client::handshake_completed() {
 
   if (config.tp_file) {
     std::array<uint8_t, 256> data;
-    auto datalen = ngtcp2_conn_encode_early_transport_params(conn_, data.data(),
-                                                             data.size());
+    auto datalen = ngtcp2_conn_encode_0rtt_transport_params(conn_, data.data(),
+                                                            data.size());
     if (datalen < 0) {
-      std::cerr << "Could not encode early transport parameters: "
+      std::cerr << "Could not encode 0-RTT transport parameters: "
                 << ngtcp2_strerror(datalen) << std::endl;
     } else if (util::write_transport_params(config.tp_file, data.data(),
                                             datalen) != 0) {
@@ -763,11 +763,11 @@ int Client::init(int fd, const Address &local_addr, const Address &remote_addr,
     if (!params) {
       early_data_ = false;
     } else {
-      auto rv = ngtcp2_conn_decode_early_transport_params(
+      auto rv = ngtcp2_conn_decode_0rtt_transport_params(
           conn_, reinterpret_cast<const uint8_t *>(params->data()),
           params->size());
       if (rv != 0) {
-        std::cerr << "ngtcp2_conn_decode_early_transport_params: "
+        std::cerr << "ngtcp2_conn_decode_0rtt_transport_params: "
                   << ngtcp2_strerror(rv) << std::endl;
         early_data_ = false;
       } else if (make_stream_early() != 0) {

--- a/lib/includes/ngtcp2/ngtcp2.h
+++ b/lib/includes/ngtcp2/ngtcp2.h
@@ -2684,11 +2684,11 @@ typedef int (*ngtcp2_hp_mask)(uint8_t *dest, const ngtcp2_crypto_cipher *hp,
 /**
  * @macro
  *
- * :macro:`NGTCP2_STREAM_DATA_FLAG_EARLY` indicates that this chunk of
+ * :macro:`NGTCP2_STREAM_DATA_FLAG_0RTT` indicates that this chunk of
  * data contains data received in 0-RTT packet, and the handshake has
  * not completed yet, which means that the data might be replayed.
  */
-#define NGTCP2_STREAM_DATA_FLAG_EARLY 0x02u
+#define NGTCP2_STREAM_DATA_FLAG_0RTT 0x02u
 
 /**
  * @functypedef
@@ -2704,7 +2704,7 @@ typedef int (*ngtcp2_hp_mask)(uint8_t *dest, const ngtcp2_crypto_cipher *hp,
  * overlap.  The data is passed as |data| of length |datalen|.
  * |datalen| may be 0 if and only if |fin| is nonzero.
  *
- * If :macro:`NGTCP2_STREAM_DATA_FLAG_EARLY` is set in |flags|, it
+ * If :macro:`NGTCP2_STREAM_DATA_FLAG_0RTT` is set in |flags|, it
  * indicates that a part of or whole data was received in 0RTT packet
  * and a handshake has not completed yet.
  *
@@ -3125,11 +3125,11 @@ typedef void (*ngtcp2_delete_crypto_cipher_ctx)(
 /**
  * @macro
  *
- * :macro:`NGTCP2_DATAGRAM_FLAG_EARLY` indicates that DATAGRAM frame
- * is received in 0RTT packet and the handshake has not completed yet,
+ * :macro:`NGTCP2_DATAGRAM_FLAG_0RTT` indicates that DATAGRAM frame is
+ * received in 0RTT packet and the handshake has not completed yet,
  * which means that the data might be replayed.
  */
-#define NGTCP2_DATAGRAM_FLAG_EARLY 0x01u
+#define NGTCP2_DATAGRAM_FLAG_0RTT 0x01u
 
 /**
  * @functypedef
@@ -3138,7 +3138,7 @@ typedef void (*ngtcp2_delete_crypto_cipher_ctx)(
  * received.  |flags| is bitwise-OR of zero or more of
  * :macro:`NGTCP2_DATAGRAM_FLAG_* <NGTCP2_DATAGRAM_FLAG_NONE>`.
  *
- * If :macro:`NGTCP2_DATAGRAM_FLAG_EARLY` is set in |flags|, it
+ * If :macro:`NGTCP2_DATAGRAM_FLAG_0RTT` is set in |flags|, it
  * indicates that DATAGRAM frame was received in 0RTT packet and a
  * handshake has not completed yet.
  *
@@ -3870,7 +3870,7 @@ NGTCP2_EXTERN int ngtcp2_conn_install_tx_handshake_key(
 /**
  * @function
  *
- * `ngtcp2_conn_install_early_key` installs packet protection AEAD
+ * `ngtcp2_conn_install_0rtt_key` installs packet protection AEAD
  * cipher context object |aead_ctx|, IV |iv| of length |ivlen|, and
  * packet header protection cipher context object |hp_ctx| to encrypt
  * (for client) or decrypt (for server) 0RTT packets.
@@ -3890,7 +3890,7 @@ NGTCP2_EXTERN int ngtcp2_conn_install_tx_handshake_key(
  * :macro:`NGTCP2_ERR_NOMEM`
  *     Out of memory.
  */
-NGTCP2_EXTERN int ngtcp2_conn_install_early_key(
+NGTCP2_EXTERN int ngtcp2_conn_install_0rtt_key(
     ngtcp2_conn *conn, const ngtcp2_crypto_aead_ctx *aead_ctx,
     const uint8_t *iv, size_t ivlen, const ngtcp2_crypto_cipher_ctx *hp_ctx);
 
@@ -4088,7 +4088,7 @@ ngtcp2_conn_get_remote_transport_params(ngtcp2_conn *conn);
 /**
  * @function
  *
- * `ngtcp2_conn_encode_early_transport_params` encodes the QUIC
+ * `ngtcp2_conn_encode_0rtt_transport_params` encodes the QUIC
  * transport parameters that are used for early data in the buffer
  * pointed by |dest| of length |destlen|.  The subset includes at
  * least the following fields:
@@ -4121,14 +4121,14 @@ ngtcp2_conn_get_remote_transport_params(ngtcp2_conn *conn);
  *     Buffer is too small.
  */
 NGTCP2_EXTERN
-ngtcp2_ssize ngtcp2_conn_encode_early_transport_params(ngtcp2_conn *conn,
-                                                       uint8_t *dest,
-                                                       size_t destlen);
+ngtcp2_ssize ngtcp2_conn_encode_0rtt_transport_params(ngtcp2_conn *conn,
+                                                      uint8_t *dest,
+                                                      size_t destlen);
 
 /**
  * @function
  *
- * `ngtcp2_conn_decode_early_transport_params` decodes QUIC transport
+ * `ngtcp2_conn_decode_0rtt_transport_params` decodes QUIC transport
  * parameters from |data| of length |datalen|, which is assumed to be
  * the parameters received from the server in the previous connection,
  * and sets it to |conn|.  These parameters are used to send early
@@ -4156,9 +4156,9 @@ ngtcp2_ssize ngtcp2_conn_encode_early_transport_params(ngtcp2_conn *conn,
  * :macro:`NGTCP2_ERR_MALFORMED_TRANSPORT_PARAM`
  *     The input is malformed.
  */
-NGTCP2_EXTERN int ngtcp2_conn_decode_early_transport_params(ngtcp2_conn *conn,
-                                                            const uint8_t *data,
-                                                            size_t datalen);
+NGTCP2_EXTERN int ngtcp2_conn_decode_0rtt_transport_params(ngtcp2_conn *conn,
+                                                           const uint8_t *data,
+                                                           size_t datalen);
 
 /**
  * @function
@@ -4214,7 +4214,7 @@ NGTCP2_EXTERN ngtcp2_ssize ngtcp2_conn_encode_local_transport_params(
  *
  * Application can call this function before handshake completes.  For
  * 0RTT packet, application can call this function after calling
- * `ngtcp2_conn_decode_early_transport_params`.  For 1RTT packet,
+ * `ngtcp2_conn_decode_0rtt_transport_params`.  For 1RTT packet,
  * application can call this function after calling
  * `ngtcp2_conn_decode_remote_transport_params` and
  * `ngtcp2_conn_install_tx_key`.  If ngtcp2 crypto support library is
@@ -4242,7 +4242,7 @@ NGTCP2_EXTERN int ngtcp2_conn_open_bidi_stream(ngtcp2_conn *conn,
  *
  * Application can call this function before handshake completes.  For
  * 0RTT packet, application can call this function after calling
- * `ngtcp2_conn_decode_early_transport_params`.  For 1RTT packet,
+ * `ngtcp2_conn_decode_0rtt_transport_params`.  For 1RTT packet,
  * application can call this function after calling
  * `ngtcp2_conn_decode_remote_transport_params` and
  * `ngtcp2_conn_install_tx_key`.  If ngtcp2 crypto support library is
@@ -5117,23 +5117,23 @@ ngtcp2_conn_get_crypto_ctx(ngtcp2_conn *conn);
 /**
  * @function
  *
- * `ngtcp2_conn_set_early_crypto_ctx` sets |ctx| for 0RTT packet
+ * `ngtcp2_conn_set_0rtt_crypto_ctx` sets |ctx| for 0RTT packet
  * encryption.  The passed data will be passed to
  * :type:`ngtcp2_encrypt`, :type:`ngtcp2_decrypt` and
  * :type:`ngtcp2_hp_mask` callbacks.
  */
 NGTCP2_EXTERN void
-ngtcp2_conn_set_early_crypto_ctx(ngtcp2_conn *conn,
-                                 const ngtcp2_crypto_ctx *ctx);
+ngtcp2_conn_set_0rtt_crypto_ctx(ngtcp2_conn *conn,
+                                const ngtcp2_crypto_ctx *ctx);
 
 /**
  * @function
  *
- * `ngtcp2_conn_get_early_crypto_ctx` returns
- * :type:`ngtcp2_crypto_ctx` object for 0RTT packet encryption.
+ * `ngtcp2_conn_get_0rtt_crypto_ctx` returns :type:`ngtcp2_crypto_ctx`
+ * object for 0RTT packet encryption.
  */
 NGTCP2_EXTERN const ngtcp2_crypto_ctx *
-ngtcp2_conn_get_early_crypto_ctx(ngtcp2_conn *conn);
+ngtcp2_conn_get_0rtt_crypto_ctx(ngtcp2_conn *conn);
 
 /**
  * @enum

--- a/lib/ngtcp2_conn.c
+++ b/lib/ngtcp2_conn.c
@@ -580,7 +580,7 @@ static int conn_call_recv_datagram(ngtcp2_conn *conn,
   }
 
   if (!conn_is_tls_handshake_completed(conn)) {
-    flags |= NGTCP2_DATAGRAM_FLAG_EARLY;
+    flags |= NGTCP2_DATAGRAM_FLAG_0RTT;
   }
 
   rv = conn->callbacks.recv_datagram(conn, flags, data, datalen,
@@ -6915,7 +6915,7 @@ static int conn_emit_pending_stream_data(ngtcp2_conn *conn, ngtcp2_strm *strm,
       sdflags |= NGTCP2_STREAM_DATA_FLAG_FIN;
     }
     if (!handshake_completed) {
-      sdflags |= NGTCP2_STREAM_DATA_FLAG_EARLY;
+      sdflags |= NGTCP2_STREAM_DATA_FLAG_0RTT;
     }
 
     rv = conn_call_recv_stream_data(conn, strm, sdflags, offset, data, datalen);
@@ -7235,7 +7235,7 @@ static int conn_recv_stream(ngtcp2_conn *conn, const ngtcp2_stream *fr) {
         sdflags |= NGTCP2_STREAM_DATA_FLAG_FIN;
       }
       if (!conn_is_tls_handshake_completed(conn)) {
-        sdflags |= NGTCP2_STREAM_DATA_FLAG_EARLY;
+        sdflags |= NGTCP2_STREAM_DATA_FLAG_0RTT;
       }
       rv = conn_call_recv_stream_data(conn, strm, sdflags, offset, data,
                                       (size_t)datalen);
@@ -10672,10 +10672,10 @@ int ngtcp2_conn_install_tx_handshake_key(
   return 0;
 }
 
-int ngtcp2_conn_install_early_key(ngtcp2_conn *conn,
-                                  const ngtcp2_crypto_aead_ctx *aead_ctx,
-                                  const uint8_t *iv, size_t ivlen,
-                                  const ngtcp2_crypto_cipher_ctx *hp_ctx) {
+int ngtcp2_conn_install_0rtt_key(ngtcp2_conn *conn,
+                                 const ngtcp2_crypto_aead_ctx *aead_ctx,
+                                 const uint8_t *iv, size_t ivlen,
+                                 const ngtcp2_crypto_cipher_ctx *hp_ctx) {
   int rv;
 
   assert(ivlen >= 8);
@@ -11383,9 +11383,9 @@ ngtcp2_conn_get_remote_transport_params(ngtcp2_conn *conn) {
   return conn->remote.transport_params;
 }
 
-ngtcp2_ssize ngtcp2_conn_encode_early_transport_params(ngtcp2_conn *conn,
-                                                       uint8_t *dest,
-                                                       size_t destlen) {
+ngtcp2_ssize ngtcp2_conn_encode_0rtt_transport_params(ngtcp2_conn *conn,
+                                                      uint8_t *dest,
+                                                      size_t destlen) {
   ngtcp2_transport_params params, *src;
 
   if (conn->server) {
@@ -11418,9 +11418,9 @@ ngtcp2_ssize ngtcp2_conn_encode_early_transport_params(ngtcp2_conn *conn,
   return ngtcp2_transport_params_encode(dest, destlen, &params);
 }
 
-int ngtcp2_conn_decode_early_transport_params(ngtcp2_conn *conn,
-                                              const uint8_t *data,
-                                              size_t datalen) {
+int ngtcp2_conn_decode_0rtt_transport_params(ngtcp2_conn *conn,
+                                             const uint8_t *data,
+                                             size_t datalen) {
   ngtcp2_transport_params params;
   int rv;
 
@@ -11429,10 +11429,10 @@ int ngtcp2_conn_decode_early_transport_params(ngtcp2_conn *conn,
     return rv;
   }
 
-  return ngtcp2_conn_set_early_remote_transport_params(conn, &params);
+  return ngtcp2_conn_set_0rtt_remote_transport_params(conn, &params);
 }
 
-int ngtcp2_conn_set_early_remote_transport_params(
+int ngtcp2_conn_set_0rtt_remote_transport_params(
     ngtcp2_conn *conn, const ngtcp2_transport_params *params) {
   ngtcp2_transport_params *p;
 
@@ -13496,12 +13496,12 @@ const ngtcp2_crypto_ctx *ngtcp2_conn_get_crypto_ctx(ngtcp2_conn *conn) {
   return &conn->pktns.crypto.ctx;
 }
 
-void ngtcp2_conn_set_early_crypto_ctx(ngtcp2_conn *conn,
-                                      const ngtcp2_crypto_ctx *ctx) {
+void ngtcp2_conn_set_0rtt_crypto_ctx(ngtcp2_conn *conn,
+                                     const ngtcp2_crypto_ctx *ctx) {
   conn->early.ctx = *ctx;
 }
 
-const ngtcp2_crypto_ctx *ngtcp2_conn_get_early_crypto_ctx(ngtcp2_conn *conn) {
+const ngtcp2_crypto_ctx *ngtcp2_conn_get_0rtt_crypto_ctx(ngtcp2_conn *conn) {
   return &conn->early.ctx;
 }
 

--- a/lib/ngtcp2_conn.h
+++ b/lib/ngtcp2_conn.h
@@ -1118,7 +1118,7 @@ int ngtcp2_conn_set_remote_transport_params(
 /**
  * @function
  *
- * `ngtcp2_conn_set_early_remote_transport_params` sets |params| as
+ * `ngtcp2_conn_set_0rtt_remote_transport_params` sets |params| as
  * transport parameters previously received from a server.  The
  * parameters are used to send early data.  QUIC requires that client
  * application should remember transport parameters along with a
@@ -1151,7 +1151,7 @@ int ngtcp2_conn_set_remote_transport_params(
  * :macro:`NGTCP2_ERR_NOMEM`
  *     Out of memory.
  */
-int ngtcp2_conn_set_early_remote_transport_params(
+int ngtcp2_conn_set_0rtt_remote_transport_params(
     ngtcp2_conn *conn, const ngtcp2_transport_params *params);
 
 /*

--- a/tests/main.c
+++ b/tests/main.c
@@ -312,8 +312,8 @@ int main(void) {
       !CU_add_test(pSuite, "conn_pmtud_loss", test_ngtcp2_conn_pmtud_loss) ||
       !CU_add_test(pSuite, "conn_amplification",
                    test_ngtcp2_conn_amplification) ||
-      !CU_add_test(pSuite, "conn_encode_early_transport_params",
-                   test_ngtcp2_conn_encode_early_transport_params) ||
+      !CU_add_test(pSuite, "conn_encode_0rtt_transport_params",
+                   test_ngtcp2_conn_encode_0rtt_transport_params) ||
       !CU_add_test(pSuite, "conn_create_ack_frame",
                    test_ngtcp2_conn_create_ack_frame) ||
       !CU_add_test(pSuite, "conn_new_failmalloc",

--- a/tests/ngtcp2_conn_test.h
+++ b/tests/ngtcp2_conn_test.h
@@ -96,7 +96,7 @@ void test_ngtcp2_conn_version_negotiation(void);
 void test_ngtcp2_conn_server_negotiate_version(void);
 void test_ngtcp2_conn_pmtud_loss(void);
 void test_ngtcp2_conn_amplification(void);
-void test_ngtcp2_conn_encode_early_transport_params(void);
+void test_ngtcp2_conn_encode_0rtt_transport_params(void);
 void test_ngtcp2_conn_create_ack_frame(void);
 void test_ngtcp2_conn_new_failmalloc(void);
 void test_ngtcp2_accept(void);


### PR DESCRIPTION
Rename early functions to 0rtt except for those that are specifically related to TLSv1.3 early data (e.g., ngtcp2_early_data_rejected)