### PR TITLE
Require GnuTLS >= 3.7.5

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -57,7 +57,7 @@ directory require at least one of the following TLS backends:
 
 - `OpenSSL with QUIC support
   <https://github.com/quictls/openssl/tree/OpenSSL_1_1_1t+quic>`_
-- GnuTLS >= 3.7.2
+- GnuTLS >= 3.7.5
 - BoringSSL (commit b0341041b03ea71d8371a9692aedae263fc06ee9)
 - Picotls (commit 9a3a311b2db4ebfa91ca365a954177541f02c5b3)
 - wolfSSL >= 5.5.0

--- a/configure.ac
+++ b/configure.ac
@@ -284,7 +284,7 @@ AM_CONDITIONAL([HAVE_OPENSSL], [ test "x${have_openssl}" = "xyes" ])
 # GnuTLS (required for libngtcp2_crypto_gnutls)
 have_gnutls=no
 if test "x${request_gnutls}" != "xno"; then
-  PKG_CHECK_MODULES([GNUTLS], [gnutls >= 3.7.2],
+  PKG_CHECK_MODULES([GNUTLS], [gnutls >= 3.7.3],
                     [have_gnutls=yes], [have_gnutls=no])
   if test "x${have_gnutls}" = "xno"; then
     AC_MSG_NOTICE($GNUTLS_PKG_ERRORS)


### PR DESCRIPTION
Older versions do not work because of the bug that cannot deal with partially received TLS messages correctly.

Minimum version in configure script is set to 3.7.3 because that is the GnuTLS version ubuntu 22.04 has.