### PR TITLE
Add delivery_rate_sec to ngtcp2_conn_info

### DIFF
--- a/lib/includes/ngtcp2/ngtcp2.h
+++ b/lib/includes/ngtcp2/ngtcp2.h
@@ -1586,6 +1586,11 @@ typedef struct ngtcp2_conn_info {
    * packets which have not been acknowledged.
    */
   uint64_t bytes_in_flight;
+  /**
+   * :member:`delivery_rate_sec` is the current sending rate measured
+   * in byte per second.
+   */
+  uint64_t delivery_rate_sec;
 } ngtcp2_conn_info;
 
 /**

--- a/lib/ngtcp2_conn.c
+++ b/lib/ngtcp2_conn.c
@@ -12851,6 +12851,7 @@ void ngtcp2_conn_get_conn_info_versioned(ngtcp2_conn *conn,
   cinfo->cwnd = cstat->cwnd;
   cinfo->ssthresh = cstat->ssthresh;
   cinfo->bytes_in_flight = cstat->bytes_in_flight;
+  cinfo->delivery_rate_sec = cstat->delivery_rate_sec;
 }
 
 static void conn_get_loss_time_and_pktns(ngtcp2_conn *conn,


### PR DESCRIPTION
Allows application to use delivery rate information