### PR TITLE
Rename ngtcp2_conn_is_in_closing_period and ngtcp2_conn_is_in_draining_period

### DIFF
--- a/examples/client.cc
+++ b/examples/client.cc
@@ -1553,8 +1553,8 @@ int Client::send_blocked_packet() {
 }
 
 int Client::handle_error() {
-  if (!conn_ || ngtcp2_conn_is_in_closing_period(conn_) ||
-      ngtcp2_conn_is_in_draining_period(conn_)) {
+  if (!conn_ || ngtcp2_conn_in_closing_period(conn_) ||
+      ngtcp2_conn_in_draining_period(conn_)) {
     return 0;
   }
 

--- a/examples/gtlssimpleclient.c
+++ b/examples/gtlssimpleclient.c
@@ -591,8 +591,8 @@ static void client_close(struct client *c) {
   ngtcp2_path_storage ps;
   uint8_t buf[1280];
 
-  if (ngtcp2_conn_is_in_closing_period(c->conn) ||
-      ngtcp2_conn_is_in_draining_period(c->conn)) {
+  if (ngtcp2_conn_in_closing_period(c->conn) ||
+      ngtcp2_conn_in_draining_period(c->conn)) {
     goto fin;
   }
 

--- a/examples/h09client.cc
+++ b/examples/h09client.cc
@@ -1466,8 +1466,8 @@ int Client::send_blocked_packet() {
 }
 
 int Client::handle_error() {
-  if (!conn_ || ngtcp2_conn_is_in_closing_period(conn_) ||
-      ngtcp2_conn_is_in_draining_period(conn_)) {
+  if (!conn_ || ngtcp2_conn_in_closing_period(conn_) ||
+      ngtcp2_conn_in_draining_period(conn_)) {
     return 0;
   }
 

--- a/examples/h09server.cc
+++ b/examples/h09server.cc
@@ -273,7 +273,7 @@ void close_waitcb(struct ev_loop *loop, ev_timer *w, int revents) {
   auto s = h->server();
   auto conn = h->conn();
 
-  if (ngtcp2_conn_is_in_closing_period(conn)) {
+  if (ngtcp2_conn_in_closing_period(conn)) {
     if (!config.quiet) {
       std::cerr << "Closing Period is over" << std::endl;
     }
@@ -281,7 +281,7 @@ void close_waitcb(struct ev_loop *loop, ev_timer *w, int revents) {
     s->remove(h);
     return;
   }
-  if (ngtcp2_conn_is_in_draining_period(conn)) {
+  if (ngtcp2_conn_in_draining_period(conn)) {
     if (!config.quiet) {
       std::cerr << "Draining Period is over" << std::endl;
     }
@@ -901,8 +901,8 @@ int Handler::handle_expiry() {
 }
 
 int Handler::on_write() {
-  if (ngtcp2_conn_is_in_closing_period(conn_) ||
-      ngtcp2_conn_is_in_draining_period(conn_)) {
+  if (ngtcp2_conn_in_closing_period(conn_) ||
+      ngtcp2_conn_in_draining_period(conn_)) {
     return 0;
   }
 
@@ -1184,8 +1184,8 @@ void Handler::start_draining_period() {
 }
 
 int Handler::start_closing_period() {
-  if (!conn_ || ngtcp2_conn_is_in_closing_period(conn_) ||
-      ngtcp2_conn_is_in_draining_period(conn_)) {
+  if (!conn_ || ngtcp2_conn_in_closing_period(conn_) ||
+      ngtcp2_conn_in_draining_period(conn_)) {
     return 0;
   }
 
@@ -1235,7 +1235,7 @@ int Handler::handle_error() {
     return -1;
   }
 
-  if (ngtcp2_conn_is_in_draining_period(conn_)) {
+  if (ngtcp2_conn_in_draining_period(conn_)) {
     return NETWORK_ERR_CLOSE_WAIT;
   }
 
@@ -1253,7 +1253,7 @@ int Handler::send_conn_close() {
 
   assert(conn_closebuf_ && conn_closebuf_->size());
   assert(conn_);
-  assert(!ngtcp2_conn_is_in_draining_period(conn_));
+  assert(!ngtcp2_conn_in_draining_period(conn_));
 
   auto path = ngtcp2_conn_get_path(conn_);
 
@@ -1874,7 +1874,7 @@ int Server::on_read(Endpoint &ep) {
 
     auto h = (*handler_it).second;
     auto conn = h->conn();
-    if (ngtcp2_conn_is_in_closing_period(conn)) {
+    if (ngtcp2_conn_in_closing_period(conn)) {
       // TODO do exponential backoff.
       switch (h->send_conn_close()) {
       case 0:
@@ -1884,7 +1884,7 @@ int Server::on_read(Endpoint &ep) {
       }
       continue;
     }
-    if (ngtcp2_conn_is_in_draining_period(conn)) {
+    if (ngtcp2_conn_in_draining_period(conn)) {
       continue;
     }
 

--- a/examples/server.cc
+++ b/examples/server.cc
@@ -573,7 +573,7 @@ void close_waitcb(struct ev_loop *loop, ev_timer *w, int revents) {
   auto s = h->server();
   auto conn = h->conn();
 
-  if (ngtcp2_conn_is_in_closing_period(conn)) {
+  if (ngtcp2_conn_in_closing_period(conn)) {
     if (!config.quiet) {
       std::cerr << "Closing Period is over" << std::endl;
     }
@@ -581,7 +581,7 @@ void close_waitcb(struct ev_loop *loop, ev_timer *w, int revents) {
     s->remove(h);
     return;
   }
-  if (ngtcp2_conn_is_in_draining_period(conn)) {
+  if (ngtcp2_conn_in_draining_period(conn)) {
     if (!config.quiet) {
       std::cerr << "Draining Period is over" << std::endl;
     }
@@ -1634,8 +1634,8 @@ int Handler::handle_expiry() {
 }
 
 int Handler::on_write() {
-  if (ngtcp2_conn_is_in_closing_period(conn_) ||
-      ngtcp2_conn_is_in_draining_period(conn_)) {
+  if (ngtcp2_conn_in_closing_period(conn_) ||
+      ngtcp2_conn_in_draining_period(conn_)) {
     return 0;
   }
 
@@ -1941,8 +1941,8 @@ void Handler::start_draining_period() {
 }
 
 int Handler::start_closing_period() {
-  if (!conn_ || ngtcp2_conn_is_in_closing_period(conn_) ||
-      ngtcp2_conn_is_in_draining_period(conn_)) {
+  if (!conn_ || ngtcp2_conn_in_closing_period(conn_) ||
+      ngtcp2_conn_in_draining_period(conn_)) {
     return 0;
   }
 
@@ -1992,7 +1992,7 @@ int Handler::handle_error() {
     return -1;
   }
 
-  if (ngtcp2_conn_is_in_draining_period(conn_)) {
+  if (ngtcp2_conn_in_draining_period(conn_)) {
     return NETWORK_ERR_CLOSE_WAIT;
   }
 
@@ -2010,7 +2010,7 @@ int Handler::send_conn_close() {
 
   assert(conn_closebuf_ && conn_closebuf_->size());
   assert(conn_);
-  assert(!ngtcp2_conn_is_in_draining_period(conn_));
+  assert(!ngtcp2_conn_in_draining_period(conn_));
 
   auto path = ngtcp2_conn_get_path(conn_);
 
@@ -2587,7 +2587,7 @@ int Server::on_read(Endpoint &ep) {
 
     auto h = (*handler_it).second;
     auto conn = h->conn();
-    if (ngtcp2_conn_is_in_closing_period(conn)) {
+    if (ngtcp2_conn_in_closing_period(conn)) {
       // TODO do exponential backoff.
       switch (h->send_conn_close()) {
       case 0:
@@ -2597,7 +2597,7 @@ int Server::on_read(Endpoint &ep) {
       }
       continue;
     }
-    if (ngtcp2_conn_is_in_draining_period(conn)) {
+    if (ngtcp2_conn_in_draining_period(conn)) {
       continue;
     }
 

--- a/examples/simpleclient.c
+++ b/examples/simpleclient.c
@@ -552,8 +552,8 @@ static void client_close(struct client *c) {
   ngtcp2_path_storage ps;
   uint8_t buf[1280];
 
-  if (ngtcp2_conn_is_in_closing_period(c->conn) ||
-      ngtcp2_conn_is_in_draining_period(c->conn)) {
+  if (ngtcp2_conn_in_closing_period(c->conn) ||
+      ngtcp2_conn_in_draining_period(c->conn)) {
     goto fin;
   }
 

--- a/lib/includes/ngtcp2/ngtcp2.h
+++ b/lib/includes/ngtcp2/ngtcp2.h
@@ -4673,18 +4673,18 @@ NGTCP2_EXTERN ngtcp2_ssize ngtcp2_conn_writev_datagram_versioned(
 /**
  * @function
  *
- * `ngtcp2_conn_is_in_closing_period` returns nonzero if |conn| is in
- * the closing period.
+ * `ngtcp2_conn_in_closing_period` returns nonzero if |conn| is in the
+ * closing period.
  */
-NGTCP2_EXTERN int ngtcp2_conn_is_in_closing_period(ngtcp2_conn *conn);
+NGTCP2_EXTERN int ngtcp2_conn_in_closing_period(ngtcp2_conn *conn);
 
 /**
  * @function
  *
- * `ngtcp2_conn_is_in_draining_period` returns nonzero if |conn| is in
+ * `ngtcp2_conn_in_draining_period` returns nonzero if |conn| is in
  * the draining period.
  */
-NGTCP2_EXTERN int ngtcp2_conn_is_in_draining_period(ngtcp2_conn *conn);
+NGTCP2_EXTERN int ngtcp2_conn_in_draining_period(ngtcp2_conn *conn);
 
 /**
  * @function

--- a/lib/ngtcp2_conn.c
+++ b/lib/ngtcp2_conn.c
@@ -12442,11 +12442,11 @@ ngtcp2_ssize ngtcp2_conn_write_connection_close_versioned(
   }
 }
 
-int ngtcp2_conn_is_in_closing_period(ngtcp2_conn *conn) {
+int ngtcp2_conn_in_closing_period(ngtcp2_conn *conn) {
   return conn->state == NGTCP2_CS_CLOSING;
 }
 
-int ngtcp2_conn_is_in_draining_period(ngtcp2_conn *conn) {
+int ngtcp2_conn_in_draining_period(ngtcp2_conn *conn) {
   return conn->state == NGTCP2_CS_DRAINING;
 }
 


### PR DESCRIPTION
Rename the following functions:

- ngtcp2_conn_is_in_closing_period -> ngtcp2_conn_in_closing_period
- ngtcp2_conn_is_in_draining_period -> ngtcp2_conn_in_draining_period