### PR TITLE
ngtcp2_conn_write_datagram conveniently accepts single buffer

### DIFF
--- a/lib/includes/ngtcp2/ngtcp2.h
+++ b/lib/includes/ngtcp2/ngtcp2.h
@@ -5737,7 +5737,7 @@ NGTCP2_EXTERN uint32_t ngtcp2_select_version(const uint32_t *preferred_versions,
  * version.
  */
 #define ngtcp2_conn_write_datagram(CONN, PATH, PI, DEST, DESTLEN, PACCEPTED,   \
-                                    FLAGS, DGRAM_ID, DATAV, DATAVCNT, TS)      \
+                                    FLAGS, DGRAM_ID, DATA, DATALEN, TS)      \
   ngtcp2_conn_write_datagram_versioned(                                        \
       (CONN), (PATH), NGTCP2_PKT_INFO_VERSION, (PI), (DEST), (DESTLEN),        \
       (PACCEPTED), (FLAGS), (DGRAM_ID), (DATA), (DATALEN), (TS))

--- a/lib/includes/ngtcp2/ngtcp2.h
+++ b/lib/includes/ngtcp2/ngtcp2.h
@@ -5736,9 +5736,9 @@ NGTCP2_EXTERN uint32_t ngtcp2_select_version(const uint32_t *preferred_versions,
  * `ngtcp2_conn_write_datagram_versioned` to set the correct struct
  * version.
  */
-#define ngtcp2_conn_write_datagram(CONN, PATH, PI, DEST, DESTLEN, PACCEPTED,  \
+#define ngtcp2_conn_write_datagram(CONN, PATH, PI, DEST, DESTLEN, PACCEPTED,   \
                                     FLAGS, DGRAM_ID, DATAV, DATAVCNT, TS)      \
-  ngtcp2_conn_write_datagram_versioned(                                       \
+  ngtcp2_conn_write_datagram_versioned(                                        \
       (CONN), (PATH), NGTCP2_PKT_INFO_VERSION, (PI), (DEST), (DESTLEN),        \
       (PACCEPTED), (FLAGS), (DGRAM_ID), (DATA), (DATALEN), (TS))
 

--- a/lib/includes/ngtcp2/ngtcp2.h
+++ b/lib/includes/ngtcp2/ngtcp2.h
@@ -4545,6 +4545,19 @@ NGTCP2_EXTERN ngtcp2_ssize ngtcp2_conn_writev_stream_versioned(
 /**
  * @function
  *
+ * `ngtcp2_conn_write_datagram` is just like
+ * `ngtcp2_conn_writev_datagram`.  The only difference is that it
+ * conveniently accepts a single buffer.
+ */
+NGTCP2_EXTERN ngtcp2_ssize ngtcp2_conn_write_datagram_versioned(
+    ngtcp2_conn *conn, ngtcp2_path *path, int pkt_info_version,
+    ngtcp2_pkt_info *pi, uint8_t *dest, size_t destlen, int *paccepted,
+    uint32_t flags, uint64_t dgram_id, const uint8_t *data, size_t datalen,
+    ngtcp2_tstamp ts);
+
+/**
+ * @function
+ *
  * `ngtcp2_conn_writev_datagram` writes a packet containing unreliable
  * data in DATAGRAM frame.  The buffer of the packet is pointed by
  * |dest| of length |destlen|.  This function performs QUIC handshake
@@ -5717,6 +5730,17 @@ NGTCP2_EXTERN uint32_t ngtcp2_select_version(const uint32_t *preferred_versions,
   ngtcp2_conn_writev_stream_versioned(                                         \
       (CONN), (PATH), NGTCP2_PKT_INFO_VERSION, (PI), (DEST), (DESTLEN),        \
       (PDATALEN), (FLAGS), (STREAM_ID), (DATAV), (DATAVCNT), (TS))
+
+/*
+ * `ngtcp2_conn_write_datagram` is a wrapper around
+ * `ngtcp2_conn_write_datagram_versioned` to set the correct struct
+ * version.
+ */
+#define ngtcp2_conn_write_datagram(CONN, PATH, PI, DEST, DESTLEN, PACCEPTED,  \
+                                    FLAGS, DGRAM_ID, DATAV, DATAVCNT, TS)      \
+  ngtcp2_conn_write_datagram_versioned(                                       \
+      (CONN), (PATH), NGTCP2_PKT_INFO_VERSION, (PI), (DEST), (DESTLEN),        \
+      (PACCEPTED), (FLAGS), (DGRAM_ID), (DATA), (DATALEN), (TS))
 
 /*
  * `ngtcp2_conn_writev_datagram` is a wrapper around

--- a/lib/ngtcp2_conn.c
+++ b/lib/ngtcp2_conn.c
@@ -11788,6 +11788,22 @@ ngtcp2_ssize ngtcp2_conn_writev_stream_versioned(
                                  destlen, pvmsg, ts);
 }
 
+
+ngtcp2_ssize ngtcp2_conn_write_datagram_versioned(
+    ngtcp2_conn *conn, ngtcp2_path *path, int pkt_info_version,
+    ngtcp2_pkt_info *pi, uint8_t *dest, size_t destlen, int *paccepted,
+    uint32_t flags, uint64_t dgram_id, const uint8_t *data, size_t datalen,
+    ngtcp2_tstamp ts) {
+    ngtcp2_vec datav;
+
+    datav.len = datalen;
+    datav.base = (uint8_t *)data;
+
+  return ngtcp2_conn_writev_datagram_versioned(conn, path, pkt_info_version, pi,
+                                                dest, destlen, paccepted, flags,
+                                                dgram_id, &datav, 1, ts);
+}
+
 ngtcp2_ssize ngtcp2_conn_writev_datagram_versioned(
     ngtcp2_conn *conn, ngtcp2_path *path, int pkt_info_version,
     ngtcp2_pkt_info *pi, uint8_t *dest, size_t destlen, int *paccepted,

--- a/lib/ngtcp2_conn.c
+++ b/lib/ngtcp2_conn.c
@@ -11794,10 +11794,10 @@ ngtcp2_ssize ngtcp2_conn_write_datagram_versioned(
     ngtcp2_pkt_info *pi, uint8_t *dest, size_t destlen, int *paccepted,
     uint32_t flags, uint64_t dgram_id, const uint8_t *data, size_t datalen,
     ngtcp2_tstamp ts) {
-    ngtcp2_vec datav;
+  ngtcp2_vec datav;
 
-    datav.len = datalen;
-    datav.base = (uint8_t *)data;
+  datav.len = datalen;
+  datav.base = (uint8_t *)data;
 
   return ngtcp2_conn_writev_datagram_versioned(conn, path, pkt_info_version, pi,
                                                 dest, destlen, paccepted, flags,


### PR DESCRIPTION
Similar convenience API already exists for write_stream