### PR TITLE
Assert max_idle_timeout and max_ack_delay

### DIFF
--- a/lib/includes/ngtcp2/ngtcp2.h
+++ b/lib/includes/ngtcp2/ngtcp2.h
@@ -1513,7 +1513,8 @@ typedef struct ngtcp2_transport_params {
   uint64_t initial_max_streams_uni;
   /**
    * :member:`max_idle_timeout` is a duration during which sender
-   * allows quiescent.
+   * allows quiescent.  0 means no idle timeout.  It must not be
+   * UINT64_MAX.
    */
   ngtcp2_duration max_idle_timeout;
   /**
@@ -1533,7 +1534,10 @@ typedef struct ngtcp2_transport_params {
   uint64_t ack_delay_exponent;
   /**
    * :member:`max_ack_delay` is the maximum acknowledgement delay by
-   * which the local endpoint will delay sending acknowledgements.
+   * which the local endpoint will delay sending acknowledgements.  It
+   * must be strictly less than (1 << 14) milliseconds.
+   * Sub-millisecond part is dropped when sending it in a QUIC
+   * transport parameter.
    */
   ngtcp2_duration max_ack_delay;
   /**

--- a/lib/ngtcp2_conn.c
+++ b/lib/ngtcp2_conn.c
@@ -1088,6 +1088,8 @@ static int conn_new(ngtcp2_conn **pconn, const ngtcp2_cid *dcid,
   assert(server || !params->stateless_reset_token_present);
   assert(server || !params->preferred_addr_present);
   assert(server || !params->retry_scid_present);
+  assert(params->max_idle_timeout != UINT64_MAX);
+  assert(params->max_ack_delay < (1 << 14) * NGTCP2_MILLISECONDS);
   assert(server || callbacks->client_initial);
   assert(!server || callbacks->recv_client_initial);
   assert(callbacks->recv_crypto_data);


### PR DESCRIPTION
Assert ngtcp2_transport_params.max_idle_timeout and max_ack_delay for invalid values.