### PR TITLE
Fix compile error with libressl

### DIFF
--- a/crypto/quictls/quictls.c
+++ b/crypto/quictls/quictls.c
@@ -192,7 +192,7 @@ ngtcp2_crypto_ctx *ngtcp2_crypto_ctx_tls(ngtcp2_crypto_ctx *ctx,
     return NULL;
   }
 
-  cipher_id = SSL_CIPHER_get_id(cipher);
+  cipher_id = (uint32_t)SSL_CIPHER_get_id(cipher);
 
   if (!supported_cipher_id(cipher_id)) {
     return NULL;
@@ -821,6 +821,10 @@ static SSL_QUIC_METHOD quic_method = {
     add_handshake_data,
     flush_flight,
     send_alert,
+#ifdef LIBRESSL_VERSION_NUMBER
+    NULL,
+    NULL,
+#endif /* LIBRESSL_VERSION_NUMBER */
 };
 
 static void crypto_quictls_configure_context(SSL_CTX *ssl_ctx) {


### PR DESCRIPTION
This change fixes compile errors with libressl.  This is a stopgap solution.  If the difference between libressl and quictls gets larger, we will consider to make a separate library for libressl.

Applications in examples do not compile with libressl, and it is a known fact, and we do not fix it until libressl gets its own ngtcp2_crypto library.

Fixes #935 