### PR TITLE
docker: Switch to wolfssl

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,8 +5,11 @@ RUN apt-get update && \
         git g++ clang-14 make binutils autoconf automake autotools-dev libtool \
         pkg-config libev-dev libjemalloc-dev \
         ca-certificates mime-support && \
-    git clone --depth 1 -b OpenSSL_1_1_1w+quic https://github.com/quictls/openssl && \
-    cd openssl && ./config --openssldir=/etc/ssl && make -j$(nproc) && make install_sw && cd .. && rm -rf openssl && \
+    git clone --depth 1 -b v5.6.4-stable https://github.com/wolfSSL/wolfssl && \
+    cd wolfssl && autoreconf -i && \
+    ./configure --enable-static --enable-all --enable-quic --enable-aesni \
+        --enable-harden && \
+    make -j$(nproc) && make install-strip && cd .. && rm -rf wolfssl && \
     git clone --depth 1 https://github.com/ngtcp2/nghttp3 && \
     cd nghttp3 && autoreconf -i && \
     ./configure --enable-lib-only CC=clang-14 CXX=clang++-14 && \
@@ -17,12 +20,12 @@ RUN apt-get update && \
         CC=clang-14 \
         CXX=clang++-14 \
         LIBTOOL_LDFLAGS="-static-libtool-libs" \
-        OPENSSL_LIBS="-l:libssl.a -l:libcrypto.a -ldl -pthread" \
         LIBEV_LIBS="-l:libev.a" \
-        JEMALLOC_LIBS="-l:libjemalloc.a -lm" && \
+        JEMALLOC_LIBS="-l:libjemalloc.a -lm" \
+        --with-wolfssl && \
     make -j$(nproc) && \
-    strip examples/qtlsclient examples/qtlsserver && \
-    cp examples/qtlsclient examples/qtlsserver /usr/local/bin && \
+    strip examples/wsslclient examples/wsslserver && \
+    cp examples/wsslclient examples/wsslserver /usr/local/bin && \
     cd .. && rm -rf ngtcp2 && \
     apt-get -y purge \
         git g++ clang-14 make binutils autoconf automake autotools-dev libtool \
@@ -33,7 +36,7 @@ RUN apt-get update && \
 
 FROM gcr.io/distroless/cc-debian12
 
-COPY --from=build /usr/local/bin/qtlsclient /usr/local/bin/qtlsserver /usr/local/bin/
+COPY --from=build /usr/local/bin/wsslclient /usr/local/bin/wsslserver /usr/local/bin/
 COPY --from=build /etc/mime.types /etc/
 
-CMD ["/usr/local/bin/qtlsclient"]
+CMD ["/usr/local/bin/wsslclient"]


### PR DESCRIPTION
Switch docker client/server to wolfssl because OpenSSL 1.1.1 has been EOLed and OpenSSL 3.x has the various performance issues due to its design decision.

Now it contains wsslclient and wsslserver instead of qtlsclient and qtlsserver.