### PR TITLE
keep-alive timeout defaults to UINT64_MAX

### DIFF
--- a/lib/includes/ngtcp2/ngtcp2.h
+++ b/lib/includes/ngtcp2/ngtcp2.h
@@ -4025,8 +4025,9 @@ NGTCP2_EXTERN uint8_t ngtcp2_conn_get_tls_alert(ngtcp2_conn *conn);
  *
  * `ngtcp2_conn_set_keep_alive_timeout` sets keep-alive timeout.  If
  * nonzero value is given, after a connection is idle at least in a
- * given amount of time, a keep-alive packet is sent.  If 0 is set,
- * keep-alive functionality is disabled, and this is the default.
+ * given amount of time, a keep-alive packet is sent.  If UINT64_MAX
+ * is set, keep-alive functionality is disabled, and this is the
+ * default.
  */
 NGTCP2_EXTERN void ngtcp2_conn_set_keep_alive_timeout(ngtcp2_conn *conn,
                                                       ngtcp2_duration timeout);


### PR DESCRIPTION
This changes the default value of keep-alive timeout to UINT64_MAX. Previously, it is 0, and it is the value that disables keep-alive. Now, to disable keep-alive, set it to UINT64_MAX.