### PR TITLE
Handle unsigned conversion warning

### DIFF
--- a/lib/ngtcp2_pkt.c
+++ b/lib/ngtcp2_pkt.c
@@ -539,7 +539,8 @@ ngtcp2_ssize ngtcp2_pkt_decode_frame(ngtcp2_frame *dest, const uint8_t *payload,
     return ngtcp2_pkt_decode_datagram_frame(&dest->datagram, payload,
                                             payloadlen);
   default:
-    if ((type & ~(NGTCP2_FRAME_STREAM - 1)) == NGTCP2_FRAME_STREAM) {
+    if ((type & ~((uint64_t)NGTCP2_FRAME_STREAM - 1)) ==
+        (uint64_t)NGTCP2_FRAME_STREAM) {
       return ngtcp2_pkt_decode_stream_frame(&dest->stream, payload, payloadlen);
     }
 


### PR DESCRIPTION
With recent change to the type of frame type, this part gives me conversion warning when running unit tests.

```
unsigned conversion from ‘int’ to ‘uint64_t’ {aka ‘long unsigned int’} changes value from ‘-8’ to ‘18446744073709551608’
[-Wsign-conversion]
     if ((type & ~(NGTCP2_FRAME_STREAM - 1)) == NGTCP2_FRAME_STREAM) {
```