### PR TITLE
Use __FILE_NAME__ instead of __FILE__

### DIFF
--- a/lib/ngtcp2_unreachable.h
+++ b/lib/ngtcp2_unreachable.h
@@ -31,8 +31,14 @@
 
 #include <ngtcp2/ngtcp2.h>
 
+#ifdef __FILE_NAME__
+#  define NGTCP2_FILE_NAME __FILE_NAME__
+#else /* !__FILE_NAME__ */
+#  define NGTCP2_FILE_NAME "(file)"
+#endif /* !__FILE_NAME__ */
+
 #define ngtcp2_unreachable()                                                   \
-  ngtcp2_unreachable_fail(__FILE__, __LINE__, __func__)
+  ngtcp2_unreachable_fail(NGTCP2_FILE_NAME, __LINE__, __func__)
 
 #ifdef _MSC_VER
 __declspec(noreturn)


### PR DESCRIPTION
Use __FILE_NAME__ instead of __FILE__ not to include a full source file path.

Fixes #1003 