### PR TITLE
Rename ngtcp2_conn_decode_*_transport_params

### DIFF
--- a/crypto/boringssl/boringssl.c
+++ b/crypto/boringssl/boringssl.c
@@ -469,7 +469,7 @@ int ngtcp2_crypto_set_remote_transport_params(ngtcp2_conn *conn, void *tls) {
 
   SSL_get_peer_quic_transport_params(ssl, &tp, &tplen);
 
-  rv = ngtcp2_conn_decode_remote_transport_params(conn, tp, tplen);
+  rv = ngtcp2_conn_decode_and_set_remote_transport_params(conn, tp, tplen);
   if (rv != 0) {
     ngtcp2_conn_set_tls_error(conn, rv);
     return -1;

--- a/crypto/gnutls/gnutls.c
+++ b/crypto/gnutls/gnutls.c
@@ -590,7 +590,7 @@ static int tp_recv_func(gnutls_session_t session, const uint8_t *data,
   ngtcp2_conn *conn = conn_ref->get_conn(conn_ref);
   int rv;
 
-  rv = ngtcp2_conn_decode_remote_transport_params(conn, data, datalen);
+  rv = ngtcp2_conn_decode_and_set_remote_transport_params(conn, data, datalen);
   if (rv != 0) {
     ngtcp2_conn_set_tls_error(conn, rv);
     return -1;

--- a/crypto/includes/ngtcp2/ngtcp2_crypto.h
+++ b/crypto/includes/ngtcp2/ngtcp2_crypto.h
@@ -370,7 +370,7 @@ ngtcp2_crypto_hp_mask_cb(uint8_t *dest, const ngtcp2_crypto_cipher *hp,
  * function retrieves a remote QUIC transport parameters extension
  * from an object obtained by `ngtcp2_conn_get_tls_native_handle` and
  * sets it to |conn| by calling
- * `ngtcp2_conn_decode_remote_transport_params`.
+ * `ngtcp2_conn_decode_and_set_remote_transport_params`.
  *
  * This function returns 0 if it succeeds, or -1.
  */
@@ -418,7 +418,7 @@ NGTCP2_EXTERN int ngtcp2_crypto_derive_and_install_rx_key(
  * function retrieves a remote QUIC transport parameters extension
  * from an object obtained by `ngtcp2_conn_get_tls_native_handle` and
  * sets it to |conn| by calling
- * `ngtcp2_conn_decode_remote_transport_params`.
+ * `ngtcp2_conn_decode_and_set_remote_transport_params`.
  *
  * This function returns 0 if it succeeds, or -1.
  */

--- a/crypto/openssl/openssl.c
+++ b/crypto/openssl/openssl.c
@@ -653,7 +653,7 @@ int ngtcp2_crypto_set_remote_transport_params(ngtcp2_conn *conn, void *tls) {
 
   SSL_get_peer_quic_transport_params(ssl, &tp, &tplen);
 
-  rv = ngtcp2_conn_decode_remote_transport_params(conn, tp, tplen);
+  rv = ngtcp2_conn_decode_and_set_remote_transport_params(conn, tp, tplen);
   if (rv != 0) {
     ngtcp2_conn_set_tls_error(conn, rv);
     return -1;

--- a/crypto/picotls/picotls.c
+++ b/crypto/picotls/picotls.c
@@ -554,8 +554,8 @@ int ngtcp2_crypto_picotls_collected_extensions(
     conn_ref = *ptls_get_data_ptr(ptls);
     conn = conn_ref->get_conn(conn_ref);
 
-    rv = ngtcp2_conn_decode_remote_transport_params(conn, extensions->data.base,
-                                                    extensions->data.len);
+    rv = ngtcp2_conn_decode_and_set_remote_transport_params(
+        conn, extensions->data.base, extensions->data.len);
     if (rv != 0) {
       ngtcp2_conn_set_tls_error(conn, rv);
       return -1;

--- a/crypto/wolfssl/wolfssl.c
+++ b/crypto/wolfssl/wolfssl.c
@@ -363,7 +363,7 @@ int ngtcp2_crypto_set_remote_transport_params(ngtcp2_conn *conn, void *tls) {
   wolfSSL_get_peer_quic_transport_params(ssl, &tp, &tplen);
   DEBUG_MSG("WOLFSSL: get peer transport params, len=%lu\n", tplen);
 
-  rv = ngtcp2_conn_decode_remote_transport_params(conn, tp, tplen);
+  rv = ngtcp2_conn_decode_and_set_remote_transport_params(conn, tp, tplen);
   if (rv != 0) {
     DEBUG_MSG("WOLFSSL: decode peer transport params failed, rv=%d\n", rv);
     ngtcp2_conn_set_tls_error(conn, rv);

--- a/doc/source/programmers-guide.rst
+++ b/doc/source/programmers-guide.rst
@@ -316,11 +316,11 @@ parameters received from a server in the previous connection.
 `ngtcp2_conn_encode_0rtt_transport_params` returns the encoded QUIC
 transport parameters that include these values.  When sending 0-RTT
 data, the remembered transport parameters should be set via
-`ngtcp2_conn_decode_0rtt_transport_params`.  Then client can open
-streams with `ngtcp2_conn_open_bidi_streams` or
+`ngtcp2_conn_decode_and_set_0rtt_transport_params`.  Then client can
+open streams with `ngtcp2_conn_open_bidi_streams` or
 `ngtcp2_conn_open_uni_stream`.  Note that
-`ngtcp2_conn_decode_0rtt_transport_params` does not invoke neither
-:member:`ngtcp2_callbacks.extend_max_local_streams_bidi` nor
+`ngtcp2_conn_decode_and_set_0rtt_transport_params` does not invoke
+neither :member:`ngtcp2_callbacks.extend_max_local_streams_bidi` nor
 :member:`ngtcp2_callbacks.extend_max_local_streams_uni`.
 
 Other than that, there is no difference between 0-RTT and 1-RTT data

--- a/examples/client.cc
+++ b/examples/client.cc
@@ -818,11 +818,11 @@ int Client::init(int fd, const Address &local_addr, const Address &remote_addr,
     if (!params) {
       early_data_ = false;
     } else {
-      auto rv = ngtcp2_conn_decode_0rtt_transport_params(
+      auto rv = ngtcp2_conn_decode_and_set_0rtt_transport_params(
           conn_, reinterpret_cast<const uint8_t *>(params->data()),
           params->size());
       if (rv != 0) {
-        std::cerr << "ngtcp2_conn_decode_0rtt_transport_params: "
+        std::cerr << "ngtcp2_conn_decode_and_set_0rtt_transport_params: "
                   << ngtcp2_strerror(rv) << std::endl;
         early_data_ = false;
       } else if (make_stream_early() != 0) {

--- a/examples/h09client.cc
+++ b/examples/h09client.cc
@@ -763,11 +763,11 @@ int Client::init(int fd, const Address &local_addr, const Address &remote_addr,
     if (!params) {
       early_data_ = false;
     } else {
-      auto rv = ngtcp2_conn_decode_0rtt_transport_params(
+      auto rv = ngtcp2_conn_decode_and_set_0rtt_transport_params(
           conn_, reinterpret_cast<const uint8_t *>(params->data()),
           params->size());
       if (rv != 0) {
-        std::cerr << "ngtcp2_conn_decode_0rtt_transport_params: "
+        std::cerr << "ngtcp2_conn_decode_and_set_0rtt_transport_params:"
                   << ngtcp2_strerror(rv) << std::endl;
         early_data_ = false;
       } else if (make_stream_early() != 0) {

--- a/lib/includes/ngtcp2/ngtcp2.h
+++ b/lib/includes/ngtcp2/ngtcp2.h
@@ -4069,9 +4069,9 @@ NGTCP2_EXTERN ngtcp2_duration ngtcp2_conn_get_pto(ngtcp2_conn *conn);
 /**
  * @function
  *
- * `ngtcp2_conn_decode_remote_transport_params` decodes QUIC transport
- * parameters from the buffer pointed by |data| of length |datalen|,
- * and sets the result to |conn|.
+ * `ngtcp2_conn_decode_and_set_remote_transport_params` decodes QUIC
+ * transport parameters from the buffer pointed by |data| of length
+ * |datalen|, and sets the result to |conn|.
  *
  * This function returns 0 if it succeeds, or one of the following
  * negative error codes:
@@ -4087,9 +4087,8 @@ NGTCP2_EXTERN ngtcp2_duration ngtcp2_conn_get_pto(ngtcp2_conn *conn);
  * :macro:`NGTCP2_ERR_CALLBACK_FAILURE`
  *     User callback failed
  */
-NGTCP2_EXTERN int
-ngtcp2_conn_decode_remote_transport_params(ngtcp2_conn *conn,
-                                           const uint8_t *data, size_t datalen);
+NGTCP2_EXTERN int ngtcp2_conn_decode_and_set_remote_transport_params(
+    ngtcp2_conn *conn, const uint8_t *data, size_t datalen);
 
 /**
  * @function
@@ -4144,12 +4143,12 @@ ngtcp2_ssize ngtcp2_conn_encode_0rtt_transport_params(ngtcp2_conn *conn,
 /**
  * @function
  *
- * `ngtcp2_conn_decode_0rtt_transport_params` decodes QUIC transport
- * parameters from |data| of length |datalen|, which is assumed to be
- * the parameters received from the server in the previous connection,
- * and sets it to |conn|.  These parameters are used to send 0-RTT
- * data.  QUIC requires that client application should remember
- * transport parameters along with a session ticket.
+ * `ngtcp2_conn_decode_and_set_0rtt_transport_params` decodes QUIC
+ * transport parameters from |data| of length |datalen|, which is
+ * assumed to be the parameters received from the server in the
+ * previous connection, and sets it to |conn|.  These parameters are
+ * used to send 0-RTT data.  QUIC requires that client application
+ * should remember transport parameters along with a session ticket.
  *
  * At least following fields should be included:
  *
@@ -4173,9 +4172,8 @@ ngtcp2_ssize ngtcp2_conn_encode_0rtt_transport_params(ngtcp2_conn *conn,
  * :macro:`NGTCP2_ERR_MALFORMED_TRANSPORT_PARAM`
  *     The input is malformed.
  */
-NGTCP2_EXTERN int ngtcp2_conn_decode_0rtt_transport_params(ngtcp2_conn *conn,
-                                                           const uint8_t *data,
-                                                           size_t datalen);
+NGTCP2_EXTERN int ngtcp2_conn_decode_and_set_0rtt_transport_params(
+    ngtcp2_conn *conn, const uint8_t *data, size_t datalen);
 
 /**
  * @function
@@ -4231,9 +4229,9 @@ NGTCP2_EXTERN ngtcp2_ssize ngtcp2_conn_encode_local_transport_params(
  *
  * Application can call this function before handshake completes.  For
  * 0-RTT packet, application can call this function after calling
- * `ngtcp2_conn_decode_0rtt_transport_params`.  For 1-RTT packet,
- * application can call this function after calling
- * `ngtcp2_conn_decode_remote_transport_params` and
+ * `ngtcp2_conn_decode_and_set_0rtt_transport_params`.  For 1-RTT
+ * packet, application can call this function after calling
+ * `ngtcp2_conn_decode_and_set_remote_transport_params` and
  * `ngtcp2_conn_install_tx_key`.  If ngtcp2 crypto support library is
  * used, application can call this function after calling
  * `ngtcp2_crypto_derive_and_install_tx_key` for 1-RTT packet.
@@ -4259,9 +4257,9 @@ NGTCP2_EXTERN int ngtcp2_conn_open_bidi_stream(ngtcp2_conn *conn,
  *
  * Application can call this function before handshake completes.  For
  * 0-RTT packet, application can call this function after calling
- * `ngtcp2_conn_decode_0rtt_transport_params`.  For 1-RTT packet,
- * application can call this function after calling
- * `ngtcp2_conn_decode_remote_transport_params` and
+ * `ngtcp2_conn_decode_and_set_0rtt_transport_params`.  For 1-RTT
+ * packet, application can call this function after calling
+ * `ngtcp2_conn_decode_and_set_remote_transport_params` and
  * `ngtcp2_conn_install_tx_key`.  If ngtcp2 crypto support library is
  * used, application can call this function after calling
  * `ngtcp2_crypto_derive_and_install_tx_key` for 1-RTT packet.

--- a/lib/ngtcp2_conn.c
+++ b/lib/ngtcp2_conn.c
@@ -11371,9 +11371,9 @@ int ngtcp2_conn_set_remote_transport_params(
   return 0;
 }
 
-int ngtcp2_conn_decode_remote_transport_params(ngtcp2_conn *conn,
-                                               const uint8_t *data,
-                                               size_t datalen) {
+int ngtcp2_conn_decode_and_set_remote_transport_params(ngtcp2_conn *conn,
+                                                       const uint8_t *data,
+                                                       size_t datalen) {
   ngtcp2_transport_params params;
   int rv;
 
@@ -11429,9 +11429,9 @@ ngtcp2_ssize ngtcp2_conn_encode_0rtt_transport_params(ngtcp2_conn *conn,
   return ngtcp2_transport_params_encode(dest, destlen, &params);
 }
 
-int ngtcp2_conn_decode_0rtt_transport_params(ngtcp2_conn *conn,
-                                             const uint8_t *data,
-                                             size_t datalen) {
+int ngtcp2_conn_decode_and_set_0rtt_transport_params(ngtcp2_conn *conn,
+                                                     const uint8_t *data,
+                                                     size_t datalen) {
   ngtcp2_transport_params params;
   int rv;
 

--- a/tests/ngtcp2_conn_test.c
+++ b/tests/ngtcp2_conn_test.c
@@ -9564,7 +9564,8 @@ void test_ngtcp2_conn_encode_0rtt_transport_params(void) {
   ngtcp2_conn_install_initial_key(conn, &aead_ctx, null_iv, &hp_ctx, &aead_ctx,
                                   null_iv, &hp_ctx, sizeof(null_iv));
 
-  rv = ngtcp2_conn_decode_0rtt_transport_params(conn, buf, (size_t)slen);
+  rv =
+      ngtcp2_conn_decode_and_set_0rtt_transport_params(conn, buf, (size_t)slen);
 
   CU_ASSERT(0 == rv);
   CU_ASSERT(early_params.initial_max_streams_bidi ==


### PR DESCRIPTION
Rename the following functions:

- ngtcp2_conn_decode_0rtt_transport_params -> ngtcp2_conn_decode_and_set_0rtt_transport_params

- ngtcp2_conn_decode_remote_transport_params -> ngtcp2_conn_decode_and_set_remote_transport_params

Fixes #740 