### PR TITLE
Fix incorrect iteration in loss detection

### DIFF
--- a/lib/ngtcp2_rtb.c
+++ b/lib/ngtcp2_rtb.c
@@ -1019,6 +1019,17 @@ static int rtb_detect_lost_pkt(ngtcp2_rtb *rtb, uint64_t *ppkt_lost,
       start_ts = ngtcp2_max(rtb->persistent_congestion_start_ts,
                             cstat->first_rtt_sample_ts);
 
+      if (ent->hd.pkt_num >= pktns->tx.ecn.start_pkt_num &&
+          (ent->flags & NGTCP2_RTB_ENTRY_FLAG_ECN)) {
+        ++ecn_pkt_lost;
+      }
+
+      bytes_lost += rtb_on_remove(rtb, ent, cstat);
+      rv = rtb_on_pkt_lost(rtb, &it, ent, cstat, conn, pktns, ts);
+      if (rv != 0) {
+        return rv;
+      }
+
       for (; !ngtcp2_ksl_it_end(&it);) {
         ent = ngtcp2_ksl_it_get(&it);
 


### PR DESCRIPTION
There is no iteration when a packet is declared lost between outer **for** iteration and inner **for** iteration, which makes check in original line 1025 in ngtcp2_rtb.c:

    if (last_lost_pkt_num == ent->hd.pkt_num + 1 && ent->ts >= start_ts)

will never be met even if the packet number after the lost one is consecutive.