### PR TITLE
ngtcp2_conn_write_connection_close: Fix assertion failure

### DIFF
--- a/lib/ngtcp2_conn.c
+++ b/lib/ngtcp2_conn.c
@@ -12303,12 +12303,9 @@ ngtcp2_ssize ngtcp2_conn_write_application_close_pkt(
     destlen -= (size_t)nwrite;
   }
 
-  if (conn->state != NGTCP2_CS_POST_HANDSHAKE) {
-    assert(res);
-
-    if (!conn->server || !conn->pktns.crypto.tx.ckm) {
-      return res;
-    }
+  if (conn->state != NGTCP2_CS_POST_HANDSHAKE &&
+      (!conn->server || !conn->pktns.crypto.tx.ckm)) {
+    return res;
   }
 
   assert(conn->pktns.crypto.tx.ckm);


### PR DESCRIPTION
Fix assertion failure in a race condition where server is not transitioned to NGTCP2_CS_POST_HANDSHAKE state after handshake is confirmed.

Fixes #1151 