### PR TITLE
ngtcp2_idtr: Clean doc and fix wrong assertions

### DIFF
--- a/lib/ngtcp2_idtr.c
+++ b/lib/ngtcp2_idtr.c
@@ -41,8 +41,7 @@ void ngtcp2_idtr_free(ngtcp2_idtr *idtr) {
 }
 
 /*
- * id_from_stream_id translates |stream_id| to id space used by
- * ngtcp2_idtr.
+ * id_from_stream_id translates |stream_id| to an internal ID.
  */
 static uint64_t id_from_stream_id(int64_t stream_id) {
   return (uint64_t)(stream_id >> 2);
@@ -51,8 +50,8 @@ static uint64_t id_from_stream_id(int64_t stream_id) {
 int ngtcp2_idtr_open(ngtcp2_idtr *idtr, int64_t stream_id) {
   uint64_t q;
 
-  assert((idtr->server && (stream_id % 2)) ||
-         (!idtr->server && (stream_id % 2)) == 0);
+  assert((idtr->server && (stream_id & 1)) ||
+         (!idtr->server && !(stream_id & 1)));
 
   q = id_from_stream_id(stream_id);
 
@@ -66,14 +65,10 @@ int ngtcp2_idtr_open(ngtcp2_idtr *idtr, int64_t stream_id) {
 int ngtcp2_idtr_is_open(ngtcp2_idtr *idtr, int64_t stream_id) {
   uint64_t q;
 
-  assert((idtr->server && (stream_id % 2)) ||
-         (!idtr->server && (stream_id % 2)) == 0);
+  assert((idtr->server && (stream_id & 1)) ||
+         (!idtr->server && !(stream_id & 1)));
 
   q = id_from_stream_id(stream_id);
 
   return ngtcp2_gaptr_is_pushed(&idtr->gap, q, 1);
-}
-
-uint64_t ngtcp2_idtr_first_gap(ngtcp2_idtr *idtr) {
-  return ngtcp2_gaptr_first_gap_offset(&idtr->gap);
 }

--- a/lib/ngtcp2_idtr.h
+++ b/lib/ngtcp2_idtr.h
@@ -38,8 +38,10 @@
  * ngtcp2_idtr tracks the usage of stream ID.
  */
 typedef struct ngtcp2_idtr {
-  /* gap maintains the range of ID which is not used yet. Initially,
-     its range is [0, UINT64_MAX). */
+  /* gap maintains the range of an internal ID which is not used yet.
+     Initially, its range is [0, UINT64_MAX).  The internal ID and
+     stream ID are in the different number spaces.  See
+     id_from_stream_id to convert a stream ID to an internal ID. */
   ngtcp2_gaptr gap;
   /* server is nonzero if this object records server initiated stream
      ID. */
@@ -49,7 +51,7 @@ typedef struct ngtcp2_idtr {
 /*
  * ngtcp2_idtr_init initializes |idtr|.
  *
- * If this object records server initiated ID (even number), set
+ * If this object records server initiated stream ID (odd number), set
  * |server| to nonzero.
  */
 void ngtcp2_idtr_init(ngtcp2_idtr *idtr, int server, const ngtcp2_mem *mem);
@@ -60,30 +62,21 @@ void ngtcp2_idtr_init(ngtcp2_idtr *idtr, int server, const ngtcp2_mem *mem);
 void ngtcp2_idtr_free(ngtcp2_idtr *idtr);
 
 /*
- * ngtcp2_idtr_open claims that |stream_id| is in used.
+ * ngtcp2_idtr_open claims that |stream_id| is in use.
  *
  * It returns 0 if it succeeds, or one of the following negative error
  * codes:
  *
  * NGTCP2_ERR_STREAM_IN_USE
- *     ID has already been used.
+ *     |stream_id| has already been used.
  * NGTCP2_ERR_NOMEM
  *     Out of memory.
  */
 int ngtcp2_idtr_open(ngtcp2_idtr *idtr, int64_t stream_id);
 
 /*
- * ngtcp2_idtr_open tells whether ID |stream_id| is in used or not.
- *
- * It returns nonzero if |stream_id| is used.
+ * ngtcp2_idtr_open returns nonzero if |stream_id| is in use.
  */
 int ngtcp2_idtr_is_open(ngtcp2_idtr *idtr, int64_t stream_id);
-
-/*
- * ngtcp2_idtr_first_gap returns the first id of first gap.  If there
- * is no gap, it returns UINT64_MAX.  The returned id is an id space
- * used in this object internally, and not stream ID.
- */
-uint64_t ngtcp2_idtr_first_gap(ngtcp2_idtr *idtr);
 
 #endif /* NGTCP2_IDTR_H */


### PR DESCRIPTION
Clean doc and fix wrong assertions.  The unused ngtcp2_idtr_first_gap is removed.