### PR TITLE
Tweak crypto helper library API

### DIFF
--- a/crypto/includes/ngtcp2/ngtcp2_crypto_picotls.h
+++ b/crypto/includes/ngtcp2/ngtcp2_crypto_picotls.h
@@ -36,8 +36,8 @@ extern "C" {
 /**
  * @struct
  *
- * :type:`ngtcp2_crypto_picotls_ctx` contains per-connection state
- * of Picotls objects and must be an object to bet set to
+ * :type:`ngtcp2_crypto_picotls_ctx` contains per-connection state of
+ * Picotls objects and must be an object to bet set to
  * `ngtcp2_conn_set_tls_native_handle`.
  */
 typedef struct ngtcp2_crypto_picotls_ctx {
@@ -206,7 +206,7 @@ ngtcp2_crypto_picotls_configure_client_session(ngtcp2_crypto_picotls_ctx *cptls,
  *
  * `ngtcp2_crypto_picotls_deconfigure_session` frees the resources
  * allocated for |cptls| during QUIC connection.  It frees the
- * following data using :manpage:`free(3)`.
+ * following data using :manpage:`free(3)`:
  *
  * - handshake_properties.max_early_data_size
  * - handshake_properties.additional_extensions[0].data.base

--- a/crypto/shared.c
+++ b/crypto/shared.c
@@ -64,8 +64,6 @@ int ngtcp2_crypto_hkdf_expand_label(uint8_t *dest, size_t destlen,
                                    (size_t)(p - info));
 }
 
-#define NGTCP2_CRYPTO_INITIAL_SECRETLEN 32
-
 int ngtcp2_crypto_derive_initial_secrets(uint8_t *rx_secret, uint8_t *tx_secret,
                                          uint8_t *initial_secret,
                                          uint32_t version,

--- a/crypto/shared.h
+++ b/crypto/shared.h
@@ -73,6 +73,30 @@
 #define NGTCP2_CRYPTO_MAX_DECRYPTION_FAILURE_AES_CCM (2965820ULL)
 
 /**
+ * @macro
+ *
+ * :macro:`NGTCP2_CRYPTO_INITIAL_SECRETLEN` is the length of secret
+ * for Initial packets.
+ */
+#define NGTCP2_CRYPTO_INITIAL_SECRETLEN 32
+
+/**
+ * @macro
+ *
+ * :macro:`NGTCP2_CRYPTO_INITIAL_KEYLEN` is the length of key for
+ * Initial packets.
+ */
+#define NGTCP2_CRYPTO_INITIAL_KEYLEN 16
+
+/**
+ * @macro
+ *
+ * :macro:`NGTCP2_CRYPTO_INITIAL_IVLEN` is the length of IV for
+ * Initial packets.
+ */
+#define NGTCP2_CRYPTO_INITIAL_IVLEN 12
+
+/**
  * @function
  *
  * `ngtcp2_crypto_ctx_initial` initializes |ctx| for Initial packet
@@ -105,6 +129,25 @@ ngtcp2_crypto_aead *ngtcp2_crypto_aead_init(ngtcp2_crypto_aead *aead,
  * AEAD_AES_128_GCM for Retry packet integrity protection.
  */
 ngtcp2_crypto_aead *ngtcp2_crypto_aead_retry(ngtcp2_crypto_aead *aead);
+
+/**
+ * @enum
+ *
+ * :type:`ngtcp2_crypto_side` indicates which side the application
+ * implements; client or server.
+ */
+typedef enum ngtcp2_crypto_side {
+  /**
+   * :enum:`NGTCP2_CRYPTO_SIDE_CLIENT` indicates that the application
+   * is client.
+   */
+  NGTCP2_CRYPTO_SIDE_CLIENT,
+  /**
+   * :enum:`NGTCP2_CRYPTO_SIDE_SERVER` indicates that the application
+   * is server.
+   */
+  NGTCP2_CRYPTO_SIDE_SERVER
+} ngtcp2_crypto_side;
 
 /**
  * @function
@@ -346,5 +389,19 @@ ngtcp2_crypto_aead *ngtcp2_crypto_aead_aes_128_gcm(ngtcp2_crypto_aead *aead);
  * This function returns 0 if it succeeds, or -1.
  */
 int ngtcp2_crypto_random(uint8_t *data, size_t datalen);
+
+/**
+ * @function
+ *
+ * `ngtcp2_crypto_hkdf_expand_label` performs HKDF expand label.  The
+ * result is |destlen| bytes long, and is stored to the buffer pointed
+ * by |dest|.
+ *
+ * This function returns 0 if it succeeds, or -1.
+ */
+int ngtcp2_crypto_hkdf_expand_label(uint8_t *dest, size_t destlen,
+                                    const ngtcp2_crypto_md *md,
+                                    const uint8_t *secret, size_t secretlen,
+                                    const uint8_t *label, size_t labellen);
 
 #endif /* NGTCP2_SHARED_H */

--- a/lib/includes/ngtcp2/ngtcp2.h
+++ b/lib/includes/ngtcp2/ngtcp2.h
@@ -2073,7 +2073,8 @@ typedef struct ngtcp2_crypto_cipher_ctx {
  * crypto related objects in one place.  Use
  * `ngtcp2_crypto_ctx_initial` to initialize this struct for Initial
  * packet encryption.  For Handshake and 1-RTT packets, use
- * `ngtcp2_crypto_ctx_tls`.
+ * `ngtcp2_crypto_ctx_tls`.  For 0-RTT packets, use
+ * `ngtcp2_crypto_ctx_tls_early`.
  */
 typedef struct ngtcp2_crypto_ctx {
   /**


### PR DESCRIPTION
Update documentation.

Hide following macros/enums/functions:

macros

- NGTCP2_CRYPTO_INITIAL_SECRETLEN
- NGTCP2_CRYPTO_INITIAL_KEYLEN
- NGTCP2_CRYPTO_INITIAL_IVLEN

function

- ngtcp2_crypto_hkdf_expand_label

enum

- ngtcp2_crypto_side