### PR TITLE
Close connection with fatal error

### DIFF
--- a/lib/includes/ngtcp2/ngtcp2.h
+++ b/lib/includes/ngtcp2/ngtcp2.h
@@ -771,7 +771,7 @@ typedef struct NGTCP2_ALIGN(8) ngtcp2_pkt_info {
  *
  * :macro:`NGTCP2_ERR_FATAL` indicates that error codes less than this
  * value is fatal error.  When this error is returned, an endpoint
- * should drop connection immediately.
+ * should close connection immediately.
  */
 #define NGTCP2_ERR_FATAL -500
 /**


### PR DESCRIPTION
Initially, we recommended to drop connection without any action on a fatal error (that is liberr < NGTCP2_ERR_FATAL).  But now the general error handling is always call ngtcp2_conn_write_connection_close except for some particular cases.