### PR TITLE
Add 2 new ngtcp2_ccerr_type values

### DIFF
--- a/lib/includes/ngtcp2/ngtcp2.h
+++ b/lib/includes/ngtcp2/ngtcp2.h
@@ -5213,7 +5213,19 @@ typedef enum ngtcp2_ccerr_type {
    * transport error, and it indicates that connection is closed
    * because of idle timeout.
    */
-  NGTCP2_CCERR_TYPE_IDLE_CLOSE
+  NGTCP2_CCERR_TYPE_IDLE_CLOSE,
+  /**
+   * :enum:`NGTCP2_CCERR_TYPE_DROP_CONN` is a special case of QUIC
+   * transport error, and it indicates that connection should be
+   * dropped without sending a CONNECTION_CLOSE frame.
+   */
+  NGTCP2_CCERR_TYPE_DROP_CONN,
+  /**
+   * :enum:`NGTCP2_CCERR_TYPE_RETRY` is a special case of QUIC
+   * transport error, and it indicates that RETRY packet should be
+   * sent to a client.
+   */
+  NGTCP2_CCERR_TYPE_RETRY
 } ngtcp2_ccerr_type;
 
 /**
@@ -5302,6 +5314,18 @@ NGTCP2_EXTERN void ngtcp2_ccerr_set_transport_error(ngtcp2_ccerr *ccerr,
  * <ngtcp2_ccerr.type>` is set to
  * :enum:`ngtcp2_ccerr_type.NGTCP2_CCERR_TYPE_IDLE_CLOSE`, and
  * :member:`ccerr->error_code <ngtcp2_ccerr.error_code>` to
+ * :macro:`NGTCP2_NO_ERROR`.
+ *
+ * If |liberr| is :macro:`NGTCP2_ERR_DROP_CONN`, :member:`ccerr->type
+ * <ngtcp2_ccerr.type>` is set to
+ * :enum:`ngtcp2_ccerr_type.NGTCP2_CCERR_TYPE_DROP_CONN`, and
+ * :member:`ccerr->error_code <ngtcp2_ccerr.error_code>` to
+ * :macro:`NGTCP2_NO_ERROR`.
+ *
+ * If |liberr| is :macro:`NGTCP2_ERR_RETRY`, :member:`ccerr->type
+ * <ngtcp2_ccerr.type>` is set to
+ * :enum:`ngtcp2_ccerr_type.NGTCP2_CCERR_TYPE_RETRY`, and
+ * :member:`ccerr->error_type <ngtcp2_ccerr.error_code>` to
  * :macro:`NGTCP2_NO_ERROR`.
  *
  * Otherwise, :member:`ccerr->type <ngtcp2_ccerr.type>` is set to

--- a/lib/ngtcp2_conn.c
+++ b/lib/ngtcp2_conn.c
@@ -12371,6 +12371,16 @@ void ngtcp2_ccerr_set_liberr(ngtcp2_ccerr *ccerr, int liberr,
                reasonlen);
 
     return;
+  case NGTCP2_ERR_DROP_CONN:
+    ccerr_init(ccerr, NGTCP2_CCERR_TYPE_DROP_CONN, NGTCP2_NO_ERROR, reason,
+               reasonlen);
+
+    return;
+  case NGTCP2_ERR_RETRY:
+    ccerr_init(ccerr, NGTCP2_CCERR_TYPE_RETRY, NGTCP2_NO_ERROR, reason,
+               reasonlen);
+
+    return;
   };
 
   ngtcp2_ccerr_set_transport_error(

--- a/tests/ngtcp2_conn_test.c
+++ b/tests/ngtcp2_conn_test.c
@@ -121,6 +121,7 @@ static const MunitTest tests[] = {
     munit_void_test(test_ngtcp2_accept),
     munit_void_test(test_ngtcp2_select_version),
     munit_void_test(test_ngtcp2_pkt_write_connection_close),
+    munit_void_test(test_ngtcp2_ccerr_set_liberr),
     munit_test_end(),
 };
 
@@ -12750,4 +12751,27 @@ void test_ngtcp2_pkt_write_connection_close(void) {
       null_encrypt, &aead, &aead_ctx, null_iv, null_hp_mask, &hp_mask, &hp_ctx);
 
   assert_ptrdiff(NGTCP2_ERR_NOBUF, ==, spktlen);
+}
+
+void test_ngtcp2_ccerr_set_liberr(void) {
+  ngtcp2_ccerr ccerr;
+
+  ngtcp2_ccerr_set_liberr(&ccerr, NGTCP2_ERR_RECV_VERSION_NEGOTIATION, NULL, 0);
+
+  assert_enum(ngtcp2_ccerr_type, NGTCP2_CCERR_TYPE_VERSION_NEGOTIATION, ==,
+              ccerr.type);
+
+  ngtcp2_ccerr_set_liberr(&ccerr, NGTCP2_ERR_IDLE_CLOSE, NULL, 0);
+
+  assert_enum(ngtcp2_ccerr_type, NGTCP2_CCERR_TYPE_IDLE_CLOSE, ==,
+              ccerr.type);
+
+  ngtcp2_ccerr_set_liberr(&ccerr, NGTCP2_ERR_DROP_CONN, NULL, 0);
+
+  assert_enum(ngtcp2_ccerr_type, NGTCP2_CCERR_TYPE_DROP_CONN, ==,
+              ccerr.type);
+
+  ngtcp2_ccerr_set_liberr(&ccerr, NGTCP2_ERR_RETRY, NULL, 0);
+
+  assert_enum(ngtcp2_ccerr_type, NGTCP2_CCERR_TYPE_RETRY, ==, ccerr.type);
 }

--- a/tests/ngtcp2_conn_test.h
+++ b/tests/ngtcp2_conn_test.h
@@ -116,5 +116,6 @@ munit_void_test_decl(test_ngtcp2_conn_new_failmalloc);
 munit_void_test_decl(test_ngtcp2_accept);
 munit_void_test_decl(test_ngtcp2_select_version);
 munit_void_test_decl(test_ngtcp2_pkt_write_connection_close);
+munit_void_test_decl(test_ngtcp2_ccerr_set_liberr);
 
 #endif /* NGTCP2_CONN_TEST_H */


### PR DESCRIPTION
This commit adds the following 2 types:

- NGTCP2_CCERR_TYPE_DROP_CONN
- NGTCP2_CCERR_TYPE_RETRY

These are 2 special error codes returned from ngtcp2_conn_read_pkt, and need special handling.  ngtcp2_ccerr_set_liberr is updated to set these types when NGTCP2_ERR_DROP_CONN and NGTCP2_ERR_RETRY are set respectively.