### PR TITLE
Rework transmitting empty STREAM frame

### DIFF
--- a/lib/includes/ngtcp2/ngtcp2.h
+++ b/lib/includes/ngtcp2/ngtcp2.h
@@ -4437,8 +4437,10 @@ NGTCP2_EXTERN ngtcp2_ssize ngtcp2_conn_write_stream_versioned(
  * In that case, |*pdatalen| would be -1 if |pdatalen| is not
  * ``NULL``.
  *
- * If |flags| & :macro:`NGTCP2_WRITE_STREAM_FLAG_FIN` is nonzero, and
- * 0 length STREAM frame is successfully serialized, |*pdatalen| would
+ * Empty data is treated specially, and it is only accepted if no
+ * data, including the empty data, is submitted to a stream or
+ * :macro:`NGTCP2_WRITE_STREAM_FLAG_FIN` is set in |flags|.  If 0
+ * length STREAM frame is successfully serialized, |*pdatalen| would
  * be 0.
  *
  * The number of data encoded in STREAM frame is stored in |*pdatalen|

--- a/lib/ngtcp2_strm.h
+++ b/lib/ngtcp2_strm.h
@@ -86,6 +86,9 @@ typedef struct ngtcp2_frame_chain ngtcp2_frame_chain;
    received from the remote endpoint.  In this case,
    NGTCP2_STRM_FLAG_SHUT_WR is also set. */
 #define NGTCP2_STRM_FLAG_STOP_SENDING_RECVED 0x800u
+/* NGTCP2_STRM_FLAG_ANY_SENT indicates that any STREAM frame,
+   including empty one, has been sent. */
+#define NGTCP2_STRM_FLAG_ANY_SENT 0x1000u
 
 typedef struct ngtcp2_strm ngtcp2_strm;
 


### PR DESCRIPTION
Now empty stream data transmission is allowed only when:
- no data, including empty data, has been submitted; or
- NGTCP2_WRITE_STREAM_FLAG_FIN flag is set

It captures the only known use case of empty STREAM frame, that is tell a remote endpoint that a stream is just opened.