### PR TITLE
Make crypto static library targets explicitly STATIC

### DIFF
--- a/crypto/boringssl/CMakeLists.txt
+++ b/crypto/boringssl/CMakeLists.txt
@@ -45,7 +45,7 @@ endforeach()
 
 if(ENABLE_STATIC_LIB)
   # Public static library
-  add_library(ngtcp2_crypto_boringssl_static ${ngtcp2_crypto_boringssl_SOURCES})
+  add_library(ngtcp2_crypto_boringssl_static STATIC ${ngtcp2_crypto_boringssl_SOURCES})
   set_target_properties(ngtcp2_crypto_boringssl_static PROPERTIES
     COMPILE_FLAGS "${WARNCFLAGS}"
     ARCHIVE_OUTPUT_NAME ngtcp2_crypto_boringssl${STATIC_LIB_SUFFIX}

--- a/crypto/gnutls/CMakeLists.txt
+++ b/crypto/gnutls/CMakeLists.txt
@@ -65,7 +65,7 @@ endif()
 
 if(ENABLE_STATIC_LIB)
   # Public static library
-  add_library(ngtcp2_crypto_gnutls_static ${ngtcp2_crypto_gnutls_SOURCES})
+  add_library(ngtcp2_crypto_gnutls_static STATIC ${ngtcp2_crypto_gnutls_SOURCES})
   set_target_properties(ngtcp2_crypto_gnutls_static PROPERTIES
     COMPILE_FLAGS "${WARNCFLAGS}"
     VERSION ${CRYPTO_GNUTLS_LT_VERSION}

--- a/crypto/picotls/CMakeLists.txt
+++ b/crypto/picotls/CMakeLists.txt
@@ -46,7 +46,7 @@ endforeach()
 
 if(ENABLE_STATIC_LIB)
   # Public static library
-  add_library(ngtcp2_crypto_picotls_static ${ngtcp2_crypto_picotls_SOURCES})
+  add_library(ngtcp2_crypto_picotls_static STATIC ${ngtcp2_crypto_picotls_SOURCES})
   set_target_properties(ngtcp2_crypto_picotls_static PROPERTIES
     COMPILE_FLAGS "${WARNCFLAGS}"
     ARCHIVE_OUTPUT_NAME ngtcp2_crypto_picotls${STATIC_LIB_SUFFIX}

--- a/crypto/quictls/CMakeLists.txt
+++ b/crypto/quictls/CMakeLists.txt
@@ -65,7 +65,7 @@ endif()
 
 if(ENABLE_STATIC_LIB)
   # Public static library
-  add_library(ngtcp2_crypto_quictls_static ${ngtcp2_crypto_quictls_SOURCES})
+  add_library(ngtcp2_crypto_quictls_static STATIC ${ngtcp2_crypto_quictls_SOURCES})
   set_target_properties(ngtcp2_crypto_quictls_static PROPERTIES
     COMPILE_FLAGS "${WARNCFLAGS}"
     VERSION ${CRYPTO_QUICTLS_LT_VERSION}

--- a/crypto/wolfssl/CMakeLists.txt
+++ b/crypto/wolfssl/CMakeLists.txt
@@ -65,7 +65,7 @@ endif()
 
 if(ENABLE_STATIC_LIB)
   # Public static library
-  add_library(ngtcp2_crypto_wolfssl_static ${ngtcp2_crypto_wolfssl_SOURCES})
+  add_library(ngtcp2_crypto_wolfssl_static STATIC ${ngtcp2_crypto_wolfssl_SOURCES})
   set_target_properties(ngtcp2_crypto_wolfssl_static PROPERTIES
     COMPILE_FLAGS "${WARNCFLAGS}"
     ARCHIVE_OUTPUT_NAME ngtcp2_crypto_wolfssl${STATIC_LIB_SUFFIX}


### PR DESCRIPTION
Not having the STATIC keyword in `add_library(...)` makes CMake go look for a `BUILD_SHARED_LIBS` variable and, if set, makes the "static" library crypto targets actually create a shared library.

This causes a problem if including ngtcp2 as a subproject from some other project that itself happens to have a default of `BUILD_SHARED_LIBS=ON`, resulting in the "static" targets getting built dynamically.

This fixes it by making the crypto static library targets explicitly STATIC so that this cmake messiness doesn't happen (and also matches the way the main ngtcp2_static target is created).