### PR TITLE
Optimize STOP_SENDING

### DIFF
--- a/lib/ngtcp2_strm.c
+++ b/lib/ngtcp2_strm.c
@@ -158,6 +158,18 @@ void ngtcp2_strm_update_rx_offset(ngtcp2_strm *strm, uint64_t offset) {
   ngtcp2_rob_remove_prefix(strm->rx.rob, offset);
 }
 
+void ngtcp2_strm_discard_reordered_data(ngtcp2_strm *strm) {
+  if (strm->rx.rob == NULL) {
+    return;
+  }
+
+  strm->rx.cont_offset = ngtcp2_strm_rx_offset(strm);
+
+  ngtcp2_rob_free(strm->rx.rob);
+  ngtcp2_mem_free(strm->mem, strm->rx.rob);
+  strm->rx.rob = NULL;
+}
+
 void ngtcp2_strm_shutdown(ngtcp2_strm *strm, uint32_t flags) {
   strm->flags |= flags & NGTCP2_STRM_FLAG_SHUT_RDWR;
 }

--- a/lib/ngtcp2_strm.h
+++ b/lib/ngtcp2_strm.h
@@ -220,6 +220,12 @@ int ngtcp2_strm_recv_reordering(ngtcp2_strm *strm, const uint8_t *data,
 void ngtcp2_strm_update_rx_offset(ngtcp2_strm *strm, uint64_t offset);
 
 /*
+ * ngtcp2_strm_discard_reordered_data discards all buffered reordered
+ * data.
+ */
+void ngtcp2_strm_discard_reordered_data(ngtcp2_strm *strm);
+
+/*
  * ngtcp2_strm_shutdown shutdowns |strm|.  |flags| should be
  * NGTCP2_STRM_FLAG_SHUT_RD, and/or NGTCP2_STRM_FLAG_SHUT_WR.
  */

--- a/tests/main.c
+++ b/tests/main.c
@@ -360,6 +360,8 @@ int main(void) {
                    test_ngtcp2_strm_streamfrq_unacked_offset) ||
       !CU_add_test(pSuite, "strm_streamfrq_unacked_pop",
                    test_ngtcp2_strm_streamfrq_unacked_pop) ||
+      !CU_add_test(pSuite, "strm_discard_reordered_data",
+                   test_ngtcp2_strm_discard_reordered_data) ||
       !CU_add_test(pSuite, "pv_add_entry", test_ngtcp2_pv_add_entry) ||
       !CU_add_test(pSuite, "pv_validate", test_ngtcp2_pv_validate) ||
       !CU_add_test(pSuite, "pmtud_probe", test_ngtcp2_pmtud_probe) ||

--- a/tests/ngtcp2_strm_test.c
+++ b/tests/ngtcp2_strm_test.c
@@ -576,3 +576,35 @@ void test_ngtcp2_strm_streamfrq_unacked_pop(void) {
 
   ngtcp2_objalloc_free(&frc_objalloc);
 }
+
+void test_ngtcp2_strm_discard_reordered_data(void) {
+  ngtcp2_strm strm;
+  const ngtcp2_mem *mem = ngtcp2_mem_default();
+
+  /* No reordered data has been received. */
+  ngtcp2_strm_init(&strm, 0, NGTCP2_STRM_FLAG_NONE, 0, 0, NULL, NULL, mem);
+
+  ngtcp2_strm_update_rx_offset(&strm, 1000000007);
+  ngtcp2_strm_discard_reordered_data(&strm);
+
+  CU_ASSERT(NULL == strm.rx.rob);
+  CU_ASSERT(1000000007 == ngtcp2_strm_rx_offset(&strm));
+
+  ngtcp2_strm_free(&strm);
+
+  /* Discard reordered data */
+  ngtcp2_strm_init(&strm, 0, NGTCP2_STRM_FLAG_NONE, 0, 0, NULL, NULL, mem);
+
+  ngtcp2_strm_update_rx_offset(&strm, 1000000007);
+  ngtcp2_strm_recv_reordering(&strm, nulldata, 117, 1000000008);
+
+  CU_ASSERT(NULL != strm.rx.rob);
+  CU_ASSERT(1000000007 == ngtcp2_strm_rx_offset(&strm));
+
+  ngtcp2_strm_discard_reordered_data(&strm);
+
+  CU_ASSERT(NULL == strm.rx.rob);
+  CU_ASSERT(1000000007 == ngtcp2_strm_rx_offset(&strm));
+
+  ngtcp2_strm_free(&strm);
+}

--- a/tests/ngtcp2_strm_test.h
+++ b/tests/ngtcp2_strm_test.h
@@ -32,5 +32,6 @@
 void test_ngtcp2_strm_streamfrq_pop(void);
 void test_ngtcp2_strm_streamfrq_unacked_offset(void);
 void test_ngtcp2_strm_streamfrq_unacked_pop(void);
+void test_ngtcp2_strm_discard_reordered_data(void);
 
 #endif /* NGTCP2_STRM_TEST_H */


### PR DESCRIPTION
- Remove redundant check for NGTCP2_STRM_FLAG_STOP_SENDING.
- Do not buffer reordered data if STOP_SENDING is sent.