### PR TITLE
Refactor ngtcp2_frame_chain allocation for ngtcp2_stream

### DIFF
--- a/lib/ngtcp2_frame_chain.c
+++ b/lib/ngtcp2_frame_chain.c
@@ -68,16 +68,11 @@ int ngtcp2_frame_chain_stream_datacnt_objalloc_new(ngtcp2_frame_chain **pfrc,
                                                    size_t datacnt,
                                                    ngtcp2_objalloc *objalloc,
                                                    const ngtcp2_mem *mem) {
-  size_t need;
-  const size_t avail =
-      (NGTCP2_FRAME_CHAIN_STREAM_DATACNT_THRES - 1) * sizeof(ngtcp2_vec);
-
-  if (datacnt > 1) {
-    need = sizeof(ngtcp2_vec) * (datacnt - 1);
-
-    if (need > avail) {
-      return ngtcp2_frame_chain_extralen_new(pfrc, need - avail, mem);
-    }
+  if (datacnt > NGTCP2_FRAME_CHAIN_STREAM_DATACNT_THRES) {
+    return ngtcp2_frame_chain_extralen_new(pfrc,
+                                           sizeof(ngtcp2_vec) * (datacnt - 1) -
+                                               NGTCP2_FRAME_CHAIN_STREAM_AVAIL,
+                                           mem);
   }
 
   return ngtcp2_frame_chain_objalloc_new(pfrc, objalloc);
@@ -141,9 +136,7 @@ void ngtcp2_frame_chain_objalloc_del(ngtcp2_frame_chain *frc,
   switch (frc->fr.type) {
   case NGTCP2_FRAME_CRYPTO:
   case NGTCP2_FRAME_STREAM:
-    if (frc->fr.stream.datacnt &&
-        sizeof(ngtcp2_vec) * (frc->fr.stream.datacnt - 1) >
-            sizeof(ngtcp2_frame) - sizeof(ngtcp2_stream)) {
+    if (frc->fr.stream.datacnt > NGTCP2_FRAME_CHAIN_STREAM_DATACNT_THRES) {
       ngtcp2_frame_chain_del(frc, mem);
 
       return;

--- a/lib/ngtcp2_frame_chain.h
+++ b/lib/ngtcp2_frame_chain.h
@@ -121,12 +121,18 @@ int ngtcp2_frame_chain_objalloc_new(ngtcp2_frame_chain **pfrc,
 int ngtcp2_frame_chain_extralen_new(ngtcp2_frame_chain **pfrc, size_t extralen,
                                     const ngtcp2_mem *mem);
 
+/* NGTCP2_FRAME_CHAIN_STREAM_AVAIL is the number of additional bytes
+   available after ngtcp2_stream when it is embedded in
+   ngtcp2_frame. */
+#define NGTCP2_FRAME_CHAIN_STREAM_AVAIL                                        \
+  (sizeof(ngtcp2_frame) - sizeof(ngtcp2_stream))
+
 /* NGTCP2_FRAME_CHAIN_STREAM_DATACNT_THRES is the number of datacnt
    that changes allocation method.  If datacnt is more than this
    value, ngtcp2_frame_chain is allocated without ngtcp2_objalloc.
    Otherwise, it is allocated using ngtcp2_objalloc.  */
 #define NGTCP2_FRAME_CHAIN_STREAM_DATACNT_THRES                                \
-  ((sizeof(ngtcp2_frame) - sizeof(ngtcp2_stream)) / sizeof(ngtcp2_vec) + 1)
+  (NGTCP2_FRAME_CHAIN_STREAM_AVAIL / sizeof(ngtcp2_vec) + 1)
 
 /*
  * ngtcp2_frame_chain_stream_datacnt_objalloc_new works like


### PR DESCRIPTION
Simplify ngtcp2_frame_chain allocation and deallocation for ngtcp2_stream with new macros.