### PR TITLE
Adjust NGTCP2_ACKTR_MAX_ENT to match NGTCP2_MAX_ACK_RANGES + 1

### DIFF
--- a/lib/ngtcp2_acktr.h
+++ b/lib/ngtcp2_acktr.h
@@ -39,7 +39,7 @@
 
 /* NGTCP2_ACKTR_MAX_ENT is the maximum number of ngtcp2_acktr_entry
    which ngtcp2_acktr stores. */
-#define NGTCP2_ACKTR_MAX_ENT 1024
+#define NGTCP2_ACKTR_MAX_ENT (NGTCP2_MAX_ACK_RANGES + 1)
 
 typedef struct ngtcp2_log ngtcp2_log;
 


### PR DESCRIPTION
Because we create ACK frame with at most NGTCP2_MAX_ACK_RANGES + 1 ranges, including the first range, no need to remember more than those ranges.