### PR TITLE
Refactor packet writer functions for testing

### DIFF
--- a/tests/ngtcp2_test_helper.h
+++ b/tests/ngtcp2_test_helper.h
@@ -83,63 +83,6 @@ size_t ngtcp2_t_encode_ack_frame(uint8_t *out, uint64_t largest_ack,
                                  uint64_t ack_blklen);
 
 /*
- * write_pkt_flags writes a QUIC packet containing frames pointed by
- * |fr| of length |frlen| in |out| whose capacity is |outlen|.  This
- * function returns the number of bytes written.
- */
-size_t write_pkt_flags(uint8_t *out, size_t outlen, uint8_t flags,
-                       const ngtcp2_cid *dcid, int64_t pkt_num,
-                       ngtcp2_frame *fr, size_t frlen, ngtcp2_crypto_km *ckm);
-
-/*
- * write_pkt is write_pkt_flags with flag = NGTCP2_PKT_FLAG_NONE.
- */
-size_t write_pkt(uint8_t *out, size_t outlen, const ngtcp2_cid *dcid,
-                 int64_t pkt_num, ngtcp2_frame *fr, size_t frlen,
-                 ngtcp2_crypto_km *ckm);
-
-/*
- * write_initial_pkt_flags writes a QUIC Initial packet containing
- * |frlen| frames pointed by |fr| into |out| whose capacity is
- * |outlen|.  This function returns the number of bytes written.
- */
-size_t write_initial_pkt_flags(uint8_t *out, size_t outlen, uint8_t flags,
-                               const ngtcp2_cid *dcid, const ngtcp2_cid *scid,
-                               int64_t pkt_num, uint32_t version,
-                               const uint8_t *token, size_t tokenlen,
-                               ngtcp2_frame *fr, size_t frlen,
-                               ngtcp2_crypto_km *ckm);
-
-/*
- * write_initial_pkt is write_initial_pkt_flags with flag =
- * NGTCP2_PKT_FLAG_NONE.
- */
-size_t write_initial_pkt(uint8_t *out, size_t outlen, const ngtcp2_cid *dcid,
-                         const ngtcp2_cid *scid, int64_t pkt_num,
-                         uint32_t version, const uint8_t *token,
-                         size_t tokenlen, ngtcp2_frame *fr, size_t frlen,
-                         ngtcp2_crypto_km *ckm);
-
-/*
- * write_handshake_pkt writes a QUIC Handshake packet containing
- * |frlen| frames pointed by |fr| into |out| whose capacity is
- * |outlen|.  This function returns the number of bytes written.
- */
-size_t write_handshake_pkt(uint8_t *out, size_t outlen, const ngtcp2_cid *dcid,
-                           const ngtcp2_cid *scid, int64_t pkt_num,
-                           uint32_t version, ngtcp2_frame *fr, size_t frlen,
-                           ngtcp2_crypto_km *ckm);
-
-/*
- * write_0rtt_pkt writes a QUIC 0RTT packet containing |frlen| frames
- * pointed by |fr| into |out| whose capacity is |outlen|.  This
- * function returns the number of bytes written.
- */
-size_t write_0rtt_pkt(uint8_t *out, size_t outlen, const ngtcp2_cid *dcid,
-                      const ngtcp2_cid *scid, int64_t pkt_num, uint32_t version,
-                      ngtcp2_frame *fr, size_t frlen, ngtcp2_crypto_km *ckm);
-
-/*
  * open_stream opens new stream denoted by |stream_id|.
  */
 ngtcp2_strm *open_stream(ngtcp2_conn *conn, int64_t stream_id);


### PR DESCRIPTION
Remove wrapper packet writer functions and use the underlying functions directly.