### PR TITLE
Rework getting the number of Connection IDs

### DIFF
--- a/doc/source/programmers-guide.rst
+++ b/doc/source/programmers-guide.rst
@@ -289,13 +289,11 @@ datagram is received, and it does not belong to any existing
 connections, and it is successfully processed by
 `ngtcp2_conn_read_pkt()`, associate the Destination Connection ID in
 the QUIC packet and :type:`ngtcp2_conn` object.  The server must
-associate the Connection ID returned by `ngtcp2_conn_get_scid()` to
-the :type:`ngtcp2_conn` object as well.  Use
-`ngtcp2_conn_get_num_scid()` to get the number of Connection IDs that
-`ngtcp2_conn_get_scid()` returns.  When new Connection ID is asked by
-the library, :member:`ngtcp2_callbacks.get_new_connection_id` is
-called.  Inside the callback, associate the newly generated Connection
-ID to the :type:`ngtcp2_conn` object.
+associate the Connection IDs returned by `ngtcp2_conn_get_scid()` to
+the :type:`ngtcp2_conn` object as well.  When new Connection ID is
+asked by the library, :member:`ngtcp2_callbacks.get_new_connection_id`
+is called.  Inside the callback, associate the newly generated
+Connection ID to the :type:`ngtcp2_conn` object.
 
 When Connection ID is no longer used, its association should be
 removed.  When Connection ID is retired,

--- a/examples/h09server.cc
+++ b/examples/h09server.cc
@@ -1884,7 +1884,7 @@ void Server::read_pkt(Endpoint &ep, const Address &local_addr,
     std::array<ngtcp2_cid, 2> scids;
     auto conn = h->conn();
 
-    auto num_scid = ngtcp2_conn_get_num_scid(conn);
+    auto num_scid = ngtcp2_conn_get_scid(conn, nullptr);
 
     assert(num_scid <= scids.size());
 
@@ -2347,7 +2347,7 @@ void Server::remove(const Handler *h) {
 
   dissociate_cid(ngtcp2_conn_get_client_initial_dcid(conn));
 
-  std::vector<ngtcp2_cid> cids(ngtcp2_conn_get_num_scid(conn));
+  std::vector<ngtcp2_cid> cids(ngtcp2_conn_get_scid(conn, nullptr));
   ngtcp2_conn_get_scid(conn, cids.data());
 
   for (auto &cid : cids) {

--- a/examples/server.cc
+++ b/examples/server.cc
@@ -2597,7 +2597,7 @@ void Server::read_pkt(Endpoint &ep, const Address &local_addr,
     std::array<ngtcp2_cid, 2> scids;
     auto conn = h->conn();
 
-    auto num_scid = ngtcp2_conn_get_num_scid(conn);
+    auto num_scid = ngtcp2_conn_get_scid(conn, nullptr);
 
     assert(num_scid <= scids.size());
 
@@ -3061,7 +3061,7 @@ void Server::remove(const Handler *h) {
 
   dissociate_cid(ngtcp2_conn_get_client_initial_dcid(conn));
 
-  std::vector<ngtcp2_cid> cids(ngtcp2_conn_get_num_scid(conn));
+  std::vector<ngtcp2_cid> cids(ngtcp2_conn_get_scid(conn, nullptr));
   ngtcp2_conn_get_scid(conn, cids.data());
 
   for (auto &cid : cids) {

--- a/lib/includes/ngtcp2/ngtcp2.h
+++ b/lib/includes/ngtcp2/ngtcp2.h
@@ -4715,30 +4715,16 @@ ngtcp2_conn_get_client_initial_dcid(ngtcp2_conn *conn);
 /**
  * @function
  *
- * `ngtcp2_conn_get_num_scid` returns the number of Source Connection
- * IDs which a local endpoint has provided to a remote endpoint, and
- * are not retired.
- */
-NGTCP2_EXTERN size_t ngtcp2_conn_get_num_scid(ngtcp2_conn *conn);
-
-/**
- * @function
- *
  * `ngtcp2_conn_get_scid` writes the all Source Connection IDs which a
  * local endpoint has provided to a remote endpoint, and are not
- * retired in |dest|.  The buffer pointed by |dest| must have
- * sizeof(:type:`ngtcp2_cid`) * n bytes available, where n is the
- * return value of `ngtcp2_conn_get_num_scid`.
+ * retired in |dest|.  If |dest| is NULL, this function does not write
+ * anything, and returns the number of Source Connection IDs that
+ * would otherwise be written to the provided buffer.  The buffer
+ * pointed by |dest| must have sizeof(:type:`ngtcp2_cid`) * n bytes
+ * available, where n is the return value of `ngtcp2_conn_get_scid`
+ * with |dest| == NULL.
  */
 NGTCP2_EXTERN size_t ngtcp2_conn_get_scid(ngtcp2_conn *conn, ngtcp2_cid *dest);
-
-/**
- * @function
- *
- * `ngtcp2_conn_get_num_active_dcid` returns the number of the active
- * Destination Connection ID.
- */
-NGTCP2_EXTERN size_t ngtcp2_conn_get_num_active_dcid(ngtcp2_conn *conn);
 
 /**
  * @struct
@@ -4776,10 +4762,14 @@ typedef struct ngtcp2_cid_token {
  * @function
  *
  * `ngtcp2_conn_get_active_dcid` writes the all active Destination
- * Connection IDs and their tokens to |dest|.  The buffer pointed by
- * |dest| must have sizeof(:type:`ngtcp2_cid_token`) * n bytes
- * available, where n is the return value of
- * `ngtcp2_conn_get_num_active_dcid`.
+ * Connection IDs and their tokens to |dest|.  Before handshake
+ * completes, this function returns 0.  If |dest| is NULL, this
+ * function does not write anything, and returns the number of
+ * Destination Connection IDs that would otherwise be written to the
+ * provided buffer.  The buffer pointed by |dest| must have
+ * sizeof(:type:`ngtcp2_cid_token`) * n bytes available, where n is
+ * the return value of `ngtcp2_conn_get_active_dcid` with |dest| ==
+ * NULL.
  */
 NGTCP2_EXTERN size_t ngtcp2_conn_get_active_dcid(ngtcp2_conn *conn,
                                                  ngtcp2_cid_token *dest);

--- a/lib/ngtcp2_conn.c
+++ b/lib/ngtcp2_conn.c
@@ -13181,15 +13181,15 @@ static int conn_has_uncommited_preferred_addr_cid(ngtcp2_conn *conn) {
          conn->local.transport_params.preferred_addr_present;
 }
 
-size_t ngtcp2_conn_get_num_scid(ngtcp2_conn *conn) {
-  return ngtcp2_ksl_len(&conn->scid.set) +
-         (size_t)conn_has_uncommited_preferred_addr_cid(conn);
-}
-
 size_t ngtcp2_conn_get_scid(ngtcp2_conn *conn, ngtcp2_cid *dest) {
   ngtcp2_cid *origdest = dest;
   ngtcp2_ksl_it it;
   ngtcp2_scid *scid;
+
+  if (dest == NULL) {
+    return ngtcp2_ksl_len(&conn->scid.set) +
+           (size_t)conn_has_uncommited_preferred_addr_cid(conn);
+  }
 
   for (it = ngtcp2_ksl_begin(&conn->scid.set); !ngtcp2_ksl_it_end(&it);
        ngtcp2_ksl_it_next(&it)) {
@@ -13204,13 +13204,9 @@ size_t ngtcp2_conn_get_scid(ngtcp2_conn *conn, ngtcp2_cid *dest) {
   return (size_t)(dest - origdest);
 }
 
-size_t ngtcp2_conn_get_num_active_dcid(ngtcp2_conn *conn) {
+static size_t conn_get_num_active_dcid(ngtcp2_conn *conn) {
   size_t n = 1; /* for conn->dcid.current */
   ngtcp2_pv *pv = conn->pv;
-
-  if (!(conn->flags & NGTCP2_CONN_FLAG_HANDSHAKE_COMPLETED)) {
-    return 0;
-  }
 
   if (pv) {
     if (pv->dcid.seq != conn->dcid.current.seq) {
@@ -13247,6 +13243,10 @@ size_t ngtcp2_conn_get_active_dcid(ngtcp2_conn *conn, ngtcp2_cid_token *dest) {
 
   if (!(conn->flags & NGTCP2_CONN_FLAG_HANDSHAKE_COMPLETED)) {
     return 0;
+  }
+
+  if (dest == NULL) {
+    return conn_get_num_active_dcid(conn);
   }
 
   copy_dcid_to_cid_token(dest, &conn->dcid.current);

--- a/tests/ngtcp2_conn_test.c
+++ b/tests/ngtcp2_conn_test.c
@@ -7019,7 +7019,7 @@ void test_ngtcp2_conn_get_active_dcid(void) {
   dcid_init(&dcid);
   setup_default_client(&conn);
 
-  CU_ASSERT(1 == ngtcp2_conn_get_num_active_dcid(conn));
+  CU_ASSERT(1 == ngtcp2_conn_get_active_dcid(conn, NULL));
   CU_ASSERT(1 == ngtcp2_conn_get_active_dcid(conn, cid_token));
   CU_ASSERT(0 == cid_token[0].seq);
   CU_ASSERT(ngtcp2_cid_eq(&dcid, &cid_token[0].cid));
@@ -8764,7 +8764,7 @@ void test_ngtcp2_conn_get_scid(void) {
                          NGTCP2_PROTO_VER_V1, &cb, &settings, &params,
                          /* mem = */ NULL, NULL);
 
-  CU_ASSERT(1 == ngtcp2_conn_get_num_scid(conn));
+  CU_ASSERT(1 == ngtcp2_conn_get_scid(conn, NULL));
 
   ngtcp2_conn_get_scid(conn, scids);
 
@@ -8781,7 +8781,7 @@ void test_ngtcp2_conn_get_scid(void) {
                          NGTCP2_PROTO_VER_V1, &cb, &settings, &params,
                          /* mem = */ NULL, NULL);
 
-  CU_ASSERT(2 == ngtcp2_conn_get_num_scid(conn));
+  CU_ASSERT(2 == ngtcp2_conn_get_scid(conn, NULL));
 
   ngtcp2_conn_get_scid(conn, scids);
 


### PR DESCRIPTION
ngtcp2_conn_get_num_scid has been removed.  ngtcp2_conn_get_scid(conn, NULL) now returns the number of Source Connection IDs that this function writes to the given buffer.

Similarly, ngtcp2_conn_get_num_active_dcid has been removed, and ngtcp2_conn_get_active_dcid(conn, NULL) returns the number of Destination Connection IDs that this function writes to the given buffer.