### PR TITLE
Reserve keep-alive timeout 0 as future extension

### DIFF
--- a/lib/includes/ngtcp2/ngtcp2.h
+++ b/lib/includes/ngtcp2/ngtcp2.h
@@ -4027,7 +4027,8 @@ NGTCP2_EXTERN uint8_t ngtcp2_conn_get_tls_alert(ngtcp2_conn *conn);
  * nonzero value is given, after a connection is idle at least in a
  * given amount of time, a keep-alive packet is sent.  If UINT64_MAX
  * is set, keep-alive functionality is disabled, and this is the
- * default.
+ * default.  Specifying 0 in |timeout| is reserved for a future
+ * extension, and for now it is treated as if UINT64_MAX is given.
  */
 NGTCP2_EXTERN void ngtcp2_conn_set_keep_alive_timeout(ngtcp2_conn *conn,
                                                       ngtcp2_duration timeout);

--- a/lib/ngtcp2_conn.c
+++ b/lib/ngtcp2_conn.c
@@ -2473,6 +2473,10 @@ static void conn_update_keep_alive_last_ts(ngtcp2_conn *conn,
 
 void ngtcp2_conn_set_keep_alive_timeout(ngtcp2_conn *conn,
                                         ngtcp2_duration timeout) {
+  if (timeout == 0) {
+    timeout = UINT64_MAX;
+  }
+
   conn->keep_alive.timeout = timeout;
 }
 


### PR DESCRIPTION
Specifying 0 in timeout parameter of
ngtcp2_conn_set_keep_alive_timeout is reserved for a future extension, and for now it is treated as if UINT64_MAX is given.