### PR TITLE
Bump minimum cmake version to 3.20

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.20)
 
 # Allow setting VISIBILITY_PRESET on static library targets without warning.
 cmake_policy(SET CMP0063 NEW)


### PR DESCRIPTION
Bump minimum cmake version to 3.20 which is the first version that has CMAKE_C_BYTE_ORDER.