### PR TITLE
Include PING in ACK once per RTT

### DIFF
--- a/lib/ngtcp2_conn.h
+++ b/lib/ngtcp2_conn.h
@@ -112,10 +112,6 @@ typedef enum {
    to put the sane limit.*/
 #define NGTCP2_MAX_SCID_POOL_SIZE 8
 
-/* NGTCP2_MAX_NON_ACK_TX_PKT is the maximum number of continuous non
-   ACK-eliciting packets. */
-#define NGTCP2_MAX_NON_ACK_TX_PKT 3
-
 /* NGTCP2_ECN_MAX_NUM_VALIDATION_PKTS is the maximum number of ECN marked
    packets sent in NGTCP2_ECN_STATE_TESTING period. */
 #define NGTCP2_ECN_MAX_NUM_VALIDATION_PKTS 10
@@ -228,9 +224,9 @@ typedef struct ngtcp2_pktns {
        last time.*/
     int64_t last_pkt_num;
     ngtcp2_frame_chain *frq;
-    /* num_non_ack_pkt is the number of continuous non ACK-eliciting
-       packets. */
-    size_t num_non_ack_pkt;
+    /* non_ack_pkt_start_ts is the timestamp since the local endpoint
+       starts sending continuous non ACK-eliciting packets. */
+    ngtcp2_tstamp non_ack_pkt_start_ts;
 
     struct {
       /* ect0 is the number of QUIC packets, not UDP datagram, which

--- a/tests/ngtcp2_conn_test.c
+++ b/tests/ngtcp2_conn_test.c
@@ -6715,7 +6715,7 @@ void test_ngtcp2_conn_handshake_loss(void) {
 
   /* Send 2 ACKs with PING to declare the latest Handshake CRYPTO to
      be lost */
-  for (i = 0; i < 4; ++i) {
+  for (i = 0; i < 2; ++i) {
     pktlen = write_handshake_pkt(
         buf, sizeof(buf), &conn->oscid, ngtcp2_conn_get_dcid(conn), ++pkt_num,
         conn->client_chosen_version, &fr, 1, &null_ckm);
@@ -6725,7 +6725,8 @@ void test_ngtcp2_conn_handshake_loss(void) {
 
     CU_ASSERT(0 == rv);
 
-    spktlen = ngtcp2_conn_write_pkt(conn, NULL, NULL, buf, sizeof(buf), ++t);
+    t += conn->cstat.smoothed_rtt;
+    spktlen = ngtcp2_conn_write_pkt(conn, NULL, NULL, buf, sizeof(buf), t);
 
     CU_ASSERT(spktlen > 0);
   }


### PR DESCRIPTION
Include PING in ACK once per RTT if an endpoint only sends non ACK-eliciting packets in this period as suggested by RFC 9000, section 13.2.4.  Previously, we did this once per continuous 3 non-ACK eliciting packets.