### PR TITLE
No need to check state

### DIFF
--- a/lib/ngtcp2_conn.c
+++ b/lib/ngtcp2_conn.c
@@ -12356,8 +12356,7 @@ ngtcp2_ssize ngtcp2_conn_write_vmsg(ngtcp2_conn *conn, ngtcp2_path *path,
         }
       }
     }
-    if (conn->state != NGTCP2_CS_POST_HANDSHAKE &&
-        conn->pktns.crypto.tx.ckm == NULL) {
+    if (conn->pktns.crypto.tx.ckm == NULL) {
       return res;
     }
     break;


### PR DESCRIPTION
No need to check state because while server is writing handshake packets, it is not in NGTCP2_CS_POST_HANDSHAKE state.