### PR TITLE
Fix missing prefix for AF_INET macros in ngtcp2_crypto.c

### DIFF
--- a/crypto/shared.c
+++ b/crypto/shared.c
@@ -1086,11 +1086,11 @@ static size_t crypto_generate_regular_token_aad(uint8_t *dest,
   size_t addrlen;
 
   switch (sa->sa_family) {
-  case AF_INET:
+  case NGTCP2_AF_INET:
     addr = (const uint8_t *)&((const ngtcp2_sockaddr_in *)(void *)sa)->sin_addr;
     addrlen = sizeof(((const ngtcp2_sockaddr_in *)(void *)sa)->sin_addr);
     break;
-  case AF_INET6:
+  case NGTCP2_AF_INET6:
     addr =
         (const uint8_t *)&((const ngtcp2_sockaddr_in6 *)(void *)sa)->sin6_addr;
     addrlen = sizeof(((const ngtcp2_sockaddr_in6 *)(void *)sa)->sin6_addr);

--- a/lib/ngtcp2_crypto.c
+++ b/lib/ngtcp2_crypto.c
@@ -666,7 +666,7 @@ int ngtcp2_transport_params_decode_versioned(int transport_params_version,
 
       if (sa_in->sin_port || memcmp(empty_address, &sa_in->sin_addr,
                                     sizeof(sa_in->sin_addr)) != 0) {
-        sa_in->sin_family = AF_INET;
+        sa_in->sin_family = NGTCP2_AF_INET;
         params->preferred_addr.ipv4_present = 1;
       }
 
@@ -677,7 +677,7 @@ int ngtcp2_transport_params_decode_versioned(int transport_params_version,
 
       if (sa_in6->sin6_port || memcmp(empty_address, &sa_in6->sin6_addr,
                                       sizeof(sa_in6->sin6_addr)) != 0) {
-        sa_in6->sin6_family = AF_INET6;
+        sa_in6->sin6_family = NGTCP2_AF_INET6;
         params->preferred_addr.ipv6_present = 1;
       }
 

--- a/tests/ngtcp2_conn_test.c
+++ b/tests/ngtcp2_conn_test.c
@@ -6897,7 +6897,7 @@ void test_ngtcp2_conn_recv_path_challenge(void) {
   params.preferred_addr.cid = cid;
 
   /* Set local address of new_path */
-  assert(AF_INET == new_path.path.local.addr->sa_family);
+  assert(NGTCP2_AF_INET == new_path.path.local.addr->sa_family);
 
   params.preferred_addr.ipv4_present = 1;
   memcpy(&params.preferred_addr.ipv4, new_path.path.local.addr,

--- a/tests/ngtcp2_conversion_test.c
+++ b/tests/ngtcp2_conversion_test.c
@@ -62,7 +62,7 @@ void test_ngtcp2_transport_params_convert_to_latest(void) {
   srcbuf.preferred_addr_present = 1;
   srcbuf.preferred_addr.ipv4_present = 0;
   sa_in6 = &srcbuf.preferred_addr.ipv6;
-  sa_in6->sin6_family = AF_INET6;
+  sa_in6->sin6_family = NGTCP2_AF_INET6;
   memset(&sa_in6->sin6_addr, 0xe1, sizeof(sa_in6->sin6_addr));
   sa_in6->sin6_port = ngtcp2_htons(63111);
   srcbuf.preferred_addr.ipv6_present = 1;

--- a/tests/ngtcp2_crypto_test.c
+++ b/tests/ngtcp2_crypto_test.c
@@ -75,7 +75,7 @@ void test_ngtcp2_transport_params_encode(void) {
   params.preferred_addr_present = 1;
   params.preferred_addr.ipv4_present = 0;
   sa_in6 = &params.preferred_addr.ipv6;
-  sa_in6->sin6_family = AF_INET6;
+  sa_in6->sin6_family = NGTCP2_AF_INET6;
   memset(&sa_in6->sin6_addr, 0xe1, sizeof(sa_in6->sin6_addr));
   sa_in6->sin6_port = ngtcp2_htons(63111);
   params.preferred_addr.ipv6_present = 1;
@@ -260,7 +260,7 @@ void test_ngtcp2_transport_params_decode_new(void) {
   params.ack_delay_exponent = 20;
   params.preferred_addr_present = 1;
   sa_in = &params.preferred_addr.ipv4;
-  sa_in->sin_family = AF_INET;
+  sa_in->sin_family = NGTCP2_AF_INET;
   memset(&sa_in->sin_addr, 0xf1, sizeof(sa_in->sin_addr));
   sa_in->sin_port = ngtcp2_htons(11732);
   params.preferred_addr.ipv4_present = 1;

--- a/tests/ngtcp2_test_helper.c
+++ b/tests/ngtcp2_test_helper.c
@@ -397,7 +397,7 @@ ngtcp2_ssize pkt_decode_hd_short_mask(ngtcp2_pkt_hd *dest, const uint8_t *pkt,
 static void addr_init(ngtcp2_sockaddr_in *dest, uint32_t addr, uint16_t port) {
   memset(dest, 0, sizeof(*dest));
 
-  dest->sin_family = AF_INET;
+  dest->sin_family = NGTCP2_AF_INET;
   dest->sin_port = ngtcp2_htons(port);
   dest->sin_addr.s_addr = ngtcp2_htonl(addr);
 }


### PR DESCRIPTION
This a fix we had on our side. The remaining of the lib is using `NGTCP2_` prefixed `AF_INET` macros, but this file was not for these two lines.

FYI: We didn't update samples/tests to use the ngtcp2 macros.