### PR TITLE
Merge ngtcp2_crypto into ngtcp2_stream

### DIFF
--- a/lib/ngtcp2_conn.h
+++ b/lib/ngtcp2_conn.h
@@ -294,8 +294,6 @@ typedef struct ngtcp2_pktns {
 
   struct {
     struct {
-      /* frq contains crypto data sorted by their offset. */
-      ngtcp2_ksl frq;
       /* offset is the offset of crypto stream in this packet number
          space. */
       uint64_t offset;

--- a/lib/ngtcp2_log.c
+++ b/lib/ngtcp2_log.c
@@ -414,7 +414,7 @@ static void log_fr_path_response(ngtcp2_log *log, const ngtcp2_pkt_hd *hd,
 }
 
 static void log_fr_crypto(ngtcp2_log *log, const ngtcp2_pkt_hd *hd,
-                          const ngtcp2_crypto *fr, const char *dir) {
+                          const ngtcp2_stream *fr, const char *dir) {
   log->log_printf(
       log->user_data,
       (NGTCP2_LOG_PKT " CRYPTO(0x%02x) offset=%" PRIu64 " len=%" PRIu64),
@@ -521,7 +521,7 @@ static void log_fr(ngtcp2_log *log, const ngtcp2_pkt_hd *hd,
     log_fr_path_response(log, hd, &fr->path_response, dir);
     break;
   case NGTCP2_FRAME_CRYPTO:
-    log_fr_crypto(log, hd, &fr->crypto, dir);
+    log_fr_crypto(log, hd, &fr->stream, dir);
     break;
   case NGTCP2_FRAME_NEW_TOKEN:
     log_fr_new_token(log, hd, &fr->new_token, dir);

--- a/lib/ngtcp2_pkt.h
+++ b/lib/ngtcp2_pkt.h
@@ -173,14 +173,20 @@ typedef enum {
   NGTCP2_FRAME_DATAGRAM_LEN = 0x31,
 } ngtcp2_frame_type;
 
+/* ngtcp2_stream represents STREAM and CRYPTO frames. */
 typedef struct ngtcp2_stream {
   uint8_t type;
   /**
    * flags of decoded STREAM frame.  This gets ignored when encoding
-   * STREAM frame.
+   * STREAM frame.  CRYPTO frame does not include this field, and must
+   * set it to 0.
    */
   uint8_t flags;
+  /* CRYPTO frame does not include this field, and must set it to
+     0. */
   uint8_t fin;
+  /* CRYPTO frame does not include this field, and must set it to
+     0. */
   int64_t stream_id;
   uint64_t offset;
   /* datacnt is the number of elements that data contains.  Although
@@ -301,17 +307,6 @@ typedef struct ngtcp2_path_response {
   uint8_t data[NGTCP2_PATH_CHALLENGE_DATALEN];
 } ngtcp2_path_response;
 
-typedef struct ngtcp2_crypto {
-  uint8_t type;
-  uint64_t offset;
-  /* datacnt is the number of elements that data contains.  Although
-     the length of data is 1 in this definition, the library may
-     allocate extra bytes to hold more elements. */
-  size_t datacnt;
-  /* data is the array of ngtcp2_vec which references data. */
-  ngtcp2_vec data[1];
-} ngtcp2_crypto;
-
 typedef struct ngtcp2_new_token {
   uint8_t type;
   uint8_t *token;
@@ -360,7 +355,6 @@ typedef union ngtcp2_frame {
   ngtcp2_stop_sending stop_sending;
   ngtcp2_path_challenge path_challenge;
   ngtcp2_path_response path_response;
-  ngtcp2_crypto crypto;
   ngtcp2_new_token new_token;
   ngtcp2_retire_connection_id retire_connection_id;
   ngtcp2_handshake_done handshake_done;
@@ -772,7 +766,7 @@ ngtcp2_ssize ngtcp2_pkt_decode_path_response_frame(ngtcp2_path_response *dest,
  * NGTCP2_ERR_FRAME_ENCODING
  *     Payload is too short to include CRYPTO frame.
  */
-ngtcp2_ssize ngtcp2_pkt_decode_crypto_frame(ngtcp2_crypto *dest,
+ngtcp2_ssize ngtcp2_pkt_decode_crypto_frame(ngtcp2_stream *dest,
                                             const uint8_t *payload,
                                             size_t payloadlen);
 
@@ -1071,7 +1065,7 @@ ngtcp2_pkt_encode_path_response_frame(uint8_t *out, size_t outlen,
  *     Buffer does not have enough capacity to write a frame.
  */
 ngtcp2_ssize ngtcp2_pkt_encode_crypto_frame(uint8_t *out, size_t outlen,
-                                            const ngtcp2_crypto *fr);
+                                            const ngtcp2_stream *fr);
 
 /*
  * ngtcp2_pkt_encode_new_token_frame encodes NEW_TOKEN frame |fr| into

--- a/lib/ngtcp2_qlog.c
+++ b/lib/ngtcp2_qlog.c
@@ -412,7 +412,7 @@ static uint8_t *write_stop_sending_frame(uint8_t *p,
   return p;
 }
 
-static uint8_t *write_crypto_frame(uint8_t *p, const ngtcp2_crypto *fr) {
+static uint8_t *write_crypto_frame(uint8_t *p, const ngtcp2_stream *fr) {
   /*
    * {"frame_type":"crypto","offset":0000000000000000000,"length":0000000000000000000}
    */
@@ -798,7 +798,7 @@ void ngtcp2_qlog_write_frame(ngtcp2_qlog *qlog, const ngtcp2_frame *fr) {
     if (ngtcp2_buf_left(&qlog->buf) < NGTCP2_QLOG_CRYPTO_FRAME_OVERHEAD + 1) {
       return;
     }
-    p = write_crypto_frame(p, &fr->crypto);
+    p = write_crypto_frame(p, &fr->stream);
     break;
   case NGTCP2_FRAME_NEW_TOKEN:
     if (ngtcp2_buf_left(&qlog->buf) <

--- a/lib/ngtcp2_rtb.c
+++ b/lib/ngtcp2_rtb.c
@@ -93,23 +93,6 @@ int ngtcp2_frame_chain_stream_datacnt_objalloc_new(ngtcp2_frame_chain **pfrc,
   return ngtcp2_frame_chain_objalloc_new(pfrc, objalloc);
 }
 
-int ngtcp2_frame_chain_crypto_datacnt_objalloc_new(ngtcp2_frame_chain **pfrc,
-                                                   size_t datacnt,
-                                                   ngtcp2_objalloc *objalloc,
-                                                   const ngtcp2_mem *mem) {
-  size_t need, avail = sizeof(ngtcp2_frame) - sizeof(ngtcp2_crypto);
-
-  if (datacnt > 1) {
-    need = sizeof(ngtcp2_vec) * (datacnt - 1);
-
-    if (need > avail) {
-      return ngtcp2_frame_chain_extralen_new(pfrc, need - avail, mem);
-    }
-  }
-
-  return ngtcp2_frame_chain_objalloc_new(pfrc, objalloc);
-}
-
 int ngtcp2_frame_chain_new_token_objalloc_new(ngtcp2_frame_chain **pfrc,
                                               const uint8_t *token,
                                               size_t tokenlen,
@@ -166,20 +149,11 @@ void ngtcp2_frame_chain_objalloc_del(ngtcp2_frame_chain *frc,
   }
 
   switch (frc->fr.type) {
+  case NGTCP2_FRAME_CRYPTO:
   case NGTCP2_FRAME_STREAM:
     if (frc->fr.stream.datacnt &&
         sizeof(ngtcp2_vec) * (frc->fr.stream.datacnt - 1) >
             sizeof(ngtcp2_frame) - sizeof(ngtcp2_stream)) {
-      ngtcp2_frame_chain_del(frc, mem);
-
-      return;
-    }
-
-    break;
-  case NGTCP2_FRAME_CRYPTO:
-    if (frc->fr.crypto.datacnt &&
-        sizeof(ngtcp2_vec) * (frc->fr.crypto.datacnt - 1) >
-            sizeof(ngtcp2_frame) - sizeof(ngtcp2_crypto)) {
       ngtcp2_frame_chain_del(frc, mem);
 
       return;
@@ -518,28 +492,27 @@ static ngtcp2_ssize rtb_reclaim_frame(ngtcp2_rtb *rtb, uint8_t flags,
     case NGTCP2_FRAME_CRYPTO:
       /* Don't resend CRYPTO frame if the whole region it contains has
          been acknowledged */
-      gap = ngtcp2_strm_get_unacked_range_after(rtb->crypto, fr->crypto.offset);
+      gap = ngtcp2_strm_get_unacked_range_after(rtb->crypto, fr->stream.offset);
 
-      range.begin = fr->crypto.offset;
-      range.end = fr->crypto.offset +
-                  ngtcp2_vec_len(fr->crypto.data, fr->crypto.datacnt);
+      range.begin = fr->stream.offset;
+      range.end = fr->stream.offset +
+                  ngtcp2_vec_len(fr->stream.data, fr->stream.datacnt);
       range = ngtcp2_range_intersect(&range, &gap);
       if (ngtcp2_range_len(&range) == 0) {
         continue;
       }
 
-      rv = ngtcp2_frame_chain_crypto_datacnt_objalloc_new(
-          &nfrc, fr->crypto.datacnt, rtb->frc_objalloc, rtb->mem);
+      rv = ngtcp2_frame_chain_stream_datacnt_objalloc_new(
+          &nfrc, fr->stream.datacnt, rtb->frc_objalloc, rtb->mem);
       if (rv != 0) {
         return rv;
       }
 
       nfrc->fr = *fr;
-      ngtcp2_vec_copy(nfrc->fr.crypto.data, fr->crypto.data,
-                      fr->crypto.datacnt);
+      ngtcp2_vec_copy(nfrc->fr.stream.data, fr->stream.data,
+                      fr->stream.datacnt);
 
-      rv = ngtcp2_ksl_insert(&pktns->crypto.tx.frq, NULL,
-                             &nfrc->fr.crypto.offset, nfrc);
+      rv = ngtcp2_strm_streamfrq_push(&pktns->crypto.strm, nfrc);
       if (rv != 0) {
         assert(ngtcp2_err_is_fatal(rv));
         ngtcp2_frame_chain_objalloc_del(nfrc, rtb->frc_objalloc, rtb->mem);
@@ -826,8 +799,8 @@ static int rtb_process_acked_pkt(ngtcp2_rtb *rtb, ngtcp2_rtb_entry *ent,
     case NGTCP2_FRAME_CRYPTO:
       prev_stream_offset = ngtcp2_strm_get_acked_offset(crypto);
       rv = ngtcp2_strm_ack_data(
-          crypto, frc->fr.crypto.offset,
-          ngtcp2_vec_len(frc->fr.crypto.data, frc->fr.crypto.datacnt));
+          crypto, frc->fr.stream.offset,
+          ngtcp2_vec_len(frc->fr.stream.data, frc->fr.stream.datacnt));
       if (rv != 0) {
         return rv;
       }
@@ -1539,8 +1512,7 @@ static int rtb_on_pkt_lost_resched_move(ngtcp2_rtb *rtb, ngtcp2_conn *conn,
       *pfrc = frc->next;
       frc->next = NULL;
 
-      rv = ngtcp2_ksl_insert(&pktns->crypto.tx.frq, NULL,
-                             &frc->fr.crypto.offset, frc);
+      rv = ngtcp2_strm_streamfrq_push(&pktns->crypto.strm, frc);
       if (rv != 0) {
         assert(ngtcp2_err_is_fatal(rv));
         ngtcp2_frame_chain_objalloc_del(frc, rtb->frc_objalloc, rtb->mem);

--- a/lib/ngtcp2_rtb.h
+++ b/lib/ngtcp2_rtb.h
@@ -106,10 +106,6 @@ int ngtcp2_bind_frame_chains(ngtcp2_frame_chain *a, ngtcp2_frame_chain *b,
    a ngtcp2_stream can include. */
 #define NGTCP2_MAX_STREAM_DATACNT 256
 
-/* NGTCP2_MAX_CRYPTO_DATACNT is the maximum number of ngtcp2_vec that
-   a ngtcp2_crypto can include. */
-#define NGTCP2_MAX_CRYPTO_DATACNT 8
-
 /*
  * ngtcp2_frame_chain_new allocates ngtcp2_frame_chain object and
  * assigns its pointer to |*pfrc|.
@@ -145,18 +141,6 @@ int ngtcp2_frame_chain_extralen_new(ngtcp2_frame_chain **pfrc, size_t extralen,
  * ngtcp2_frame_chain_objalloc_new is called internally.
  */
 int ngtcp2_frame_chain_stream_datacnt_objalloc_new(ngtcp2_frame_chain **pfrc,
-                                                   size_t datacnt,
-                                                   ngtcp2_objalloc *objalloc,
-                                                   const ngtcp2_mem *mem);
-
-/*
- * ngtcp2_frame_chain_crypto_datacnt_objalloc_new works like
- * ngtcp2_frame_chain_new, but it allocates enough data to store
- * additional |datacnt| - 1 ngtcp2_vec object after ngtcp2_crypto
- * object.  If no additional space is required,
- * ngtcp2_frame_chain_objalloc_new is called internally.
- */
-int ngtcp2_frame_chain_crypto_datacnt_objalloc_new(ngtcp2_frame_chain **pfrc,
                                                    size_t datacnt,
                                                    ngtcp2_objalloc *objalloc,
                                                    const ngtcp2_mem *mem);

--- a/lib/ngtcp2_strm.c
+++ b/lib/ngtcp2_strm.c
@@ -175,7 +175,8 @@ static int strm_streamfrq_init(ngtcp2_strm *strm) {
 int ngtcp2_strm_streamfrq_push(ngtcp2_strm *strm, ngtcp2_frame_chain *frc) {
   int rv;
 
-  assert(frc->fr.type == NGTCP2_FRAME_STREAM);
+  assert(frc->fr.type == NGTCP2_FRAME_STREAM ||
+         frc->fr.type == NGTCP2_FRAME_CRYPTO);
   assert(frc->next == NULL);
 
   if (strm->tx.streamfrq == NULL) {
@@ -306,7 +307,7 @@ static int strm_streamfrq_unacked_pop(ngtcp2_strm *strm,
 
     assert(nfr->data[0].len > end_base_offset);
 
-    nfr->type = NGTCP2_FRAME_STREAM;
+    nfr->type = fr->type;
     nfr->flags = 0;
     nfr->fin = fr->fin;
     nfr->stream_id = fr->stream_id;
@@ -408,7 +409,7 @@ int ngtcp2_strm_streamfrq_pop(ngtcp2_strm *strm, ngtcp2_frame_chain **pfrc,
     }
 
     nfr = &nfrc->fr.stream;
-    nfr->type = NGTCP2_FRAME_STREAM;
+    nfr->type = fr->type;
     nfr->flags = 0;
     nfr->fin = fr->fin;
     nfr->stream_id = fr->stream_id;

--- a/lib/ngtcp2_strm.h
+++ b/lib/ngtcp2_strm.h
@@ -96,10 +96,10 @@ struct ngtcp2_strm {
            remote endpoint acknowledges data in out-of-order.  After that,
            acked_offset is used instead. */
         uint64_t cont_acked_offset;
-        /* streamfrq contains STREAM frame for retransmission.  The flow
-           control credits have been paid when they are transmitted first
-           time.  There are no restriction regarding flow control for
-           retransmission. */
+        /* streamfrq contains STREAM or CRYPTO frame for
+           retransmission.  The flow control credits have been paid
+           when they are transmitted first time.  There are no
+           restriction regarding flow control for retransmission. */
         ngtcp2_ksl *streamfrq;
         /* offset is the next offset of outgoing data.  In other words, it
            is the number of bytes sent in this stream without

--- a/tests/ngtcp2_conn_test.c
+++ b/tests/ngtcp2_conn_test.c
@@ -3320,10 +3320,10 @@ void test_ngtcp2_conn_recv_delayed_handshake_pkt(void) {
   setup_default_client(&conn);
 
   fr.type = NGTCP2_FRAME_CRYPTO;
-  fr.crypto.offset = 0;
-  fr.crypto.datacnt = 1;
-  fr.crypto.data[0].len = 567;
-  fr.crypto.data[0].base = null_data;
+  fr.stream.offset = 0;
+  fr.stream.datacnt = 1;
+  fr.stream.data[0].len = 567;
+  fr.stream.data[0].base = null_data;
 
   pktlen = write_handshake_pkt(buf, sizeof(buf), &conn->oscid,
                                ngtcp2_conn_get_dcid(conn), 1,
@@ -3390,10 +3390,10 @@ void test_ngtcp2_conn_handshake(void) {
   /* Make sure server Initial is padded */
   setup_handshake_server(&conn);
   fr.type = NGTCP2_FRAME_CRYPTO;
-  fr.crypto.offset = 0;
-  fr.crypto.datacnt = 1;
-  fr.crypto.data[0].len = 1200;
-  fr.crypto.data[0].base = null_data;
+  fr.stream.offset = 0;
+  fr.stream.datacnt = 1;
+  fr.stream.data[0].len = 1200;
+  fr.stream.data[0].base = null_data;
 
   pktlen = write_initial_pkt(
       buf, sizeof(buf), &rcid, ngtcp2_conn_get_dcid(conn), ++pkt_num,
@@ -3413,10 +3413,10 @@ void test_ngtcp2_conn_handshake(void) {
      is coalesced. */
   setup_handshake_server(&conn);
   fr.type = NGTCP2_FRAME_CRYPTO;
-  fr.crypto.offset = 0;
-  fr.crypto.datacnt = 1;
-  fr.crypto.data[0].len = 1200;
-  fr.crypto.data[0].base = null_data;
+  fr.stream.offset = 0;
+  fr.stream.datacnt = 1;
+  fr.stream.data[0].len = 1200;
+  fr.stream.data[0].base = null_data;
 
   pktlen = write_initial_pkt(
       buf, sizeof(buf), &rcid, ngtcp2_conn_get_dcid(conn), ++pkt_num,
@@ -3478,10 +3478,10 @@ void test_ngtcp2_conn_handshake(void) {
   CU_ASSERT(spktlen >= 1200);
 
   fr.type = NGTCP2_FRAME_CRYPTO;
-  fr.crypto.offset = 0;
-  fr.crypto.datacnt = 1;
-  fr.crypto.data[0].len = 1200;
-  fr.crypto.data[0].base = null_data;
+  fr.stream.offset = 0;
+  fr.stream.datacnt = 1;
+  fr.stream.data[0].len = 1200;
+  fr.stream.data[0].base = null_data;
 
   pktlen = write_initial_pkt(
       buf, sizeof(buf), &conn->oscid, ngtcp2_conn_get_dcid(conn), ++pkt_num,
@@ -3516,10 +3516,10 @@ void test_ngtcp2_conn_handshake(void) {
   setup_handshake_server(&conn);
 
   fr.type = NGTCP2_FRAME_CRYPTO;
-  fr.crypto.offset = 0;
-  fr.crypto.datacnt = 1;
-  fr.crypto.data[0].len = 1200;
-  fr.crypto.data[0].base = null_data;
+  fr.stream.offset = 0;
+  fr.stream.datacnt = 1;
+  fr.stream.data[0].len = 1200;
+  fr.stream.data[0].base = null_data;
 
   pktlen = write_initial_pkt(
       buf, sizeof(buf), &conn->oscid, ngtcp2_conn_get_dcid(conn), ++pkt_num,
@@ -3659,10 +3659,10 @@ void test_ngtcp2_conn_handshake_error(void) {
   CU_ASSERT(spktlen > 0);
 
   fr.type = NGTCP2_FRAME_CRYPTO;
-  fr.crypto.offset = 0;
-  fr.crypto.datacnt = 1;
-  fr.crypto.data[0].len = 333;
-  fr.crypto.data[0].base = null_data;
+  fr.stream.offset = 0;
+  fr.stream.datacnt = 1;
+  fr.stream.data[0].len = 333;
+  fr.stream.data[0].base = null_data;
 
   pktlen = write_initial_pkt(
       buf, sizeof(buf), &conn->oscid, ngtcp2_conn_get_dcid(conn), ++pkt_num,
@@ -3679,10 +3679,10 @@ void test_ngtcp2_conn_handshake_error(void) {
   conn->callbacks.recv_crypto_data = recv_crypto_handshake_error;
 
   fr.type = NGTCP2_FRAME_CRYPTO;
-  fr.crypto.offset = 0;
-  fr.crypto.datacnt = 1;
-  fr.crypto.data[0].len = 1200;
-  fr.crypto.data[0].base = null_data;
+  fr.stream.offset = 0;
+  fr.stream.datacnt = 1;
+  fr.stream.data[0].len = 1200;
+  fr.stream.data[0].base = null_data;
 
   pktlen = write_initial_pkt(
       buf, sizeof(buf), &rcid, ngtcp2_conn_get_dcid(conn), ++pkt_num,
@@ -3699,10 +3699,10 @@ void test_ngtcp2_conn_handshake_error(void) {
   conn->callbacks.recv_crypto_data = recv_crypto_handshake_error;
 
   fr.type = NGTCP2_FRAME_CRYPTO;
-  fr.crypto.offset = 0;
-  fr.crypto.datacnt = 1;
-  fr.crypto.data[0].len = 1201;
-  fr.crypto.data[0].base = null_data;
+  fr.stream.offset = 0;
+  fr.stream.datacnt = 1;
+  fr.stream.data[0].len = 1201;
+  fr.stream.data[0].base = null_data;
 
   pktlen =
       write_initial_pkt(buf, sizeof(buf), &rcid, ngtcp2_conn_get_dcid(conn),
@@ -4407,10 +4407,10 @@ void test_ngtcp2_conn_recv_stream_data(void) {
   conn->callbacks.recv_crypto_data = recv_crypto_fatal_alert_generated;
 
   fr.type = NGTCP2_FRAME_CRYPTO;
-  fr.crypto.offset = 0;
-  fr.crypto.datacnt = 1;
-  fr.crypto.data[0].len = 139;
-  fr.crypto.data[0].base = null_data;
+  fr.stream.offset = 0;
+  fr.stream.datacnt = 1;
+  fr.stream.data[0].len = 139;
+  fr.stream.data[0].base = null_data;
 
   pktlen = write_pkt(buf, sizeof(buf), &conn->oscid, ++pkt_num, &fr, 1,
                      conn->pktns.crypto.rx.ckm);
@@ -4872,10 +4872,10 @@ void test_ngtcp2_conn_recv_early_data(void) {
   conn->user_data = &ud;
 
   fr.type = NGTCP2_FRAME_CRYPTO;
-  fr.crypto.offset = 0;
-  fr.crypto.datacnt = 1;
-  fr.crypto.data[0].len = 1221;
-  fr.crypto.data[0].base = null_data;
+  fr.stream.offset = 0;
+  fr.stream.datacnt = 1;
+  fr.stream.data[0].len = 1221;
+  fr.stream.data[0].base = null_data;
 
   pktlen = write_initial_pkt(
       buf, sizeof(buf), &rcid, ngtcp2_conn_get_dcid(conn), ++pkt_num,
@@ -4945,10 +4945,10 @@ void test_ngtcp2_conn_recv_early_data(void) {
   setup_early_server(&conn);
 
   fr.type = NGTCP2_FRAME_CRYPTO;
-  fr.crypto.offset = 0;
-  fr.crypto.datacnt = 1;
-  fr.crypto.data[0].len = 111;
-  fr.crypto.data[0].base = null_data;
+  fr.stream.offset = 0;
+  fr.stream.datacnt = 1;
+  fr.stream.data[0].len = 111;
+  fr.stream.data[0].base = null_data;
 
   pktlen = write_initial_pkt(
       buf, sizeof(buf), &rcid, ngtcp2_conn_get_dcid(conn), ++pkt_num,
@@ -4998,10 +4998,10 @@ void test_ngtcp2_conn_recv_compound_pkt(void) {
   setup_handshake_server(&conn);
 
   fr.type = NGTCP2_FRAME_CRYPTO;
-  fr.crypto.offset = 0;
-  fr.crypto.datacnt = 1;
-  fr.crypto.data[0].len = 611;
-  fr.crypto.data[0].base = null_data;
+  fr.stream.offset = 0;
+  fr.stream.datacnt = 1;
+  fr.stream.data[0].len = 611;
+  fr.stream.data[0].base = null_data;
 
   pktlen = write_initial_pkt(
       buf, sizeof(buf), &conn->oscid, ngtcp2_conn_get_dcid(conn), ++pkt_num,
@@ -5084,10 +5084,10 @@ void test_ngtcp2_conn_pkt_payloadlen(void) {
   setup_handshake_server(&conn);
 
   fr.type = NGTCP2_FRAME_CRYPTO;
-  fr.crypto.offset = 0;
-  fr.crypto.datacnt = 1;
-  fr.crypto.data[0].len = 1231;
-  fr.crypto.data[0].base = null_data;
+  fr.stream.offset = 0;
+  fr.stream.datacnt = 1;
+  fr.stream.data[0].len = 1231;
+  fr.stream.data[0].base = null_data;
 
   dcid = ngtcp2_conn_get_dcid(conn);
 
@@ -5113,10 +5113,10 @@ void test_ngtcp2_conn_pkt_payloadlen(void) {
   setup_handshake_server(&conn);
 
   fr.type = NGTCP2_FRAME_CRYPTO;
-  fr.crypto.offset = 0;
-  fr.crypto.datacnt = 1;
-  fr.crypto.data[0].len = 1000;
-  fr.crypto.data[0].base = null_data;
+  fr.stream.offset = 0;
+  fr.stream.datacnt = 1;
+  fr.stream.data[0].len = 1000;
+  fr.stream.data[0].base = null_data;
 
   pktlen = write_initial_pkt(buf, sizeof(buf), &conn->oscid,
                              ngtcp2_conn_get_dcid(conn), 0, NGTCP2_PROTO_VER_V1,
@@ -5369,10 +5369,10 @@ void test_ngtcp2_conn_writev_stream(void) {
   setup_handshake_server(&conn);
 
   fr.type = NGTCP2_FRAME_CRYPTO;
-  fr.crypto.offset = 0;
-  fr.crypto.datacnt = 1;
-  fr.crypto.data[0].len = 1200;
-  fr.crypto.data[0].base = null_data;
+  fr.stream.offset = 0;
+  fr.stream.datacnt = 1;
+  fr.stream.data[0].len = 1200;
+  fr.stream.data[0].base = null_data;
 
   pktlen = write_initial_pkt(
       buf, sizeof(buf), &conn->oscid, ngtcp2_conn_get_dcid(conn), ++pkt_num,
@@ -5435,10 +5435,10 @@ void test_ngtcp2_conn_writev_stream(void) {
   setup_handshake_server(&conn);
 
   fr.type = NGTCP2_FRAME_CRYPTO;
-  fr.crypto.offset = 0;
-  fr.crypto.datacnt = 1;
-  fr.crypto.data[0].len = 1200;
-  fr.crypto.data[0].base = null_data;
+  fr.stream.offset = 0;
+  fr.stream.datacnt = 1;
+  fr.stream.data[0].len = 1200;
+  fr.stream.data[0].base = null_data;
 
   pktlen = write_initial_pkt(
       buf, sizeof(buf), &conn->oscid, ngtcp2_conn_get_dcid(conn), ++pkt_num,
@@ -5701,10 +5701,10 @@ void test_ngtcp2_conn_recv_datagram(void) {
   conn->local.transport_params.max_datagram_frame_size = 1 + 1111;
 
   fr.type = NGTCP2_FRAME_CRYPTO;
-  fr.crypto.offset = 0;
-  fr.crypto.datacnt = 1;
-  fr.crypto.data[0].len = 1199;
-  fr.crypto.data[0].base = null_data;
+  fr.stream.offset = 0;
+  fr.stream.datacnt = 1;
+  fr.stream.data[0].len = 1199;
+  fr.stream.data[0].base = null_data;
 
   pktlen = write_initial_pkt(
       buf, sizeof(buf), &rcid, ngtcp2_conn_get_dcid(conn), ++pkt_num,
@@ -7039,10 +7039,10 @@ void test_ngtcp2_conn_crypto_buffer_exceeded(void) {
   setup_default_client(&conn);
 
   fr.type = NGTCP2_FRAME_CRYPTO;
-  fr.crypto.offset = 1000000;
-  fr.crypto.datacnt = 1;
-  fr.crypto.data[0].base = null_data;
-  fr.crypto.data[0].len = 1;
+  fr.stream.offset = 1000000;
+  fr.stream.datacnt = 1;
+  fr.stream.data[0].base = null_data;
+  fr.stream.data[0].len = 1;
 
   pktlen = write_pkt(buf, sizeof(buf), &conn->oscid, ++pkt_num, &fr, 1,
                      conn->pktns.crypto.rx.ckm);
@@ -7180,10 +7180,10 @@ void test_ngtcp2_conn_handshake_loss(void) {
   conn->callbacks.recv_crypto_data = recv_crypto_data;
 
   frs[0].type = NGTCP2_FRAME_CRYPTO;
-  frs[0].crypto.offset = 0;
-  frs[0].crypto.datacnt = 1;
-  frs[0].crypto.data[0].len = 123;
-  frs[0].crypto.data[0].base = null_data;
+  frs[0].stream.offset = 0;
+  frs[0].stream.datacnt = 1;
+  frs[0].stream.data[0].len = 123;
+  frs[0].stream.data[0].base = null_data;
 
   frs[1].type = NGTCP2_FRAME_PADDING;
   frs[1].padding.len = 1005;
@@ -7239,9 +7239,9 @@ void test_ngtcp2_conn_handshake_loss(void) {
   it = ngtcp2_ksl_begin(&conn->hs_pktns->rtb.ents);
   ent = ngtcp2_ksl_it_get(&it);
 
-  CU_ASSERT(0 == ent->frc->fr.crypto.offset);
-  CU_ASSERT(987 == ngtcp2_vec_len(ent->frc->fr.crypto.data,
-                                  ent->frc->fr.crypto.datacnt));
+  CU_ASSERT(0 == ent->frc->fr.stream.offset);
+  CU_ASSERT(987 == ngtcp2_vec_len(ent->frc->fr.stream.data,
+                                  ent->frc->fr.stream.datacnt));
   CU_ASSERT(3 == ent->hd.pkt_num);
 
   fr.type = NGTCP2_FRAME_ACK;
@@ -7274,10 +7274,10 @@ void test_ngtcp2_conn_handshake_loss(void) {
   ent = ngtcp2_ksl_it_get(&it);
 
   CU_ASSERT(NGTCP2_FRAME_CRYPTO == ent->frc->fr.type);
-  CU_ASSERT(987 == ent->frc->fr.crypto.offset);
-  CU_ASSERT(1 == ent->frc->fr.crypto.datacnt);
-  CU_ASSERT(1183 == ngtcp2_vec_len(ent->frc->fr.crypto.data,
-                                   ent->frc->fr.crypto.datacnt));
+  CU_ASSERT(987 == ent->frc->fr.stream.offset);
+  CU_ASSERT(1 == ent->frc->fr.stream.datacnt);
+  CU_ASSERT(1183 == ngtcp2_vec_len(ent->frc->fr.stream.data,
+                                   ent->frc->fr.stream.datacnt));
   CU_ASSERT(4 == ent->hd.pkt_num);
 
   spktlen = ngtcp2_conn_write_pkt(conn, NULL, NULL, buf, sizeof(buf), ++t);
@@ -7299,10 +7299,10 @@ void test_ngtcp2_conn_handshake_loss(void) {
   ent = ngtcp2_ksl_it_get(&it);
 
   CU_ASSERT(NGTCP2_FRAME_CRYPTO == ent->frc->fr.type);
-  CU_ASSERT(0 == ent->frc->fr.crypto.offset);
-  CU_ASSERT(2 == ent->frc->fr.crypto.datacnt);
-  CU_ASSERT(987 == ngtcp2_vec_len(ent->frc->fr.crypto.data,
-                                  ent->frc->fr.crypto.datacnt));
+  CU_ASSERT(0 == ent->frc->fr.stream.offset);
+  CU_ASSERT(2 == ent->frc->fr.stream.datacnt);
+  CU_ASSERT(987 == ngtcp2_vec_len(ent->frc->fr.stream.data,
+                                  ent->frc->fr.stream.datacnt));
   CU_ASSERT(5 == ent->hd.pkt_num);
 
   spktlen = ngtcp2_conn_write_pkt(conn, NULL, NULL, buf, sizeof(buf), ++t);
@@ -7313,10 +7313,10 @@ void test_ngtcp2_conn_handshake_loss(void) {
   ent = ngtcp2_ksl_it_get(&it);
 
   CU_ASSERT(NGTCP2_FRAME_CRYPTO == ent->frc->fr.type);
-  CU_ASSERT(987 == ent->frc->fr.crypto.offset);
-  CU_ASSERT(1 == ent->frc->fr.crypto.datacnt);
-  CU_ASSERT(1183 == ngtcp2_vec_len(ent->frc->fr.crypto.data,
-                                   ent->frc->fr.crypto.datacnt));
+  CU_ASSERT(987 == ent->frc->fr.stream.offset);
+  CU_ASSERT(1 == ent->frc->fr.stream.datacnt);
+  CU_ASSERT(1183 == ngtcp2_vec_len(ent->frc->fr.stream.data,
+                                   ent->frc->fr.stream.datacnt));
 
   CU_ASSERT(6 == ent->hd.pkt_num);
 
@@ -7331,10 +7331,10 @@ void test_ngtcp2_conn_handshake_loss(void) {
   conn->callbacks.recv_crypto_data = recv_crypto_data;
 
   frs[0].type = NGTCP2_FRAME_CRYPTO;
-  frs[0].crypto.offset = 0;
-  frs[0].crypto.datacnt = 1;
-  frs[0].crypto.data[0].len = 123;
-  frs[0].crypto.data[0].base = null_data;
+  frs[0].stream.offset = 0;
+  frs[0].stream.datacnt = 1;
+  frs[0].stream.data[0].len = 123;
+  frs[0].stream.data[0].base = null_data;
 
   frs[1].type = NGTCP2_FRAME_PADDING;
   frs[1].padding.len = 1005;
@@ -7368,9 +7368,9 @@ void test_ngtcp2_conn_handshake_loss(void) {
   ent = ngtcp2_ksl_it_get(&it);
 
   CU_ASSERT(NGTCP2_FRAME_CRYPTO == ent->frc->fr.type);
-  CU_ASSERT(2170 == ent->frc->fr.crypto.offset);
-  CU_ASSERT(830 == ngtcp2_vec_len(ent->frc->fr.crypto.data,
-                                  ent->frc->fr.crypto.datacnt));
+  CU_ASSERT(2170 == ent->frc->fr.stream.offset);
+  CU_ASSERT(830 == ngtcp2_vec_len(ent->frc->fr.stream.data,
+                                  ent->frc->fr.stream.datacnt));
   CU_ASSERT(2 == ent->hd.pkt_num);
 
   t += 30 * NGTCP2_MILLISECONDS;
@@ -7392,9 +7392,9 @@ void test_ngtcp2_conn_handshake_loss(void) {
   ent = ngtcp2_ksl_it_get(&it);
 
   CU_ASSERT(NGTCP2_FRAME_CRYPTO == ent->frc->fr.type);
-  CU_ASSERT(0 == ent->frc->fr.crypto.offset);
-  CU_ASSERT(987 == ngtcp2_vec_len(ent->frc->fr.crypto.data,
-                                  ent->frc->fr.crypto.datacnt));
+  CU_ASSERT(0 == ent->frc->fr.stream.offset);
+  CU_ASSERT(987 == ngtcp2_vec_len(ent->frc->fr.stream.data,
+                                  ent->frc->fr.stream.datacnt));
   CU_ASSERT(3 == ent->hd.pkt_num);
 
   t += 30 * NGTCP2_MILLISECONDS;
@@ -7413,9 +7413,9 @@ void test_ngtcp2_conn_handshake_loss(void) {
   ent = ngtcp2_ksl_it_get(&it);
 
   CU_ASSERT(NGTCP2_FRAME_CRYPTO == ent->frc->fr.type);
-  CU_ASSERT(987 == ent->frc->fr.crypto.offset);
-  CU_ASSERT(991 == ngtcp2_vec_len(ent->frc->fr.crypto.data,
-                                  ent->frc->fr.crypto.datacnt));
+  CU_ASSERT(987 == ent->frc->fr.stream.offset);
+  CU_ASSERT(991 == ngtcp2_vec_len(ent->frc->fr.stream.data,
+                                  ent->frc->fr.stream.datacnt));
   CU_ASSERT(4 == ent->hd.pkt_num);
 
   spktlen = ngtcp2_conn_write_pkt(conn, NULL, NULL, buf, sizeof(buf), ++t);
@@ -7425,9 +7425,9 @@ void test_ngtcp2_conn_handshake_loss(void) {
   ent = ngtcp2_ksl_it_get(&it);
 
   CU_ASSERT(NGTCP2_FRAME_CRYPTO == ent->frc->fr.type);
-  CU_ASSERT(1978 == ent->frc->fr.crypto.offset);
-  CU_ASSERT(192 == ngtcp2_vec_len(ent->frc->fr.crypto.data,
-                                  ent->frc->fr.crypto.datacnt));
+  CU_ASSERT(1978 == ent->frc->fr.stream.offset);
+  CU_ASSERT(192 == ngtcp2_vec_len(ent->frc->fr.stream.data,
+                                  ent->frc->fr.stream.datacnt));
   CU_ASSERT(5 == ent->hd.pkt_num);
 
   spktlen = ngtcp2_conn_write_pkt(conn, NULL, NULL, buf, sizeof(buf), ++t);
@@ -7464,9 +7464,9 @@ void test_ngtcp2_conn_handshake_loss(void) {
   ent = ngtcp2_ksl_it_get(&it);
 
   CU_ASSERT(NGTCP2_FRAME_CRYPTO == ent->frc->fr.type);
-  CU_ASSERT(2170 == ent->frc->fr.crypto.offset);
-  CU_ASSERT(830 == ngtcp2_vec_len(ent->frc->fr.crypto.data,
-                                  ent->frc->fr.crypto.datacnt));
+  CU_ASSERT(2170 == ent->frc->fr.stream.offset);
+  CU_ASSERT(830 == ngtcp2_vec_len(ent->frc->fr.stream.data,
+                                  ent->frc->fr.stream.datacnt));
   CU_ASSERT(6 == ent->hd.pkt_num);
   CU_ASSERT(NULL == ent->frc->next);
 
@@ -7478,9 +7478,9 @@ void test_ngtcp2_conn_handshake_loss(void) {
   ent = ngtcp2_ksl_it_get(&it);
 
   CU_ASSERT(NGTCP2_FRAME_CRYPTO == ent->frc->fr.type);
-  CU_ASSERT(987 == ent->frc->fr.crypto.offset);
-  CU_ASSERT(991 == ngtcp2_vec_len(ent->frc->fr.crypto.data,
-                                  ent->frc->fr.crypto.datacnt));
+  CU_ASSERT(987 == ent->frc->fr.stream.offset);
+  CU_ASSERT(991 == ngtcp2_vec_len(ent->frc->fr.stream.data,
+                                  ent->frc->fr.stream.datacnt));
   CU_ASSERT(7 == ent->hd.pkt_num);
   CU_ASSERT(NULL == ent->frc->next);
 
@@ -7503,10 +7503,10 @@ void test_ngtcp2_conn_handshake_loss(void) {
   CU_ASSERT(spktlen >= 1200);
 
   fr.type = NGTCP2_FRAME_CRYPTO;
-  fr.crypto.offset = 0;
-  fr.crypto.datacnt = 1;
-  fr.crypto.data[0].len = 117;
-  fr.crypto.data[0].base = null_data;
+  fr.stream.offset = 0;
+  fr.stream.datacnt = 1;
+  fr.stream.data[0].len = 117;
+  fr.stream.data[0].base = null_data;
 
   pktlen = write_initial_pkt(
       buf, sizeof(buf), &conn->oscid, ngtcp2_conn_get_dcid(conn), ++pkt_num,
@@ -7592,7 +7592,7 @@ void test_ngtcp2_conn_handshake_loss(void) {
   rv = ngtcp2_conn_read_pkt(conn, &null_path.path, &null_pi, buf, pktlen, ++t);
 
   CU_ASSERT(0 == rv);
-  CU_ASSERT(ngtcp2_ksl_len(&conn->hs_pktns->crypto.tx.frq) != 0);
+  CU_ASSERT(!ngtcp2_strm_streamfrq_empty(&conn->hs_pktns->crypto.strm));
   CU_ASSERT(conn->cstat.bytes_in_flight > conn->cstat.cwnd);
 
   /* Resending Handshake CRYPTO is allowed even if it exceeds CWND in
@@ -7600,7 +7600,7 @@ void test_ngtcp2_conn_handshake_loss(void) {
   spktlen = ngtcp2_conn_write_pkt(conn, NULL, NULL, buf, sizeof(buf), ++t);
 
   CU_ASSERT(spktlen > 0);
-  CU_ASSERT(ngtcp2_ksl_len(&conn->hs_pktns->crypto.tx.frq) == 0);
+  CU_ASSERT(ngtcp2_strm_streamfrq_empty(&conn->hs_pktns->crypto.strm));
 
   /* Check that Handshake ACK only packet can be sent anytime */
   fr.type = NGTCP2_FRAME_PING;
@@ -7664,7 +7664,7 @@ void test_ngtcp2_conn_handshake_loss(void) {
 
   t += 35 * NGTCP2_MILLISECONDS;
 
-  CU_ASSERT(0 == ngtcp2_ksl_len(&conn->in_pktns->crypto.tx.frq));
+  CU_ASSERT(ngtcp2_strm_streamfrq_empty(&conn->in_pktns->crypto.strm));
 
   ngtcp2_conn_on_loss_detection_timer(conn, t);
 
@@ -7677,7 +7677,7 @@ void test_ngtcp2_conn_handshake_loss(void) {
 
   CU_ASSERT(1 == conn->in_pktns->rtb.probe_pkt_left);
   CU_ASSERT(conn->cstat.bytes_in_flight > conn->cstat.cwnd);
-  CU_ASSERT(ngtcp2_ksl_len(&conn->in_pktns->crypto.tx.frq) != 0);
+  CU_ASSERT(!ngtcp2_strm_streamfrq_empty(&conn->in_pktns->crypto.strm));
 
   spktlen =
       ngtcp2_conn_write_stream(conn, NULL, NULL, buf, sizeof(buf), NULL,
@@ -7767,10 +7767,10 @@ void test_ngtcp2_conn_recv_client_initial_retry(void) {
 
   setup_handshake_server(&conn);
   fr.type = NGTCP2_FRAME_CRYPTO;
-  fr.crypto.offset = 1;
-  fr.crypto.datacnt = 1;
-  fr.crypto.data[0].len = 1245;
-  fr.crypto.data[0].base = null_data;
+  fr.stream.offset = 1;
+  fr.stream.datacnt = 1;
+  fr.stream.data[0].len = 1245;
+  fr.stream.data[0].base = null_data;
 
   pktlen = write_initial_pkt(
       buf, sizeof(buf), &rcid, ngtcp2_conn_get_dcid(conn), ++pkt_num,
@@ -7808,10 +7808,10 @@ void test_ngtcp2_conn_recv_client_initial_token(void) {
   conn->local.settings.tokenlen = sizeof(raw_token);
 
   fr.type = NGTCP2_FRAME_CRYPTO;
-  fr.crypto.offset = 0;
-  fr.crypto.datacnt = 1;
-  fr.crypto.data[0].len = 1181;
-  fr.crypto.data[0].base = null_data;
+  fr.stream.offset = 0;
+  fr.stream.datacnt = 1;
+  fr.stream.data[0].len = 1181;
+  fr.stream.data[0].base = null_data;
 
   pktlen =
       write_initial_pkt(buf, sizeof(buf), &rcid, ngtcp2_conn_get_dcid(conn),
@@ -7836,10 +7836,10 @@ void test_ngtcp2_conn_recv_client_initial_token(void) {
   conn->local.settings.tokenlen = sizeof(raw_token) - 1;
 
   fr.type = NGTCP2_FRAME_CRYPTO;
-  fr.crypto.offset = 0;
-  fr.crypto.datacnt = 1;
-  fr.crypto.data[0].len = 1179;
-  fr.crypto.data[0].base = null_data;
+  fr.stream.offset = 0;
+  fr.stream.datacnt = 1;
+  fr.stream.data[0].len = 1179;
+  fr.stream.data[0].base = null_data;
 
   pktlen =
       write_initial_pkt(buf, sizeof(buf), &rcid, ngtcp2_conn_get_dcid(conn),
@@ -9315,10 +9315,10 @@ void test_ngtcp2_conn_early_data_sync_stream_data_limit(void) {
   CU_ASSERT(958);
 
   fr.type = NGTCP2_FRAME_CRYPTO;
-  fr.crypto.offset = 0;
-  fr.crypto.datacnt = 1;
-  fr.crypto.data[0].len = 198;
-  fr.crypto.data[0].base = null_data;
+  fr.stream.offset = 0;
+  fr.stream.datacnt = 1;
+  fr.stream.data[0].len = 198;
+  fr.stream.data[0].base = null_data;
 
   pktlen = write_initial_pkt(buf, sizeof(buf), &conn->oscid,
                              ngtcp2_conn_get_dcid(conn), 0, NGTCP2_PROTO_VER_V1,
@@ -9408,10 +9408,10 @@ void test_ngtcp2_conn_tls_early_data_rejected(void) {
             conn->remote.uni.max_streams);
 
   fr.type = NGTCP2_FRAME_CRYPTO;
-  fr.crypto.offset = 0;
-  fr.crypto.datacnt = 1;
-  fr.crypto.data[0].len = 198;
-  fr.crypto.data[0].base = null_data;
+  fr.stream.offset = 0;
+  fr.stream.datacnt = 1;
+  fr.stream.data[0].len = 198;
+  fr.stream.data[0].base = null_data;
 
   pktlen = write_initial_pkt(buf, sizeof(buf), &conn->oscid,
                              ngtcp2_conn_get_dcid(conn), 0, NGTCP2_PROTO_VER_V1,
@@ -9563,10 +9563,10 @@ void test_ngtcp2_conn_keep_alive(void) {
                                   conn->keep_alive.timeout, t));
 
   fr.type = NGTCP2_FRAME_CRYPTO;
-  fr.crypto.offset = 0;
-  fr.crypto.datacnt = 1;
-  fr.crypto.data[0].len = 127;
-  fr.crypto.data[0].base = null_data;
+  fr.stream.offset = 0;
+  fr.stream.datacnt = 1;
+  fr.stream.data[0].len = 127;
+  fr.stream.data[0].base = null_data;
 
   pktlen = write_initial_pkt(
       buf, sizeof(buf), &conn->oscid, ngtcp2_conn_get_dcid(conn), ++pkt_num,
@@ -10015,10 +10015,10 @@ void test_ngtcp2_conn_buffer_pkt(void) {
   setup_handshake_server(&conn);
 
   fr.type = NGTCP2_FRAME_CRYPTO;
-  fr.crypto.offset = 0;
-  fr.crypto.datacnt = 1;
-  fr.crypto.data[0].len = 1193;
-  fr.crypto.data[0].base = null_data;
+  fr.stream.offset = 0;
+  fr.stream.datacnt = 1;
+  fr.stream.data[0].len = 1193;
+  fr.stream.data[0].base = null_data;
 
   pktlen = write_initial_pkt(buf, sizeof(buf), &conn->oscid,
                              ngtcp2_conn_get_dcid(conn), pkt_num++,
@@ -10184,10 +10184,10 @@ void test_ngtcp2_conn_version_negotiation(void) {
   CU_ASSERT(spktlen > 0);
 
   fr.type = NGTCP2_FRAME_CRYPTO;
-  fr.crypto.offset = 0;
-  fr.crypto.datacnt = 1;
-  fr.crypto.data[0].len = 133;
-  fr.crypto.data[0].base = null_data;
+  fr.stream.offset = 0;
+  fr.stream.datacnt = 1;
+  fr.stream.data[0].len = 133;
+  fr.stream.data[0].base = null_data;
 
   pktlen = write_initial_pkt(buf, sizeof(buf), &conn->oscid,
                              ngtcp2_conn_get_dcid(conn), pkt_num++,
@@ -10245,10 +10245,10 @@ void test_ngtcp2_conn_version_negotiation(void) {
       recv_client_initial_no_remote_transport_params;
 
   fr.type = NGTCP2_FRAME_CRYPTO;
-  fr.crypto.offset = 0;
-  fr.crypto.datacnt = 1;
-  fr.crypto.data[0].len = 1233;
-  fr.crypto.data[0].base = null_data;
+  fr.stream.offset = 0;
+  fr.stream.datacnt = 1;
+  fr.stream.data[0].len = 1233;
+  fr.stream.data[0].base = null_data;
 
   pktlen = write_initial_pkt(buf, sizeof(buf), &conn->oscid,
                              ngtcp2_conn_get_dcid(conn), pkt_num++,
@@ -10293,10 +10293,10 @@ void test_ngtcp2_conn_version_negotiation(void) {
       recv_client_initial_no_remote_transport_params;
 
   fr.type = NGTCP2_FRAME_CRYPTO;
-  fr.crypto.offset = 0;
-  fr.crypto.datacnt = 1;
-  fr.crypto.data[0].len = 1211;
-  fr.crypto.data[0].base = null_data;
+  fr.stream.offset = 0;
+  fr.stream.datacnt = 1;
+  fr.stream.data[0].len = 1211;
+  fr.stream.data[0].base = null_data;
 
   pktlen = write_initial_pkt(buf, sizeof(buf), &conn->oscid,
                              ngtcp2_conn_get_dcid(conn), pkt_num++,
@@ -10461,10 +10461,10 @@ void test_ngtcp2_conn_amplification(void) {
   setup_early_server(&conn);
 
   fr.type = NGTCP2_FRAME_CRYPTO;
-  fr.crypto.offset = 0;
-  fr.crypto.datacnt = 1;
-  fr.crypto.data[0].len = 1200;
-  fr.crypto.data[0].base = null_data;
+  fr.stream.offset = 0;
+  fr.stream.datacnt = 1;
+  fr.stream.data[0].len = 1200;
+  fr.stream.data[0].base = null_data;
 
   pktlen = write_initial_pkt(
       buf, sizeof(buf), &rcid, ngtcp2_conn_get_dcid(conn), ++pkt_num,
@@ -11076,10 +11076,10 @@ void test_ngtcp2_conn_grease_quic_bit(void) {
   setup_handshake_server_settings(&conn, &null_path.path, &settings, &params);
 
   fr.type = NGTCP2_FRAME_CRYPTO;
-  fr.crypto.offset = 0;
-  fr.crypto.datacnt = 1;
-  fr.crypto.data[0].len = 1200;
-  fr.crypto.data[0].base = null_data;
+  fr.stream.offset = 0;
+  fr.stream.datacnt = 1;
+  fr.stream.data[0].len = 1200;
+  fr.stream.data[0].base = null_data;
 
   pktlen =
       write_initial_pkt_flags(buf, sizeof(buf), NGTCP2_PKT_FLAG_FIXED_BIT_CLEAR,
@@ -11102,10 +11102,10 @@ void test_ngtcp2_conn_grease_quic_bit(void) {
   setup_handshake_server_settings(&conn, &null_path.path, &settings, &params);
 
   fr.type = NGTCP2_FRAME_CRYPTO;
-  fr.crypto.offset = 0;
-  fr.crypto.datacnt = 1;
-  fr.crypto.data[0].len = 1200;
-  fr.crypto.data[0].base = null_data;
+  fr.stream.offset = 0;
+  fr.stream.datacnt = 1;
+  fr.stream.data[0].len = 1200;
+  fr.stream.data[0].base = null_data;
 
   pktlen = write_initial_pkt_flags(
       buf, sizeof(buf), NGTCP2_PKT_FLAG_FIXED_BIT_CLEAR, &rcid,
@@ -11127,10 +11127,10 @@ void test_ngtcp2_conn_grease_quic_bit(void) {
   setup_handshake_server_settings(&conn, &null_path.path, &settings, &params);
 
   fr.type = NGTCP2_FRAME_CRYPTO;
-  fr.crypto.offset = 0;
-  fr.crypto.datacnt = 1;
-  fr.crypto.data[0].len = 1200;
-  fr.crypto.data[0].base = null_data;
+  fr.stream.offset = 0;
+  fr.stream.datacnt = 1;
+  fr.stream.data[0].len = 1200;
+  fr.stream.data[0].base = null_data;
 
   pktlen = write_initial_pkt_flags(
       buf, sizeof(buf), NGTCP2_PKT_FLAG_FIXED_BIT_CLEAR, &rcid,
@@ -11153,10 +11153,10 @@ void test_ngtcp2_conn_grease_quic_bit(void) {
   setup_handshake_server_settings(&conn, &null_path.path, &settings, &params);
 
   fr.type = NGTCP2_FRAME_CRYPTO;
-  fr.crypto.offset = 0;
-  fr.crypto.datacnt = 1;
-  fr.crypto.data[0].len = 1200;
-  fr.crypto.data[0].base = null_data;
+  fr.stream.offset = 0;
+  fr.stream.datacnt = 1;
+  fr.stream.data[0].len = 1200;
+  fr.stream.data[0].base = null_data;
 
   pktlen = write_initial_pkt_flags(
       buf, sizeof(buf), NGTCP2_PKT_FLAG_FIXED_BIT_CLEAR, &rcid,
@@ -11807,10 +11807,10 @@ void test_ngtcp2_accept(void) {
   memset(&hd, 0, sizeof(hd));
 
   fr.type = NGTCP2_FRAME_CRYPTO;
-  fr.crypto.offset = 0;
-  fr.crypto.datacnt = 1;
-  fr.crypto.data[0].len = 1200;
-  fr.crypto.data[0].base = null_data;
+  fr.stream.offset = 0;
+  fr.stream.datacnt = 1;
+  fr.stream.data[0].len = 1200;
+  fr.stream.data[0].base = null_data;
 
   pktlen = write_initial_pkt(buf, sizeof(buf), &dcid, &scid, 0,
                              NGTCP2_PROTO_VER_V1, NULL, 0, &fr, 1, &null_ckm);
@@ -11853,10 +11853,10 @@ void test_ngtcp2_accept(void) {
   memset(&hd, 0, sizeof(hd));
 
   fr.type = NGTCP2_FRAME_CRYPTO;
-  fr.crypto.offset = 0;
-  fr.crypto.datacnt = 1;
-  fr.crypto.data[0].len = 1200;
-  fr.crypto.data[0].base = null_data;
+  fr.stream.offset = 0;
+  fr.stream.datacnt = 1;
+  fr.stream.data[0].len = 1200;
+  fr.stream.data[0].base = null_data;
 
   pktlen = write_initial_pkt(buf, sizeof(buf), &dcid, &scid, 0, 0x2, NULL, 0,
                              &fr, 1, &null_ckm);
@@ -11875,10 +11875,10 @@ void test_ngtcp2_accept(void) {
   memset(&hd, 0, sizeof(hd));
 
   fr.type = NGTCP2_FRAME_CRYPTO;
-  fr.crypto.offset = 0;
-  fr.crypto.datacnt = 1;
-  fr.crypto.data[0].len = 1127;
-  fr.crypto.data[0].base = null_data;
+  fr.stream.offset = 0;
+  fr.stream.datacnt = 1;
+  fr.stream.data[0].len = 1127;
+  fr.stream.data[0].base = null_data;
 
   pktlen = write_initial_pkt(buf, sizeof(buf), &dcid, &scid, 0, 0x2, NULL, 0,
                              &fr, 1, &null_ckm);
@@ -11893,10 +11893,10 @@ void test_ngtcp2_accept(void) {
   memset(&hd, 0, sizeof(hd));
 
   fr.type = NGTCP2_FRAME_CRYPTO;
-  fr.crypto.offset = 0;
-  fr.crypto.datacnt = 1;
-  fr.crypto.data[0].len = 1200;
-  fr.crypto.data[0].base = null_data;
+  fr.stream.offset = 0;
+  fr.stream.datacnt = 1;
+  fr.stream.data[0].len = 1200;
+  fr.stream.data[0].base = null_data;
 
   pktlen = write_pkt(buf, sizeof(buf), &dcid, 0, &fr, 1, &null_ckm);
 

--- a/tests/ngtcp2_pkt_test.c
+++ b/tests/ngtcp2_pkt_test.c
@@ -1232,26 +1232,32 @@ void test_ngtcp2_pkt_encode_crypto_frame(void) {
   size_t framelen;
 
   fr.type = NGTCP2_FRAME_CRYPTO;
-  fr.crypto.offset = 0x31f2f3f4f5f6f7f8llu;
-  fr.crypto.datacnt = 1;
-  fr.crypto.data[0].len = strsize(data);
-  fr.crypto.data[0].base = (uint8_t *)data;
+  fr.stream.flags = 0;
+  fr.stream.fin = 0;
+  fr.stream.stream_id = 0;
+  fr.stream.offset = 0x31f2f3f4f5f6f7f8llu;
+  fr.stream.datacnt = 1;
+  fr.stream.data[0].len = strsize(data);
+  fr.stream.data[0].base = (uint8_t *)data;
 
   framelen = 1 + 8 + 1 + 17;
 
-  rv = ngtcp2_pkt_encode_crypto_frame(buf, sizeof(buf), &fr.crypto);
+  rv = ngtcp2_pkt_encode_crypto_frame(buf, sizeof(buf), &fr.stream);
 
   CU_ASSERT((ngtcp2_ssize)framelen == rv);
 
-  rv = ngtcp2_pkt_decode_crypto_frame(&nfr.crypto, buf, framelen);
+  rv = ngtcp2_pkt_decode_crypto_frame(&nfr.stream, buf, framelen);
 
   CU_ASSERT((ngtcp2_ssize)framelen == rv);
   CU_ASSERT(fr.type == nfr.type);
-  CU_ASSERT(fr.crypto.offset == nfr.crypto.offset);
-  CU_ASSERT(fr.crypto.datacnt == nfr.crypto.datacnt);
-  CU_ASSERT(fr.crypto.data[0].len == nfr.crypto.data[0].len);
-  CU_ASSERT(0 == memcmp(fr.crypto.data[0].base, nfr.crypto.data[0].base,
-                        fr.crypto.data[0].len));
+  CU_ASSERT(fr.stream.flags == nfr.stream.flags);
+  CU_ASSERT(fr.stream.fin == nfr.stream.fin);
+  CU_ASSERT(fr.stream.stream_id == nfr.stream.stream_id);
+  CU_ASSERT(fr.stream.offset == nfr.stream.offset);
+  CU_ASSERT(fr.stream.datacnt == nfr.stream.datacnt);
+  CU_ASSERT(fr.stream.data[0].len == nfr.stream.data[0].len);
+  CU_ASSERT(0 == memcmp(fr.stream.data[0].base, nfr.stream.data[0].base,
+                        fr.stream.data[0].len));
 }
 
 void test_ngtcp2_pkt_encode_new_token_frame(void) {

--- a/tests/ngtcp2_qlog_test.c
+++ b/tests/ngtcp2_qlog_test.c
@@ -203,9 +203,9 @@ void test_ngtcp2_qlog_write_frame(void) {
     memset(&exfr, 0, sizeof(exfr));
 
     fr->type = NGTCP2_FRAME_CRYPTO;
-    fr->crypto.offset = 65000011;
-    fr->crypto.datacnt = 1;
-    fr->crypto.data[0].len = 111187;
+    fr->stream.offset = 65000011;
+    fr->stream.datacnt = 1;
+    fr->stream.data[0].len = 111187;
 
     ngtcp2_qlog_write_frame(&qlog, fr);
 


### PR DESCRIPTION
Share mostly identical lines of code between STREAM and CRYPTO frames by unifying its underlying structures.