### PR TITLE
Fix ngtcp2_conn_stat.max_tx_udp_payload_size update

### DIFF
--- a/lib/ngtcp2_conn_stat.h
+++ b/lib/ngtcp2_conn_stat.h
@@ -105,8 +105,9 @@ typedef struct ngtcp2_conn_stat {
   uint64_t bytes_in_flight;
   /**
    * :member:`max_tx_udp_payload_size` is the maximum size of UDP
-   * datagram payload that this endpoint transmits.  It is used by
-   * congestion controller to compute congestion window.
+   * datagram payload that this endpoint transmits to the current
+   * path.  It is used by congestion controller to compute congestion
+   * window.
    */
   size_t max_tx_udp_payload_size;
   /**

--- a/lib/ngtcp2_rtb.c
+++ b/lib/ngtcp2_rtb.c
@@ -579,9 +579,11 @@ static int rtb_process_acked_pkt(ngtcp2_rtb *rtb, ngtcp2_rtb_entry *ent,
       conn->pmtud->tx_pkt_num <= ent->hd.pkt_num) {
     ngtcp2_pmtud_probe_success(conn->pmtud, ent->pktlen);
 
-    conn->dcid.current.max_udp_payload_size =
-        conn->cstat.max_tx_udp_payload_size = ngtcp2_max_size(
-            conn->dcid.current.max_udp_payload_size, ent->pktlen);
+    if (conn->dcid.current.max_udp_payload_size < ent->pktlen) {
+      conn->dcid.current.max_udp_payload_size = ent->pktlen;
+      conn->cstat.max_tx_udp_payload_size =
+          ngtcp2_conn_get_path_max_tx_udp_payload_size(conn);
+    }
 
     if (ngtcp2_pmtud_finished(conn->pmtud)) {
       ngtcp2_conn_stop_pmtud(conn);


### PR DESCRIPTION
Fix ngtcp2_conn_stat.max_tx_udp_payload_size update to consider the case where no_tx_udp_payload_size_shaping is enabled.

Fix the document so that ngtcp2_conn_stat.max_tx_udp_payload_size is the maximum UDP payload size for the current path.