### PR TITLE
Added borringssl build instructions to README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -103,7 +103,7 @@ Build with BoringSSL
    $ git reset --hard 74646566e93de7551bfdfc5f49de7462f13d1d05
    $ mkdir build
    $ cd build
-   $ cmake ../
+   $ cmake ..
    $ make
    $ cd ..
    $ mkdir lib

--- a/README.rst
+++ b/README.rst
@@ -94,7 +94,7 @@ Build from git
 
 
 Build with BoringSSL
--------------------------------------------
+--------------------
 
 .. code-block:: shell
 

--- a/README.rst
+++ b/README.rst
@@ -93,7 +93,7 @@ Build from git
    $ make -j$(nproc) check
 
 
-Build with BoringSSL without 0-RTT enabled
+Build with BoringSSL
 -------------------------------------------
 
 .. code-block:: shell
@@ -112,8 +112,7 @@ Build with BoringSSL without 0-RTT enabled
    $ ln -s ../build/crypto/libcrypto.a
    $ cd ../ngtcp2
    $ ./configure --with-boringssl BORINGSSL_LIBS="$PWD/../boringssl/lib/libssl.a $PWD/../boringssl/lib/libcrypto.a" BORINGSSL_CFLAGS="-I$PWD/../boringssl/include" PKG_CONFIG_PATH=$PWD/../nghttp3/build/lib/pkgconfig
-    # LDFLAGS="-Wl,-rpath,$PWD/../boringssl/lib"
-   $ ./
+   $ make -j$(nproc) check
 
 
 Client/Server

--- a/README.rst
+++ b/README.rst
@@ -92,6 +92,30 @@ Build from git
    $ ./configure PKG_CONFIG_PATH=$PWD/../openssl/build/lib/pkgconfig:$PWD/../nghttp3/build/lib/pkgconfig LDFLAGS="-Wl,-rpath,$PWD/../openssl/build/lib"
    $ make -j$(nproc) check
 
+
+Build with BoringSSL without 0-RTT enabled
+-------------------------------------------
+
+.. code-block:: shell
+
+   $ git clone https://boringssl.googlesource.com/boringssl
+   $ cd boringssl
+   $ git reset --hard 74646566e93de7551bfdfc5f49de7462f13d1d05
+   $ mkdir build
+   $ cd build
+   $ cmake ../
+   $ make
+   $ cd ..
+   $ mkdir lib
+   $ cd lib
+   $ ln -s ../build/ssl/libssl.a
+   $ ln -s ../build/crypto/libcrypto.a
+   $ cd ../ngtcp2
+   $ ./configure --with-boringssl BORINGSSL_LIBS="$PWD/../boringssl/lib/libssl.a $PWD/../boringssl/lib/libcrypto.a" BORINGSSL_CFLAGS="-I$PWD/../boringssl/include" PKG_CONFIG_PATH=$PWD/../nghttp3/build/lib/pkgconfig
+    # LDFLAGS="-Wl,-rpath,$PWD/../boringssl/lib"
+   $ ./
+
+
 Client/Server
 -------------
 

--- a/README.rst
+++ b/README.rst
@@ -110,7 +110,7 @@ Build with BoringSSL
    $ cd lib
    $ ln -s ../build/ssl/libssl.a
    $ ln -s ../build/crypto/libcrypto.a
-   $ cd ../ngtcp2
+   $ cd ../../ngtcp2
    $ ./configure --with-boringssl BORINGSSL_LIBS="$PWD/../boringssl/lib/libssl.a $PWD/../boringssl/lib/libcrypto.a" BORINGSSL_CFLAGS="-I$PWD/../boringssl/include" PKG_CONFIG_PATH=$PWD/../nghttp3/build/lib/pkgconfig
    $ make -j$(nproc) check
 


### PR DESCRIPTION
I was able to successfully run ngtcp2 with boringssl a while back.   Checking in the README steps in case it might come in handy!