### PR TITLE
docker: Switch to bsslclient and bsslserver

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,38 +2,44 @@ FROM debian:12 as build
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-        git g++ clang-14 make binutils autoconf automake autotools-dev libtool \
+        git g++ clang-15 make binutils autoconf automake autotools-dev libtool \
         pkg-config libev-dev libjemalloc-dev \
-        ca-certificates mime-support && \
-    git clone --depth 1 -b OpenSSL_1_1_1w+quic https://github.com/quictls/openssl && \
-    cd openssl && ./config --openssldir=/etc/ssl && make -j$(nproc) && make install_sw && cd .. && rm -rf openssl && \
+        ca-certificates mime-support cmake && \
+    git clone --depth 1 -b v1.18.0 https://github.com/aws/aws-lc && \
+    cd aws-lc && \
+    cmake -Bbuild -DDISABLE_GO=ON \
+        -DCMAKE_C_COMPILER=clang-15 \
+        -DCMAKE_CXX_COMPILER=clang++-15 &&  \
+    make -j$(nproc) -C build && cmake --install build && \
+    cd .. && rm -rf aws-lc && \
     git clone --depth 1 https://github.com/ngtcp2/nghttp3 && \
     cd nghttp3 && autoreconf -i && \
-    ./configure --enable-lib-only CC=clang-14 CXX=clang++-14 && \
+    ./configure --enable-lib-only CC=clang-15 CXX=clang++-15 && \
     make -j$(nproc) && make install-strip && cd .. && rm -rf nghttp3 && \
     git clone --depth 1 https://github.com/ngtcp2/ngtcp2 && \
     cd ngtcp2 && autoreconf -i && \
     ./configure \
-        CC=clang-14 \
-        CXX=clang++-14 \
+        CC=clang-15 \
+        CXX=clang++-15 \
         LIBTOOL_LDFLAGS="-static-libtool-libs" \
-        OPENSSL_LIBS="-l:libssl.a -l:libcrypto.a -ldl -pthread" \
+        BORINGSSL_LIBS="-l:libssl.a -l:libcrypto.a" \
         LIBEV_LIBS="-l:libev.a" \
-        JEMALLOC_LIBS="-l:libjemalloc.a -lm" && \
+        JEMALLOC_LIBS="-l:libjemalloc.a -lm" \
+        --with-boringssl && \
     make -j$(nproc) && \
-    strip examples/qtlsclient examples/qtlsserver && \
-    cp examples/qtlsclient examples/qtlsserver /usr/local/bin && \
+    strip examples/bsslclient examples/bsslserver && \
+    cp examples/bsslclient examples/bsslserver /usr/local/bin && \
     cd .. && rm -rf ngtcp2 && \
     apt-get -y purge \
-        git g++ clang-14 make binutils autoconf automake autotools-dev libtool \
+        git g++ clang-15 make binutils autoconf automake autotools-dev libtool \
         pkg-config libev-dev libjemalloc-dev \
-        ca-certificates && \
+        ca-certificates cmake && \
     apt-get -y autoremove --purge && \
     rm -rf /var/log/*
 
 FROM gcr.io/distroless/cc-debian12
 
-COPY --from=build /usr/local/bin/qtlsclient /usr/local/bin/qtlsserver /usr/local/bin/
+COPY --from=build /usr/local/bin/bsslclient /usr/local/bin/bsslserver /usr/local/bin/
 COPY --from=build /etc/mime.types /etc/
 
-CMD ["/usr/local/bin/qtlsclient"]
+CMD ["/usr/local/bin/bsslclient"]


### PR DESCRIPTION
OpenSSL 1.1.1 has been EOLed, and OpenSSL 3.x have various performance issues because of its design decision.  aws-lc is boringssl based TLS stack, and it has a versioned release which hopefully provides API compatibility.