### PR TITLE
examples: Clarify stream limits

### DIFF
--- a/examples/client.cc
+++ b/examples/client.cc
@@ -2284,7 +2284,6 @@ void config_set_default(Config &config) {
   config.http_method = "GET"sv;
   config.max_data = 15_m;
   config.max_stream_data_bidi_local = 6_m;
-  config.max_stream_data_bidi_remote = 6_m;
   config.max_stream_data_uni = 6_m;
   config.max_window = 24_m;
   config.max_stream_window = 16_m;
@@ -2439,11 +2438,13 @@ Options:
               Default: )"
             << util::format_uint_iec(config.max_stream_data_uni) << R"(
   --max-streams-bidi=<N>
-              The number of the concurrent bidirectional streams.
+              The number of the  concurrent bidirectional streams that
+              the remote endpoint initiates.
               Default: )"
             << config.max_streams_bidi << R"(
   --max-streams-uni=<N>
-              The number of the concurrent unidirectional streams.
+              The number of the concurrent unidirectional streams that
+              the remote endpoint initiates.
               Default: )"
             << config.max_streams_uni << R"(
   --exit-on-first-stream-close

--- a/examples/h09client.cc
+++ b/examples/h09client.cc
@@ -1839,7 +1839,6 @@ void config_set_default(Config &config) {
   config.http_method = "GET"sv;
   config.max_data = 15_m;
   config.max_stream_data_bidi_local = 6_m;
-  config.max_stream_data_bidi_remote = 6_m;
   config.max_stream_data_uni = 6_m;
   config.max_window = 24_m;
   config.max_stream_window = 16_m;
@@ -1990,11 +1989,13 @@ Options:
               Default: )"
             << util::format_uint_iec(config.max_stream_data_uni) << R"(
   --max-streams-bidi=<N>
-              The number of the concurrent bidirectional streams.
+              The number of the  concurrent bidirectional streams that
+              the remote endpoint initiates.
               Default: )"
             << config.max_streams_bidi << R"(
   --max-streams-uni=<N>
-              The number of the concurrent unidirectional streams.
+              The number of the concurrent unidirectional streams that
+              the remote endpoint initiates.
               Default: )"
             << config.max_streams_uni << R"(
   --exit-on-first-stream-close

--- a/examples/h09server.cc
+++ b/examples/h09server.cc
@@ -2491,7 +2491,6 @@ void config_set_default(Config &config) {
   }
   config.mime_types_file = "/etc/mime.types"sv;
   config.max_data = 1_m;
-  config.max_stream_data_bidi_local = 256_k;
   config.max_stream_data_bidi_remote = 256_k;
   config.max_stream_data_uni = 256_k;
   config.max_window = 6_m;
@@ -2597,11 +2596,13 @@ Options:
               Default: )"
             << util::format_uint_iec(config.max_stream_data_uni) << R"(
   --max-streams-bidi=<N>
-              The number of the concurrent bidirectional streams.
+              The number of the  concurrent bidirectional streams that
+              the remote endpoint initiates.
               Default: )"
             << config.max_streams_bidi << R"(
   --max-streams-uni=<N>
-              The number of the concurrent unidirectional streams.
+              The number of the concurrent unidirectional streams that
+              the remote endpoint initiates.
               Default: )"
             << config.max_streams_uni << R"(
   --max-dyn-length=<SIZE>

--- a/examples/server.cc
+++ b/examples/server.cc
@@ -3191,7 +3191,6 @@ void config_set_default(Config &config) {
   }
   config.mime_types_file = "/etc/mime.types"sv;
   config.max_data = 1_m;
-  config.max_stream_data_bidi_local = 256_k;
   config.max_stream_data_bidi_remote = 256_k;
   config.max_stream_data_uni = 256_k;
   config.max_window = 6_m;
@@ -3297,11 +3296,13 @@ Options:
               Default: )"
             << util::format_uint_iec(config.max_stream_data_uni) << R"(
   --max-streams-bidi=<N>
-              The number of the concurrent bidirectional streams.
+              The number of the  concurrent bidirectional streams that
+              the remote endpoint initiates.
               Default: )"
             << config.max_streams_bidi << R"(
   --max-streams-uni=<N>
-              The number of the concurrent unidirectional streams.
+              The number of the concurrent unidirectional streams that
+              the remote endpoint initiates.
               Default: )"
             << config.max_streams_uni << R"(
   --max-dyn-length=<SIZE>


### PR DESCRIPTION
In HTTP without extension, server does not initiate bidirectional streams.  Set those stream limits to 0 by default.  They can be configured via options for testing purposes.