### PR TITLE
Simplify ngtcp2_strm_streamfrq_pop

### DIFF
--- a/lib/ngtcp2_strm.c
+++ b/lib/ngtcp2_strm.c
@@ -377,18 +377,16 @@ int ngtcp2_strm_streamfrq_pop(ngtcp2_strm *strm, ngtcp2_frame_chain **pfrc,
   fr = &frc->fr.stream;
   datalen = ngtcp2_vec_len(fr->data, fr->datacnt);
 
-  if (left == 0) {
-    /* datalen could be zero if 0 length STREAM has been sent */
-    if (datalen || ngtcp2_ksl_len(strm->tx.streamfrq) > 1) {
-      rv = ngtcp2_ksl_insert(strm->tx.streamfrq, NULL, &fr->offset, frc);
-      if (rv != 0) {
-        assert(ngtcp2_err_is_fatal(rv));
-        ngtcp2_frame_chain_objalloc_del(frc, strm->frc_objalloc, strm->mem);
-        return rv;
-      }
-      *pfrc = NULL;
-      return 0;
+  /* datalen could be zero if 0 length STREAM has been sent */
+  if (left == 0 && datalen) {
+    rv = ngtcp2_ksl_insert(strm->tx.streamfrq, NULL, &fr->offset, frc);
+    if (rv != 0) {
+      assert(ngtcp2_err_is_fatal(rv));
+      ngtcp2_frame_chain_objalloc_del(frc, strm->frc_objalloc, strm->mem);
+      return rv;
     }
+    *pfrc = NULL;
+    return 0;
   }
 
   if (datalen > left) {


### PR DESCRIPTION
After some re-factorization, now there is no need to check the length of streamfrq because strm_streamfrq_unacked_pop returns empty STREAM frame for a specific case.