### PR TITLE
Add flags to ngtcp2_conn_shutdown_stream

### DIFF
--- a/examples/client.cc
+++ b/examples/client.cc
@@ -1920,7 +1920,7 @@ int http_stop_sending(nghttp3_conn *conn, int64_t stream_id,
 
 int Client::stop_sending(int64_t stream_id, uint64_t app_error_code) {
   if (auto rv =
-          ngtcp2_conn_shutdown_stream_read(conn_, stream_id, app_error_code);
+          ngtcp2_conn_shutdown_stream_read(conn_, 0, stream_id, app_error_code);
       rv != 0) {
     std::cerr << "ngtcp2_conn_shutdown_stream_read: " << ngtcp2_strerror(rv)
               << std::endl;
@@ -1942,8 +1942,8 @@ int http_reset_stream(nghttp3_conn *conn, int64_t stream_id,
 } // namespace
 
 int Client::reset_stream(int64_t stream_id, uint64_t app_error_code) {
-  if (auto rv =
-          ngtcp2_conn_shutdown_stream_write(conn_, stream_id, app_error_code);
+  if (auto rv = ngtcp2_conn_shutdown_stream_write(conn_, 0, stream_id,
+                                                  app_error_code);
       rv != 0) {
     std::cerr << "ngtcp2_conn_shutdown_stream_write: " << ngtcp2_strerror(rv)
               << std::endl;

--- a/examples/h09server.cc
+++ b/examples/h09server.cc
@@ -1344,7 +1344,7 @@ int Handler::recv_stream_data(uint32_t flags, int64_t stream_id,
         http_parser_execute(&stream->htp, &htp_settings,
                             reinterpret_cast<const char *>(data), datalen);
     if (nread != datalen) {
-      if (auto rv = ngtcp2_conn_shutdown_stream(conn_, stream_id,
+      if (auto rv = ngtcp2_conn_shutdown_stream(conn_, 0, stream_id,
                                                 /* app error code */ 1);
           rv != 0) {
         std::cerr << "ngtcp2_conn_shutdown_stream: " << ngtcp2_strerror(rv)
@@ -1423,7 +1423,7 @@ int Handler::on_stream_close(int64_t stream_id, uint64_t app_error_code) {
 }
 
 void Handler::shutdown_read(int64_t stream_id, int app_error_code) {
-  ngtcp2_conn_shutdown_stream_read(conn_, stream_id, app_error_code);
+  ngtcp2_conn_shutdown_stream_read(conn_, 0, stream_id, app_error_code);
 }
 
 void Handler::add_sendq(Stream *stream) { sendq_.emplace(stream); }

--- a/examples/server.cc
+++ b/examples/server.cc
@@ -1198,7 +1198,7 @@ int http_stop_sending(nghttp3_conn *conn, int64_t stream_id,
 
 int Handler::http_stop_sending(int64_t stream_id, uint64_t app_error_code) {
   if (auto rv =
-          ngtcp2_conn_shutdown_stream_read(conn_, stream_id, app_error_code);
+          ngtcp2_conn_shutdown_stream_read(conn_, 0, stream_id, app_error_code);
       rv != 0) {
     std::cerr << "ngtcp2_conn_shutdown_stream_read: " << ngtcp2_strerror(rv)
               << std::endl;
@@ -1220,8 +1220,8 @@ int http_reset_stream(nghttp3_conn *conn, int64_t stream_id,
 } // namespace
 
 int Handler::http_reset_stream(int64_t stream_id, uint64_t app_error_code) {
-  if (auto rv =
-          ngtcp2_conn_shutdown_stream_write(conn_, stream_id, app_error_code);
+  if (auto rv = ngtcp2_conn_shutdown_stream_write(conn_, 0, stream_id,
+                                                  app_error_code);
       rv != 0) {
     std::cerr << "ngtcp2_conn_shutdown_stream_write: " << ngtcp2_strerror(rv)
               << std::endl;
@@ -2138,7 +2138,7 @@ int Handler::on_stream_close(int64_t stream_id, uint64_t app_error_code) {
 }
 
 void Handler::shutdown_read(int64_t stream_id, int app_error_code) {
-  ngtcp2_conn_shutdown_stream_read(conn_, stream_id, app_error_code);
+  ngtcp2_conn_shutdown_stream_read(conn_, 0, stream_id, app_error_code);
 }
 
 namespace {

--- a/lib/includes/ngtcp2/ngtcp2.h
+++ b/lib/includes/ngtcp2/ngtcp2.h
@@ -4293,13 +4293,15 @@ NGTCP2_EXTERN int ngtcp2_conn_open_uni_stream(ngtcp2_conn *conn,
  * |stream_id| refers to a remote unidirectional stream, this function
  * only shutdowns read side of the stream.
  *
+ * |flags| is currently unused, and should be set to 0.
+ *
  * This function returns 0 if it succeeds, or one of the following
  * negative error codes:
  *
  * :macro:`NGTCP2_ERR_NOMEM`
  *     Out of memory
  */
-NGTCP2_EXTERN int ngtcp2_conn_shutdown_stream(ngtcp2_conn *conn,
+NGTCP2_EXTERN int ngtcp2_conn_shutdown_stream(ngtcp2_conn *conn, uint32_t flags,
                                               int64_t stream_id,
                                               uint64_t app_error_code);
 
@@ -4313,6 +4315,8 @@ NGTCP2_EXTERN int ngtcp2_conn_shutdown_stream(ngtcp2_conn *conn,
  * remote endpoint.  It discards all data which has not been
  * acknowledged yet.
  *
+ * |flags| is currently unused, and should be set to 0.
+ *
  * This function returns 0 if it succeeds, or one of the following
  * negative error codes:
  *
@@ -4322,6 +4326,7 @@ NGTCP2_EXTERN int ngtcp2_conn_shutdown_stream(ngtcp2_conn *conn,
  *     |stream_id| refers to a remote unidirectional stream.
  */
 NGTCP2_EXTERN int ngtcp2_conn_shutdown_stream_write(ngtcp2_conn *conn,
+                                                    uint32_t flags,
                                                     int64_t stream_id,
                                                     uint64_t app_error_code);
 
@@ -4334,6 +4339,8 @@ NGTCP2_EXTERN int ngtcp2_conn_shutdown_stream_write(ngtcp2_conn *conn,
  * this function succeeds, no further application data is forwarded to
  * an application layer.
  *
+ * |flags| is currently unused, and should be set to 0.
+ *
  * This function returns 0 if it succeeds, or one of the following
  * negative error codes:
  *
@@ -4343,6 +4350,7 @@ NGTCP2_EXTERN int ngtcp2_conn_shutdown_stream_write(ngtcp2_conn *conn,
  *     |stream_id| refers to a local unidirectional stream.
  */
 NGTCP2_EXTERN int ngtcp2_conn_shutdown_stream_read(ngtcp2_conn *conn,
+                                                   uint32_t flags,
                                                    int64_t stream_id,
                                                    uint64_t app_error_code);
 

--- a/lib/ngtcp2_conn.c
+++ b/lib/ngtcp2_conn.c
@@ -12555,10 +12555,11 @@ static int conn_shutdown_stream_read(ngtcp2_conn *conn, ngtcp2_strm *strm,
   return conn_stop_sending(conn, strm, app_error_code);
 }
 
-int ngtcp2_conn_shutdown_stream(ngtcp2_conn *conn, int64_t stream_id,
-                                uint64_t app_error_code) {
+int ngtcp2_conn_shutdown_stream(ngtcp2_conn *conn, uint32_t flags,
+                                int64_t stream_id, uint64_t app_error_code) {
   int rv;
   ngtcp2_strm *strm;
+  (void)flags;
 
   strm = ngtcp2_conn_find_stream(conn, stream_id);
   if (strm == NULL) {
@@ -12582,9 +12583,11 @@ int ngtcp2_conn_shutdown_stream(ngtcp2_conn *conn, int64_t stream_id,
   return 0;
 }
 
-int ngtcp2_conn_shutdown_stream_write(ngtcp2_conn *conn, int64_t stream_id,
+int ngtcp2_conn_shutdown_stream_write(ngtcp2_conn *conn, uint32_t flags,
+                                      int64_t stream_id,
                                       uint64_t app_error_code) {
   ngtcp2_strm *strm;
+  (void)flags;
 
   if (!bidi_stream(stream_id) && !conn_local_stream(conn, stream_id)) {
     return NGTCP2_ERR_INVALID_ARGUMENT;
@@ -12598,9 +12601,11 @@ int ngtcp2_conn_shutdown_stream_write(ngtcp2_conn *conn, int64_t stream_id,
   return conn_shutdown_stream_write(conn, strm, app_error_code);
 }
 
-int ngtcp2_conn_shutdown_stream_read(ngtcp2_conn *conn, int64_t stream_id,
+int ngtcp2_conn_shutdown_stream_read(ngtcp2_conn *conn, uint32_t flags,
+                                     int64_t stream_id,
                                      uint64_t app_error_code) {
   ngtcp2_strm *strm;
+  (void)flags;
 
   if (!bidi_stream(stream_id) && conn_local_stream(conn, stream_id)) {
     return NGTCP2_ERR_INVALID_ARGUMENT;

--- a/tests/ngtcp2_conn_test.c
+++ b/tests/ngtcp2_conn_test.c
@@ -514,7 +514,7 @@ recv_stream_data_shutdown_stream_read(ngtcp2_conn *conn, uint32_t flags,
   recv_stream_data(conn, flags, stream_id, offset, data, datalen, user_data,
                    stream_user_data);
 
-  rv = ngtcp2_conn_shutdown_stream_read(conn, stream_id, NGTCP2_APP_ERR01);
+  rv = ngtcp2_conn_shutdown_stream_read(conn, 0, stream_id, NGTCP2_APP_ERR01);
   if (rv != 0) {
     return NGTCP2_ERR_CALLBACK_FAILURE;
   }
@@ -1451,7 +1451,7 @@ void test_ngtcp2_conn_shutdown_stream_write(void) {
   /* Stream not found */
   setup_default_server(&conn);
 
-  rv = ngtcp2_conn_shutdown_stream_write(conn, 4, NGTCP2_APP_ERR01);
+  rv = ngtcp2_conn_shutdown_stream_write(conn, 0, 4, NGTCP2_APP_ERR01);
 
   CU_ASSERT(0 == rv);
 
@@ -1464,7 +1464,7 @@ void test_ngtcp2_conn_shutdown_stream_write(void) {
   ngtcp2_conn_write_stream(conn, NULL, NULL, buf, sizeof(buf), NULL,
                            NGTCP2_WRITE_STREAM_FLAG_NONE, stream_id, null_data,
                            1239, 1);
-  rv = ngtcp2_conn_shutdown_stream_write(conn, stream_id, NGTCP2_APP_ERR01);
+  rv = ngtcp2_conn_shutdown_stream_write(conn, 0, stream_id, NGTCP2_APP_ERR01);
 
   CU_ASSERT(0 == rv);
 
@@ -1535,7 +1535,7 @@ void test_ngtcp2_conn_shutdown_stream_write(void) {
   CU_ASSERT(0 == rv);
   CU_ASSERT(NULL != ngtcp2_conn_find_stream(conn, stream_id));
 
-  rv = ngtcp2_conn_shutdown_stream_write(conn, stream_id, NGTCP2_APP_ERR01);
+  rv = ngtcp2_conn_shutdown_stream_write(conn, 0, stream_id, NGTCP2_APP_ERR01);
 
   CU_ASSERT(0 == rv);
   CU_ASSERT(NULL != ngtcp2_conn_find_stream(conn, stream_id));
@@ -1597,7 +1597,7 @@ void test_ngtcp2_conn_shutdown_stream_write(void) {
 
   CU_ASSERT(0 == rv);
 
-  rv = ngtcp2_conn_shutdown_stream_write(conn, stream_id, NGTCP2_APP_ERR01);
+  rv = ngtcp2_conn_shutdown_stream_write(conn, 0, stream_id, NGTCP2_APP_ERR01);
 
   CU_ASSERT(0 == rv);
 
@@ -1683,7 +1683,7 @@ void test_ngtcp2_conn_recv_reset_stream(void) {
 
   ngtcp2_conn_write_stream(conn, NULL, NULL, buf, sizeof(buf), NULL,
                            NGTCP2_WRITE_STREAM_FLAG_NONE, 4, null_data, 354, 2);
-  ngtcp2_conn_shutdown_stream_read(conn, 4, NGTCP2_APP_ERR01);
+  ngtcp2_conn_shutdown_stream_read(conn, 0, 4, NGTCP2_APP_ERR01);
   ngtcp2_conn_write_pkt(conn, NULL, NULL, buf, sizeof(buf), 3);
 
   fr.type = NGTCP2_FRAME_RESET_STREAM;
@@ -1720,7 +1720,7 @@ void test_ngtcp2_conn_recv_reset_stream(void) {
 
   ngtcp2_conn_write_stream(conn, NULL, NULL, buf, sizeof(buf), NULL,
                            NGTCP2_WRITE_STREAM_FLAG_NONE, 4, null_data, 354, 2);
-  ngtcp2_conn_shutdown_stream_write(conn, 4, NGTCP2_APP_ERR01);
+  ngtcp2_conn_shutdown_stream_write(conn, 0, 4, NGTCP2_APP_ERR01);
   ngtcp2_conn_write_pkt(conn, NULL, NULL, buf, sizeof(buf), 3);
 
   fr.type = NGTCP2_FRAME_RESET_STREAM;
@@ -2135,7 +2135,7 @@ void test_ngtcp2_conn_recv_reset_stream(void) {
 
   ngtcp2_conn_write_stream(conn, NULL, NULL, buf, sizeof(buf), NULL,
                            NGTCP2_WRITE_STREAM_FLAG_NONE, 4, null_data, 354, 2);
-  ngtcp2_conn_shutdown_stream_read(conn, 4, NGTCP2_APP_ERR01);
+  ngtcp2_conn_shutdown_stream_read(conn, 0, 4, NGTCP2_APP_ERR01);
   ngtcp2_conn_write_pkt(conn, NULL, NULL, buf, sizeof(buf), 3);
 
   CU_ASSERT(128 * 1024 + 956 == conn->rx.unsent_max_offset);
@@ -3235,8 +3235,8 @@ void test_ngtcp2_conn_retransmit_protected(void) {
   ngtcp2_conn_open_bidi_stream(conn, &stream_id_a, NULL);
   ngtcp2_conn_open_bidi_stream(conn, &stream_id_b, NULL);
 
-  ngtcp2_conn_shutdown_stream_write(conn, stream_id_a, NGTCP2_APP_ERR01);
-  ngtcp2_conn_shutdown_stream_write(conn, stream_id_b, NGTCP2_APP_ERR01);
+  ngtcp2_conn_shutdown_stream_write(conn, 0, stream_id_a, NGTCP2_APP_ERR01);
+  ngtcp2_conn_shutdown_stream_write(conn, 0, stream_id_b, NGTCP2_APP_ERR01);
 
   spktlen = ngtcp2_conn_write_pkt(conn, NULL, NULL, buf, sizeof(buf), ++t);
 
@@ -3445,7 +3445,7 @@ void test_ngtcp2_conn_send_max_stream_data(void) {
 
   CU_ASSERT(0 == rv);
 
-  rv = ngtcp2_conn_shutdown_stream_read(conn, 4, NGTCP2_APP_ERR01);
+  rv = ngtcp2_conn_shutdown_stream_read(conn, 0, 4, NGTCP2_APP_ERR01);
 
   CU_ASSERT(0 == rv);
 
@@ -3858,7 +3858,7 @@ void test_ngtcp2_conn_recv_stream_data(void) {
   CU_ASSERT(0 == rv);
   CU_ASSERT(NULL != ngtcp2_conn_find_stream(conn, 4));
 
-  rv = ngtcp2_conn_shutdown_stream_read(conn, 4, 99);
+  rv = ngtcp2_conn_shutdown_stream_read(conn, 0, 4, 99);
 
   CU_ASSERT(0 == rv);
 
@@ -8884,7 +8884,7 @@ void test_ngtcp2_conn_stream_close(void) {
 
   CU_ASSERT(0 == rv);
 
-  rv = ngtcp2_conn_shutdown_stream(conn, stream_id, NGTCP2_APP_ERR01);
+  rv = ngtcp2_conn_shutdown_stream(conn, 0, stream_id, NGTCP2_APP_ERR01);
 
   CU_ASSERT(0 == rv);
 
@@ -8933,7 +8933,7 @@ void test_ngtcp2_conn_stream_close(void) {
 
   CU_ASSERT(spktlen > 0);
 
-  rv = ngtcp2_conn_shutdown_stream_write(conn, stream_id, NGTCP2_APP_ERR01);
+  rv = ngtcp2_conn_shutdown_stream_write(conn, 0, stream_id, NGTCP2_APP_ERR01);
 
   CU_ASSERT(0 == rv);
 


### PR DESCRIPTION
Add flags to ngtcp2_conn_shutdown_stream functions as an extension point.