### PR TITLE
cmake: re-add two missing includes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,6 +94,9 @@ foreach(_build_type "Release" "MinSizeRel" "RelWithDebInfo")
   endforeach()
 endforeach()
 
+include(CheckCCompilerFlag)
+include(CheckCXXCompilerFlag)
+
 include(CMakePushCheckState)
 
 if(NOT CMAKE_C_COMPILER_ID MATCHES "MSVC")


### PR DESCRIPTION
Previously these were were included transitively via `cmake/ExtractValidFlags.cmake`. #964 deleted that file. The replacements it added pulled these includes after the local code uses them when `ENABLE_ASAN` enabled.

Re-add these includes into the `CMakeLists.txt` that uses them.

Reported-by: fpliu
Fixes #979