### PR TITLE
Rename NGTCP2_LOG_EVENT_RCV to NGTCP2_LOG_EVENT_LDC

### DIFF
--- a/lib/ngtcp2_conn.c
+++ b/lib/ngtcp2_conn.c
@@ -1891,7 +1891,7 @@ static int conn_cwnd_is_zero(ngtcp2_conn *conn) {
   uint64_t cwnd = conn_get_cwnd(conn);
 
   if (bytes_in_flight >= cwnd) {
-    ngtcp2_log_info(&conn->log, NGTCP2_LOG_EVENT_RCV,
+    ngtcp2_log_info(&conn->log, NGTCP2_LOG_EVENT_LDC,
                     "cwnd limited bytes_in_flight=%lu cwnd=%lu",
                     bytes_in_flight, cwnd);
   }
@@ -2805,7 +2805,7 @@ static ngtcp2_ssize conn_write_handshake_pkts(ngtcp2_conn *conn,
             conn_server_tx_left(conn, &conn->dcid.current) <
                 NGTCP2_MAX_UDP_PAYLOAD_SIZE) {
           ngtcp2_log_info(
-              &conn->log, NGTCP2_LOG_EVENT_RCV,
+              &conn->log, NGTCP2_LOG_EVENT_LDC,
               "loss detection timer canceled due to amplification limit");
           cstat->loss_detection_timer = UINT64_MAX;
         }
@@ -11946,7 +11946,7 @@ ngtcp2_ssize ngtcp2_conn_write_vmsg(ngtcp2_conn *conn, ngtcp2_path *path,
         if (server_tx_left == 0) {
           if (cstat->loss_detection_timer != UINT64_MAX) {
             ngtcp2_log_info(
-                &conn->log, NGTCP2_LOG_EVENT_RCV,
+                &conn->log, NGTCP2_LOG_EVENT_LDC,
                 "loss detection timer canceled due to amplification limit");
             cstat->loss_detection_timer = UINT64_MAX;
           }
@@ -12101,7 +12101,7 @@ ngtcp2_ssize ngtcp2_conn_write_vmsg(ngtcp2_conn *conn, ngtcp2_path *path,
       if (server_tx_left == 0 &&
           conn->cstat.loss_detection_timer != UINT64_MAX) {
         ngtcp2_log_info(
-            &conn->log, NGTCP2_LOG_EVENT_RCV,
+            &conn->log, NGTCP2_LOG_EVENT_LDC,
             "loss detection timer canceled due to amplification limit");
         conn->cstat.loss_detection_timer = UINT64_MAX;
       }
@@ -12845,7 +12845,7 @@ int ngtcp2_conn_update_rtt(ngtcp2_conn *conn, ngtcp2_duration rtt,
       /* Ignore RTT sample if adjusting ack_delay causes the sample
          less than min_rtt before handshake confirmation. */
       ngtcp2_log_info(
-          &conn->log, NGTCP2_LOG_EVENT_RCV,
+          &conn->log, NGTCP2_LOG_EVENT_LDC,
           "ignore rtt sample because ack_delay is too large latest_rtt=%" PRIu64
           " min_rtt=%" PRIu64 " ack_delay=%" PRIu64,
           rtt / NGTCP2_MILLISECONDS, cstat->min_rtt / NGTCP2_MILLISECONDS,
@@ -12868,7 +12868,7 @@ int ngtcp2_conn_update_rtt(ngtcp2_conn *conn, ngtcp2_duration rtt,
   }
 
   ngtcp2_log_info(
-      &conn->log, NGTCP2_LOG_EVENT_RCV,
+      &conn->log, NGTCP2_LOG_EVENT_LDC,
       "latest_rtt=%" PRIu64 " min_rtt=%" PRIu64 " smoothed_rtt=%" PRIu64
       " rttvar=%" PRIu64 " ack_delay=%" PRIu64,
       cstat->latest_rtt / NGTCP2_MILLISECONDS,
@@ -12973,7 +12973,7 @@ void ngtcp2_conn_set_loss_detection_timer(ngtcp2_conn *conn, ngtcp2_tstamp ts) {
   if (earliest_loss_time != UINT64_MAX) {
     cstat->loss_detection_timer = earliest_loss_time;
 
-    ngtcp2_log_info(&conn->log, NGTCP2_LOG_EVENT_RCV,
+    ngtcp2_log_info(&conn->log, NGTCP2_LOG_EVENT_LDC,
                     "loss_detection_timer=%" PRIu64 " nonzero crypto loss time",
                     cstat->loss_detection_timer);
     return;
@@ -12987,7 +12987,7 @@ void ngtcp2_conn_set_loss_detection_timer(ngtcp2_conn *conn, ngtcp2_tstamp ts) {
        (conn->flags & (NGTCP2_CONN_FLAG_SERVER_ADDR_VERIFIED |
                        NGTCP2_CONN_FLAG_HANDSHAKE_CONFIRMED)))) {
     if (cstat->loss_detection_timer != UINT64_MAX) {
-      ngtcp2_log_info(&conn->log, NGTCP2_LOG_EVENT_RCV,
+      ngtcp2_log_info(&conn->log, NGTCP2_LOG_EVENT_LDC,
                       "loss detection timer canceled");
       cstat->loss_detection_timer = UINT64_MAX;
       cstat->pto_count = 0;
@@ -13000,7 +13000,7 @@ void ngtcp2_conn_set_loss_detection_timer(ngtcp2_conn *conn, ngtcp2_tstamp ts) {
   timeout =
       cstat->loss_detection_timer > ts ? cstat->loss_detection_timer - ts : 0;
 
-  ngtcp2_log_info(&conn->log, NGTCP2_LOG_EVENT_RCV,
+  ngtcp2_log_info(&conn->log, NGTCP2_LOG_EVENT_LDC,
                   "loss_detection_timer=%" PRIu64 " timeout=%" PRIu64,
                   cstat->loss_detection_timer, timeout / NGTCP2_MILLISECONDS);
 }
@@ -13029,7 +13029,7 @@ int ngtcp2_conn_on_loss_detection_timer(ngtcp2_conn *conn, ngtcp2_tstamp ts) {
 
   conn_get_loss_time_and_pktns(conn, &earliest_loss_time, &loss_pktns);
 
-  ngtcp2_log_info(&conn->log, NGTCP2_LOG_EVENT_RCV,
+  ngtcp2_log_info(&conn->log, NGTCP2_LOG_EVENT_LDC,
                   "loss detection timer fired");
 
   if (earliest_loss_time != UINT64_MAX) {
@@ -13068,7 +13068,7 @@ int ngtcp2_conn_on_loss_detection_timer(ngtcp2_conn *conn, ngtcp2_tstamp ts) {
 
   ++cstat->pto_count;
 
-  ngtcp2_log_info(&conn->log, NGTCP2_LOG_EVENT_RCV, "pto_count=%zu",
+  ngtcp2_log_info(&conn->log, NGTCP2_LOG_EVENT_LDC, "pto_count=%zu",
                   cstat->pto_count);
 
   ngtcp2_conn_set_loss_detection_timer(conn, ts);

--- a/lib/ngtcp2_log.c
+++ b/lib/ngtcp2_log.c
@@ -68,7 +68,7 @@ void ngtcp2_log_init(ngtcp2_log *log, const ngtcp2_cid *scid,
  *   Source Connection ID in hex string.
  *
  * <EVENT>:
- *   Event.  pkt=packet, frm=frame, rcv=recovery, cry=crypto,
+ *   Event.  pkt=packet, frm=frame, ldc=loss-detection, cry=crypto,
  *   con=connection(catch all)
  *
  * # Frame event
@@ -205,8 +205,8 @@ static const char *strevent(ngtcp2_log_event ev) {
     return "pkt";
   case NGTCP2_LOG_EVENT_FRM:
     return "frm";
-  case NGTCP2_LOG_EVENT_RCV:
-    return "rcv";
+  case NGTCP2_LOG_EVENT_LDC:
+    return "ldc";
   case NGTCP2_LOG_EVENT_CRY:
     return "cry";
   case NGTCP2_LOG_EVENT_PTV:
@@ -752,11 +752,11 @@ void ngtcp2_log_remote_tp(ngtcp2_log *log,
 
 void ngtcp2_log_pkt_lost(ngtcp2_log *log, int64_t pkt_num, uint8_t type,
                          uint8_t flags, ngtcp2_tstamp sent_ts) {
-  if (!log->log_printf || !(log->events & NGTCP2_LOG_EVENT_RCV)) {
+  if (!log->log_printf || !(log->events & NGTCP2_LOG_EVENT_LDC)) {
     return;
   }
 
-  ngtcp2_log_info(log, NGTCP2_LOG_EVENT_RCV,
+  ngtcp2_log_info(log, NGTCP2_LOG_EVENT_LDC,
                   "pkn=%" PRId64 " lost type=%s sent_ts=%" PRIu64, pkt_num,
                   strpkttype_type_flags(type, flags), sent_ts);
 }

--- a/lib/ngtcp2_log.h
+++ b/lib/ngtcp2_log.h
@@ -76,9 +76,10 @@ typedef enum ngtcp2_log_event {
    */
   NGTCP2_LOG_EVENT_FRM = 0x4,
   /**
-   * :enum:`NGTCP2_LOG_EVENT_RCV` is a congestion and recovery event.
+   * :enum:`NGTCP2_LOG_EVENT_LDC` is a loss detection and congestion
+   * control event.
    */
-  NGTCP2_LOG_EVENT_RCV = 0x8,
+  NGTCP2_LOG_EVENT_LDC = 0x8,
   /**
    * :enum:`NGTCP2_LOG_EVENT_CRY` is a crypto event.
    */

--- a/lib/ngtcp2_rtb.c
+++ b/lib/ngtcp2_rtb.c
@@ -620,7 +620,7 @@ static int rtb_on_pkt_lost(ngtcp2_rtb *rtb, ngtcp2_ksl_it *it,
   }
 
   if (ent->flags & NGTCP2_RTB_ENTRY_FLAG_PTO_RECLAIMED) {
-    ngtcp2_log_info(rtb->log, NGTCP2_LOG_EVENT_RCV,
+    ngtcp2_log_info(rtb->log, NGTCP2_LOG_EVENT_LDC,
                     "pkn=%" PRId64 " has already been reclaimed on PTO",
                     ent->hd.pkt_num);
     assert(!(ent->flags & NGTCP2_RTB_ENTRY_FLAG_LOST_RETRANSMITTED));
@@ -1282,7 +1282,7 @@ static int rtb_detect_lost_pkt(ngtcp2_rtb *rtb, uint64_t *ppkt_lost,
        */
       if (rtb->pktns_id == NGTCP2_PKTNS_ID_APPLICATION && loss_window > 0) {
         if (loss_window >= congestion_period) {
-          ngtcp2_log_info(rtb->log, NGTCP2_LOG_EVENT_RCV,
+          ngtcp2_log_info(rtb->log, NGTCP2_LOG_EVENT_LDC,
                           "persistent congestion loss_window=%" PRIu64
                           " congestion_period=%" PRIu64,
                           loss_window, congestion_period);
@@ -1333,7 +1333,7 @@ void ngtcp2_rtb_remove_excessive_lost_pkt(ngtcp2_rtb *rtb, size_t n) {
 
     assert(ent->flags & NGTCP2_RTB_ENTRY_FLAG_LOST_RETRANSMITTED);
 
-    ngtcp2_log_info(rtb->log, NGTCP2_LOG_EVENT_RCV,
+    ngtcp2_log_info(rtb->log, NGTCP2_LOG_EVENT_LDC,
                     "removing stale lost pkn=%" PRId64, ent->hd.pkt_num);
 
     --rtb->num_lost_pkts;
@@ -1373,7 +1373,7 @@ void ngtcp2_rtb_remove_expired_lost_pkt(ngtcp2_rtb *rtb, ngtcp2_duration pto,
       return;
     }
 
-    ngtcp2_log_info(rtb->log, NGTCP2_LOG_EVENT_RCV,
+    ngtcp2_log_info(rtb->log, NGTCP2_LOG_EVENT_LDC,
                     "removing stale lost pkn=%" PRId64, ent->hd.pkt_num);
 
     --rtb->num_lost_pkts;
@@ -1429,7 +1429,7 @@ static int rtb_on_pkt_lost_resched_move(ngtcp2_rtb *rtb, ngtcp2_conn *conn,
   }
 
   if (ent->flags & NGTCP2_RTB_ENTRY_FLAG_PROBE) {
-    ngtcp2_log_info(rtb->log, NGTCP2_LOG_EVENT_RCV,
+    ngtcp2_log_info(rtb->log, NGTCP2_LOG_EVENT_LDC,
                     "pkn=%" PRId64
                     " is a probe packet, no retransmission is necessary",
                     ent->hd.pkt_num);
@@ -1437,7 +1437,7 @@ static int rtb_on_pkt_lost_resched_move(ngtcp2_rtb *rtb, ngtcp2_conn *conn,
   }
 
   if (ent->flags & NGTCP2_RTB_ENTRY_FLAG_PMTUD_PROBE) {
-    ngtcp2_log_info(rtb->log, NGTCP2_LOG_EVENT_RCV,
+    ngtcp2_log_info(rtb->log, NGTCP2_LOG_EVENT_LDC,
                     "pkn=%" PRId64
                     " is a PMTUD probe packet, no retransmission is necessary",
                     ent->hd.pkt_num);
@@ -1451,7 +1451,7 @@ static int rtb_on_pkt_lost_resched_move(ngtcp2_rtb *rtb, ngtcp2_conn *conn,
       --rtb->num_lost_pmtud_pkts;
     }
 
-    ngtcp2_log_info(rtb->log, NGTCP2_LOG_EVENT_RCV,
+    ngtcp2_log_info(rtb->log, NGTCP2_LOG_EVENT_LDC,
                     "pkn=%" PRId64
                     " was declared lost and has already been retransmitted",
                     ent->hd.pkt_num);
@@ -1459,7 +1459,7 @@ static int rtb_on_pkt_lost_resched_move(ngtcp2_rtb *rtb, ngtcp2_conn *conn,
   }
 
   if (ent->flags & NGTCP2_RTB_ENTRY_FLAG_PTO_RECLAIMED) {
-    ngtcp2_log_info(rtb->log, NGTCP2_LOG_EVENT_RCV,
+    ngtcp2_log_info(rtb->log, NGTCP2_LOG_EVENT_LDC,
                     "pkn=%" PRId64 " has already been reclaimed on PTO",
                     ent->hd.pkt_num);
     return 0;


### PR DESCRIPTION
Rename NGTCP2_LOG_EVENT_RCV to NGTCP2_LOG_EVENT_LDC because RCV is ambiguous (people might take it as "receive").