### PR TITLE
Rename ngtcp2_conn_early_data_rejected

### DIFF
--- a/crypto/boringssl/boringssl.c
+++ b/crypto/boringssl/boringssl.c
@@ -425,7 +425,7 @@ int ngtcp2_crypto_read_write_crypto_data(
 
         SSL_reset_early_data_reject(ssl);
 
-        rv = ngtcp2_conn_early_data_rejected(conn);
+        rv = ngtcp2_conn_tls_early_data_rejected(conn);
         if (rv != 0) {
           return -1;
         }

--- a/crypto/picotls/picotls.c
+++ b/crypto/picotls/picotls.c
@@ -386,7 +386,7 @@ int ngtcp2_crypto_read_write_crypto_data(
   if (!ngtcp2_conn_is_server(conn) &&
       cptls->handshake_properties.client.early_data_acceptance ==
           PTLS_EARLY_DATA_REJECTED) {
-    rv = ngtcp2_conn_early_data_rejected(conn);
+    rv = ngtcp2_conn_tls_early_data_rejected(conn);
     if (rv != 0) {
       rv = -1;
       goto fin;

--- a/doc/source/programmers-guide.rst
+++ b/doc/source/programmers-guide.rst
@@ -326,12 +326,12 @@ streams with `ngtcp2_conn_open_bidi_streams` or
 Other than that, there is no difference between 0-RTT and 1-RTT data
 in terms of API usage.
 
-If early data is rejected by a server, client must call
-`ngtcp2_conn_early_data_rejected`.  All connection states altered
-during 0-RTT transmission are undone.  The library does not retransmit
-0-RTT data to server as 1-RTT data.  If an application wishes to
-resend data, it has to reopen streams and writes data again.  See
-`ngtcp2_conn_early_data_rejected`.
+If early data is rejected by a server during TLS handshake, client
+must call `ngtcp2_conn_tls_early_data_rejected`.  All connection
+states altered during 0-RTT transmission are undone.  The library does
+not retransmit 0-RTT data to server as 1-RTT data.  If an application
+wishes to resend data, it has to reopen streams and writes data again.
+See `ngtcp2_conn_tls_early_data_rejected`.
 
 Closing streams
 ---------------

--- a/examples/client.cc
+++ b/examples/client.cc
@@ -304,9 +304,9 @@ int Client::handshake_completed() {
     // handshake completion (e.g., OpenSSL).  For TLS backends which
     // report it early (e.g., BoringSSL and PicoTLS), the following
     // functions are noop.
-    if (auto rv = ngtcp2_conn_early_data_rejected(conn_); rv != 0) {
-      std::cerr << "ngtcp2_conn_early_data_rejected: " << ngtcp2_strerror(rv)
-                << std::endl;
+    if (auto rv = ngtcp2_conn_tls_early_data_rejected(conn_); rv != 0) {
+      std::cerr << "ngtcp2_conn_tls_early_data_rejected: "
+                << ngtcp2_strerror(rv) << std::endl;
       return -1;
     }
 

--- a/examples/h09client.cc
+++ b/examples/h09client.cc
@@ -298,9 +298,9 @@ int Client::handshake_completed() {
     // handshake completion (e.g., OpenSSL).  For TLS backends which
     // report it early (e.g., BoringSSL and PicoTLS), the following
     // functions are noop.
-    if (auto rv = ngtcp2_conn_early_data_rejected(conn_); rv != 0) {
-      std::cerr << "ngtcp2_conn_early_data_rejected: " << ngtcp2_strerror(rv)
-                << std::endl;
+    if (auto rv = ngtcp2_conn_tls_early_data_rejected(conn_); rv != 0) {
+      std::cerr << "ngtcp2_conn_tls_early_data_rejected: "
+                << ngtcp2_strerror(rv) << std::endl;
       return -1;
     }
   }

--- a/lib/includes/ngtcp2/ngtcp2.h
+++ b/lib/includes/ngtcp2/ngtcp2.h
@@ -3251,14 +3251,16 @@ typedef int (*ngtcp2_recv_key)(ngtcp2_conn *conn, ngtcp2_encryption_level level,
 /**
  * @functypedef
  *
- * :type:`ngtcp2_early_data_rejected` is invoked when early data was
- * rejected by server, or client decided not to attempt early data.
+ * :type:`ngtcp2_tls_early_data_rejected` is invoked when early data
+ * was rejected by server during TLS handshake, or client decided not
+ * to attempt early data.
  *
  * The callback function must return 0 if it succeeds.  Returning
  * :macro:`NGTCP2_ERR_CALLBACK_FAILURE` makes the library call return
  * immediately.
  */
-typedef int (*ngtcp2_early_data_rejected)(ngtcp2_conn *conn, void *user_data);
+typedef int (*ngtcp2_tls_early_data_rejected)(ngtcp2_conn *conn,
+                                              void *user_data);
 
 #define NGTCP2_CALLBACKS_V1 1
 #define NGTCP2_CALLBACKS_VERSION NGTCP2_CALLBACKS_V1
@@ -3519,12 +3521,12 @@ typedef struct ngtcp2_callbacks {
    */
   ngtcp2_recv_key recv_tx_key;
   /**
-   * :member:`ngtcp2_early_data_rejected` is a callback function which
-   * is invoked when an attempt to send early data by client was
-   * rejected by server, or client decided not to attempt early data.
-   * This callback function is only used by client.
+   * :member:`ngtcp2_tls_early_data_rejected` is a callback function
+   * which is invoked when server rejected early data in TLS
+   * handshake, or client decided not to attempt early data.  This
+   * callback function is only used by client.
    */
-  ngtcp2_early_data_rejected early_data_rejected;
+  ngtcp2_tls_early_data_rejected tls_early_data_rejected;
 } ngtcp2_callbacks;
 
 /**
@@ -4817,9 +4819,10 @@ NGTCP2_EXTERN uint32_t ngtcp2_conn_get_negotiated_version(ngtcp2_conn *conn);
 /**
  * @function
  *
- * `ngtcp2_conn_early_data_rejected` tells |conn| that early data was
- * rejected by a server, or client decided not to attempt early data
- * for some reason.  |conn| discards the following connection states:
+ * `ngtcp2_conn_tls_early_data_rejected` tells |conn| that early data
+ * was rejected by a server during TLS handshake, or client decided
+ * not to attempt early data for some reason.  |conn| discards the
+ * following connection states:
  *
  * - Any opended streams.
  * - Stream identifier allocations.
@@ -4836,15 +4839,15 @@ NGTCP2_EXTERN uint32_t ngtcp2_conn_get_negotiated_version(ngtcp2_conn *conn);
  * :macro:`NGTCP2_ERR_CALLBACK_FAILURE`
  *     User callback failed
  */
-NGTCP2_EXTERN int ngtcp2_conn_early_data_rejected(ngtcp2_conn *conn);
+NGTCP2_EXTERN int ngtcp2_conn_tls_early_data_rejected(ngtcp2_conn *conn);
 
 /**
  * @function
  *
- * `ngtcp2_conn_get_early_data_rejected` returns nonzero if
- * `ngtcp2_conn_early_data_rejected` has been called.
+ * `ngtcp2_conn_get_tls_early_data_rejected` returns nonzero if
+ * `ngtcp2_conn_tls_early_data_rejected` has been called.
  */
-NGTCP2_EXTERN int ngtcp2_conn_get_early_data_rejected(ngtcp2_conn *conn);
+NGTCP2_EXTERN int ngtcp2_conn_get_tls_early_data_rejected(ngtcp2_conn *conn);
 
 /**
  * @function

--- a/lib/ngtcp2_conn.c
+++ b/lib/ngtcp2_conn.c
@@ -12743,7 +12743,7 @@ static void conn_discard_early_data_state(ngtcp2_conn *conn) {
   }
 }
 
-int ngtcp2_conn_early_data_rejected(ngtcp2_conn *conn) {
+int ngtcp2_conn_tls_early_data_rejected(ngtcp2_conn *conn) {
   if (conn->flags & NGTCP2_CONN_FLAG_EARLY_DATA_REJECTED) {
     return 0;
   }
@@ -12752,14 +12752,14 @@ int ngtcp2_conn_early_data_rejected(ngtcp2_conn *conn) {
 
   conn_discard_early_data_state(conn);
 
-  if (conn->callbacks.early_data_rejected) {
-    return conn->callbacks.early_data_rejected(conn, conn->user_data);
+  if (conn->callbacks.tls_early_data_rejected) {
+    return conn->callbacks.tls_early_data_rejected(conn, conn->user_data);
   }
 
   return 0;
 }
 
-int ngtcp2_conn_get_early_data_rejected(ngtcp2_conn *conn) {
+int ngtcp2_conn_get_tls_early_data_rejected(ngtcp2_conn *conn) {
   return (conn->flags & NGTCP2_CONN_FLAG_EARLY_DATA_REJECTED) != 0;
 }
 

--- a/tests/main.c
+++ b/tests/main.c
@@ -293,8 +293,8 @@ int main(void) {
                    test_ngtcp2_conn_path_validation) ||
       !CU_add_test(pSuite, "conn_early_data_sync_stream_data_limit",
                    test_ngtcp2_conn_early_data_sync_stream_data_limit) ||
-      !CU_add_test(pSuite, "conn_early_data_rejected",
-                   test_ngtcp2_conn_early_data_rejected) ||
+      !CU_add_test(pSuite, "conn_tls_early_data_rejected",
+                   test_ngtcp2_conn_tls_early_data_rejected) ||
       !CU_add_test(pSuite, "conn_keep_alive", test_ngtcp2_conn_keep_alive) ||
       !CU_add_test(pSuite, "conn_retire_stale_bound_dcid",
                    test_ngtcp2_conn_retire_stale_bound_dcid) ||

--- a/tests/ngtcp2_conn_test.c
+++ b/tests/ngtcp2_conn_test.c
@@ -8444,7 +8444,7 @@ void test_ngtcp2_conn_early_data_sync_stream_data_limit(void) {
   ngtcp2_conn_del(conn);
 }
 
-void test_ngtcp2_conn_early_data_rejected(void) {
+void test_ngtcp2_conn_tls_early_data_rejected(void) {
   ngtcp2_conn *conn;
   uint8_t buf[1024];
   ngtcp2_ssize spktlen;
@@ -8557,7 +8557,7 @@ void test_ngtcp2_conn_early_data_rejected(void) {
   CU_ASSERT(0 == rv);
 
   ngtcp2_conn_tls_handshake_completed(conn);
-  ngtcp2_conn_early_data_rejected(conn);
+  ngtcp2_conn_tls_early_data_rejected(conn);
   spktlen = ngtcp2_conn_write_pkt(conn, NULL, NULL, buf, sizeof(buf), ++t);
 
   CU_ASSERT(0 < spktlen);

--- a/tests/ngtcp2_conn_test.h
+++ b/tests/ngtcp2_conn_test.h
@@ -84,7 +84,7 @@ void test_ngtcp2_conn_rtb_reclaim_on_pto_datagram(void);
 void test_ngtcp2_conn_validate_ecn(void);
 void test_ngtcp2_conn_path_validation(void);
 void test_ngtcp2_conn_early_data_sync_stream_data_limit(void);
-void test_ngtcp2_conn_early_data_rejected(void);
+void test_ngtcp2_conn_tls_early_data_rejected(void);
 void test_ngtcp2_conn_keep_alive(void);
 void test_ngtcp2_conn_retire_stale_bound_dcid(void);
 void test_ngtcp2_conn_get_scid(void);


### PR DESCRIPTION
Rename following type/field/functions:

- ngtcp2_early_data_rejected -> ngtcp2_tls_early_data_rejected
- ngtcp2_callbacks.early_data_rejected -> tls_early_data_rejected
- ngtcp2_conn_early_data_rejected -> ngtcp2_conn_tls_early_data_rejected
- ngtcp2_conn_get_early_data_rejected -> ngtcp2_conn_get_tls_early_data_rejected