### PR TITLE
interop: Switch to wolfssl

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -142,15 +142,15 @@ The notable options are:
 
 - ``-V``, ``--validate-addr``: Enforce stateless address validation.
 
-H09qtlsclient/H09qtlsserver
+H09wsslclient/H09wsslserver
 ---------------------------
 
-There are h09qtlsclient and h09qtlsserver which speak HTTP/0.9.  They
+There are h09wsslclient and h09wsslserver which speak HTTP/0.9.  They
 are written just for `quic-interop-runner
 <https://github.com/marten-seemann/quic-interop-runner>`_.  They share
 the basic functionalities with HTTP/3 client and server but have less
-functions (e.g., h09qtlsclient does not have a capability to send
-request body, and h09qtlsserver does not understand numeric request
+functions (e.g., h09wsslclient does not have a capability to send
+request body, and h09wsslserver does not understand numeric request
 path, like /1000).
 
 Resumption and 0-RTT

--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -64,7 +64,7 @@ CLIENT_SRCS = \
 noinst_PROGRAMS =
 
 if ENABLE_EXAMPLE_QUICTLS
-noinst_PROGRAMS += qtlsclient qtlsserver h09qtlsclient h09qtlsserver \
+noinst_PROGRAMS += qtlsclient qtlsserver \
 	qtlssimpleclient
 
 qtlssimpleclient_CPPFLAGS = ${AM_CPPFLAGS} \
@@ -90,22 +90,6 @@ qtlsclient_SOURCES = client.cc client.h ${CLIENT_SRCS} \
 qtlsserver_CPPFLAGS = ${qtlsclient_CPPFLAGS}
 qtlsserver_LDADD = ${qtlsclient_LDADD}
 qtlsserver_SOURCES = server.cc server.h ${SERVER_SRCS} \
-	tls_server_context_quictls.cc tls_server_context_quictls.h \
-	tls_server_session_quictls.cc tls_server_session_quictls.h \
-	tls_session_base_quictls.cc tls_session_base_quictls.h \
-	util_openssl.cc
-
-h09qtlsclient_CPPFLAGS = ${qtlsclient_CPPFLAGS}
-h09qtlsclient_LDADD = ${qtlsclient_LDADD}
-h09qtlsclient_SOURCES = h09client.cc h09client.h ${CLIENT_SRCS} \
-	tls_client_context_quictls.cc tls_client_context_quictls.h \
-	tls_client_session_quictls.cc tls_client_session_quictls.h \
-	tls_session_base_quictls.cc tls_session_base_quictls.h \
-	util_openssl.cc
-
-h09qtlsserver_CPPFLAGS = ${qtlsclient_CPPFLAGS}
-h09qtlsserver_LDADD = ${qtlsclient_LDADD}
-h09qtlsserver_SOURCES = h09server.cc h09server.h ${SERVER_SRCS} \
 	tls_server_context_quictls.cc tls_server_context_quictls.h \
 	tls_server_session_quictls.cc tls_server_session_quictls.h \
 	tls_session_base_quictls.cc tls_session_base_quictls.h \
@@ -196,7 +180,7 @@ ptlsserver_SOURCES = server.cc server.h ${SERVER_SRCS} \
 endif # ENABLE_EXAMPLE_PICOTLS
 
 if ENABLE_EXAMPLE_WOLFSSL
-noinst_PROGRAMS += wsslclient wsslserver
+noinst_PROGRAMS += wsslclient wsslserver h09wsslclient h09wsslserver
 
 wsslclient_CPPFLAGS = ${AM_CPPFLAGS} @WOLFSSL_CFLAGS@ -DWITH_EXAMPLE_WOLFSSL
 wsslclient_LDADD = ${LDADD} \
@@ -212,6 +196,22 @@ wsslclient_SOURCES = client.cc client.h ${CLIENT_SRCS} \
 wsslserver_CPPFLAGS = ${wsslclient_CPPFLAGS}
 wsslserver_LDADD = ${wsslclient_LDADD}
 wsslserver_SOURCES = server.cc server.h ${SERVER_SRCS} \
+	tls_server_context_wolfssl.cc tls_server_context_wolfssl.h \
+	tls_server_session_wolfssl.cc tls_server_session_wolfssl.h \
+	tls_session_base_wolfssl.cc tls_session_base_wolfssl.h \
+	util_wolfssl.cc
+
+h09wsslclient_CPPFLAGS = ${wsslclient_CPPFLAGS}
+h09wsslclient_LDADD = ${wsslclient_LDADD}
+h09wsslclient_SOURCES = h09client.cc h09client.h ${CLIENT_SRCS} \
+	tls_client_context_wolfssl.cc tls_client_context_wolfssl.h \
+	tls_client_session_wolfssl.cc tls_client_session_wolfssl.h \
+	tls_session_base_wolfssl.cc tls_session_base_wolfssl.h \
+	util_wolfssl.cc
+
+h09wsslserver_CPPFLAGS = ${wsslclient_CPPFLAGS}
+h09wsslserver_LDADD = ${wsslclient_LDADD}
+h09wsslserver_SOURCES = h09server.cc h09server.h ${SERVER_SRCS} \
 	tls_server_context_wolfssl.cc tls_server_context_wolfssl.h \
 	tls_server_session_wolfssl.cc tls_server_session_wolfssl.h \
 	tls_session_base_wolfssl.cc tls_session_base_wolfssl.h \

--- a/interop/Dockerfile
+++ b/interop/Dockerfile
@@ -6,8 +6,10 @@ RUN apt-get update && \
         pkg-config libev-dev libjemalloc-dev \
         libev4 libjemalloc2 ca-certificates mime-support \
         llvm-12 libasan5 libubsan1 && \
-    git clone --depth 1 -b OpenSSL_1_1_1w+quic https://github.com/quictls/openssl && \
-    cd openssl && ./config --openssldir=/etc/ssl && make -j$(nproc) && make install_sw && cd .. && rm -rf openssl && \
+    git clone --depth 1 -b v5.6.4-stable https://github.com/wolfSSL/wolfssl && \
+    cd wolfssl && autoreconf -i && \
+    ./configure --enable-all --enable-quic --enable-aesni --enable-harden && \
+    make -j$(nproc) && make install && cd .. && rm -rf wolfssl && \
     git clone --depth 1 https://github.com/ngtcp2/nghttp3 && \
     cd nghttp3 && autoreconf -i && \
     ./configure --enable-lib-only \
@@ -22,12 +24,13 @@ RUN apt-get update && \
         CC=clang-12 \
         CXX=clang++-12 \
         LDFLAGS="-fsanitize=address,undefined -fno-sanitize-recover=undefined" \
-        CPPFLAGS="-fsanitize=address,undefined -fno-sanitize-recover=undefined -g3" && \
+        CPPFLAGS="-fsanitize=address,undefined -fno-sanitize-recover=undefined -g3" \
+        --with-wolfssl && \
     make -j$(nproc) && make install && \
-    cp examples/qtlsserver examples/qtlsclient examples/h09qtlsserver examples/h09qtlsclient /usr/local/bin && \
+    cp examples/wsslserver examples/wsslclient examples/h09wsslserver examples/h09wsslclient /usr/local/bin && \
     cd .. && \
     rm -rf ngtcp2 && \
-    rm -rf /usr/local/lib/libssl.so /usr/local/lib/libcrypto.so /usr/local/lib/libssl.a /usr/local/lib/libcrypto.a /usr/local/lib/pkgconfig/*ssl.pc /usr/local/include/openssl/* && \
+    rm -rf /usr/local/lib/libssl.so /usr/local/lib/libcrypto.so /usr/local/lib/libssl.a /usr/local/lib/libcrypto.a /usr/local/lib/pkgconfig/*ssl.pc /usr/local/include/wolfssl/* && \
     apt-get -y purge git g++ clang-12 make binutils autoconf automake \
         autotools-dev libtool pkg-config \
         libev-dev libjemalloc-dev && \

--- a/interop/run_endpoint.sh
+++ b/interop/run_endpoint.sh
@@ -25,9 +25,9 @@ if [ "$ROLE" == "client" ]; then
     REQS=($REQUESTS)
     SERVER=$(echo ${REQS[0]} | sed -re 's|^https://([^/:]+)(:[0-9]+)?/.*$|\1|')
     if [ "$TESTCASE" == "http3" ]; then
-        CLIENT_BIN="/usr/local/bin/qtlsclient"
+        CLIENT_BIN="/usr/local/bin/wsslclient"
     else
-        CLIENT_BIN="/usr/local/bin/h09qtlsclient"
+        CLIENT_BIN="/usr/local/bin/h09wsslclient"
     fi
     CLIENT_ARGS="$SERVER 443 --download /downloads -s --no-quic-dump --no-http-dump --exit-on-all-streams-close --qlog-dir $QLOGDIR --cc bbr --initial-rtt 100ms"
     if [ "$TESTCASE" == "versionnegotiation" ]; then
@@ -69,9 +69,9 @@ if [ "$ROLE" == "client" ]; then
     fi
 elif [ "$ROLE" == "server" ]; then
     if [ "$TESTCASE" == "http3" ]; then
-        SERVER_BIN="/usr/local/bin/qtlsserver"
+        SERVER_BIN="/usr/local/bin/wsslserver"
     else
-        SERVER_BIN="/usr/local/bin/h09qtlsserver"
+        SERVER_BIN="/usr/local/bin/h09wsslserver"
     fi
     SERVER_ARGS="/certs/priv.key /certs/cert.pem -s -d /www --qlog-dir $QLOGDIR --cc bbr --initial-rtt 100ms"
     case "$TESTCASE" in


### PR DESCRIPTION
Switch interop client/server to wolfssl because OpenSSL 1.1.1 has been EOLed and OpenSSL 3.x has the various performance issues due to its design decision.  wolfssl has been chosen because it has the ability to specify chacha cipher suite and it is also relatively easy to build compared to GnuTLS.