### PR TITLE
cmake: add BUILD_TESTING, fix MSVC with static + shared

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,6 +83,7 @@ if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
 endif()
 
 include(GNUInstallDirs)
+include(CMakeDependentOption)
 
 include(CMakeOptions.txt)
 
@@ -333,6 +334,10 @@ if(APPLE)
   add_definitions(-D__APPLE_USE_RFC_3542)
 endif()
 
+if(ENABLE_SHARED_LIB AND ENABLE_STATIC_LIB AND MSVC AND NOT STATIC_LIB_SUFFIX)
+  set(STATIC_LIB_SUFFIX "_static")
+endif()
+
 include_directories(
   "${CMAKE_CURRENT_BINARY_DIR}" # for config.h
 )
@@ -342,7 +347,9 @@ set(PKGDATADIR "${CMAKE_INSTALL_FULL_DATADIR}/${CMAKE_PROJECT_NAME}")
 install(FILES README.rst DESTINATION "${CMAKE_INSTALL_DOCDIR}")
 
 add_subdirectory(lib)
-add_subdirectory(tests)
+if(BUILD_TESTING)
+  add_subdirectory(tests)
+endif()
 add_subdirectory(crypto)
 add_subdirectory(third-party)
 add_subdirectory(examples)

--- a/CMakeOptions.txt
+++ b/CMakeOptions.txt
@@ -13,5 +13,6 @@ option(ENABLE_OPENSSL   "Enable OpenSSL crypto backend (required for examples)" 
 option(ENABLE_BORINGSSL "Enable BoringSSL crypto backend" OFF)
 option(ENABLE_PICOTLS "Enable Picotls crypto backend" OFF)
 option(ENABLE_WOLFSSL   "Enable wolfSSL crypto backend" OFF)
+cmake_dependent_option(BUILD_TESTING "Enable tests" ON "ENABLE_STATIC_LIB" OFF)
 
 # vim: ft=cmake:

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -91,17 +91,18 @@ if(ENABLE_SHARED_LIB)
     RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")
 endif()
 
-# Static library (for unittests because of symbol visibility)
-add_library(ngtcp2_static STATIC ${ngtcp2_SOURCES})
-set_target_properties(ngtcp2_static PROPERTIES
-  COMPILE_FLAGS "${WARNCFLAGS}"
-  VERSION ${LT_VERSION} SOVERSION ${LT_SOVERSION}
-  ARCHIVE_OUTPUT_NAME ngtcp2${STATIC_LIB_SUFFIX}
-  C_VISIBILITY_PRESET hidden
-)
-target_compile_definitions(ngtcp2_static PUBLIC "-DNGTCP2_STATICLIB")
-target_include_directories(ngtcp2_static PUBLIC ${ngtcp2_INCLUDE_DIRS})
 if(ENABLE_STATIC_LIB)
+  # Public static library
+  add_library(ngtcp2_static STATIC ${ngtcp2_SOURCES})
+  set_target_properties(ngtcp2_static PROPERTIES
+    COMPILE_FLAGS "${WARNCFLAGS}"
+    VERSION ${LT_VERSION} SOVERSION ${LT_SOVERSION}
+    ARCHIVE_OUTPUT_NAME ngtcp2${STATIC_LIB_SUFFIX}
+    C_VISIBILITY_PRESET hidden
+  )
+  target_compile_definitions(ngtcp2_static PUBLIC "-DNGTCP2_STATICLIB")
+  target_include_directories(ngtcp2_static PUBLIC ${ngtcp2_INCLUDE_DIRS})
+
   install(TARGETS ngtcp2_static
     DESTINATION "${CMAKE_INSTALL_LIBDIR}")
 endif()


### PR DESCRIPTION
Add a new option `BUILD_TESTING` to control whether or not the library is built with testing. Also fix a library naming conflict when building both static and shared libraries in MSVC by setting a default of `_static` for `STATIC_LIB_SUFFIX`.