### PR TITLE
Fix examples for picotls + libressl

### DIFF
--- a/examples/tls_client_context_picotls.cc
+++ b/examples/tls_client_context_picotls.cc
@@ -67,7 +67,9 @@ ptls_save_ticket_t save_ticket = {save_ticket_cb};
 
 namespace {
 ptls_key_exchange_algorithm_t *key_exchanges[] = {
+#if PTLS_OPENSSL_HAVE_X25519
     &ptls_openssl_x25519,
+#endif
     &ptls_openssl_secp256r1,
     &ptls_openssl_secp384r1,
     &ptls_openssl_secp521r1,
@@ -79,7 +81,9 @@ namespace {
 ptls_cipher_suite_t *cipher_suites[] = {
     &ptls_openssl_aes128gcmsha256,
     &ptls_openssl_aes256gcmsha384,
+#if PTLS_OPENSSL_HAVE_CHACHA20_POLY1305
     &ptls_openssl_chacha20poly1305sha256,
+#endif
     nullptr,
 };
 } // namespace

--- a/examples/tls_server_context_picotls.cc
+++ b/examples/tls_server_context_picotls.cc
@@ -255,7 +255,9 @@ ptls_encrypt_ticket_t encrypt_ticket = {encrypt_ticket_cb};
 
 namespace {
 ptls_key_exchange_algorithm_t *key_exchanges[] = {
+#if PTLS_OPENSSL_HAVE_X25519
     &ptls_openssl_x25519,
+#endif
     &ptls_openssl_secp256r1,
     &ptls_openssl_secp384r1,
     &ptls_openssl_secp521r1,
@@ -267,7 +269,9 @@ namespace {
 ptls_cipher_suite_t *cipher_suites[] = {
     &ptls_openssl_aes128gcmsha256,
     &ptls_openssl_aes256gcmsha384,
+#if PTLS_OPENSSL_HAVE_CHACHA20_POLY1305
     &ptls_openssl_chacha20poly1305sha256,
+#endif
     nullptr,
 };
 } // namespace


### PR DESCRIPTION
As the variables are excluded for LibreSSL in picotls's [openssl.h](https://github.com/h2o/picotls/blob/master/include/picotls/openssl.h), this patch excludes it by `#if PTLS_OPENSSL_HAVE_*`.
Without this patch, it is not possible to build the examples for picoTLS + libressl.