### PR TITLE
Fix ECN largest acked sent time

### DIFF
--- a/lib/ngtcp2_bbr.c
+++ b/lib/ngtcp2_bbr.c
@@ -246,7 +246,8 @@ static void bbr_handle_recovery(ngtcp2_cc_bbr *bbr, ngtcp2_conn_stat *cstat,
       bbr->packet_conservation = 0;
     }
 
-    if (!in_congestion_recovery(cstat, ack->largest_acked_sent_ts)) {
+    if (ack->largest_pkt_sent_ts != UINT64_MAX &&
+        !in_congestion_recovery(cstat, ack->largest_pkt_sent_ts)) {
       bbr->in_loss_recovery = 0;
       bbr->packet_conservation = 0;
       bbr_restore_cwnd(bbr, cstat);

--- a/lib/ngtcp2_bbr2.c
+++ b/lib/ngtcp2_bbr2.c
@@ -1315,7 +1315,8 @@ static void bbr_handle_recovery(ngtcp2_cc_bbr2 *bbr, ngtcp2_conn_stat *cstat,
       bbr->packet_conservation = 0;
     }
 
-    if (!in_congestion_recovery(cstat, ack->largest_acked_sent_ts)) {
+    if (ack->largest_pkt_sent_ts != UINT64_MAX &&
+        !in_congestion_recovery(cstat, ack->largest_pkt_sent_ts)) {
       bbr->in_loss_recovery = 0;
       bbr->packet_conservation = 0;
       bbr_restore_cwnd(bbr, cstat);

--- a/lib/ngtcp2_cc.h
+++ b/lib/ngtcp2_cc.h
@@ -107,10 +107,10 @@ typedef struct ngtcp2_cc_ack {
    */
   uint64_t pkt_delivered;
   /**
-   * :member:`largest_acked_sent_ts` is the time when the largest
-   * acknowledged packet was sent.
+   * :member:`largest_pkt_sent_ts` is the time when the largest
+   * acknowledged packet was sent.  It is UINT64_MAX if it is unknown.
    */
-  ngtcp2_tstamp largest_acked_sent_ts;
+  ngtcp2_tstamp largest_pkt_sent_ts;
   /**
    * :member:`rtt` is the RTT sample.  It is UINT64_MAX if no RTT
    * sample is available.


### PR DESCRIPTION
The largest acknowledged packet that ECN reacts to is the packet referred in largest_ack field, not the largest packet newly acknowledged.