### PR TITLE
Fix deprecation warning in examples/template.h

### DIFF
--- a/examples/template.h
+++ b/examples/template.h
@@ -56,15 +56,15 @@ template <typename T, size_t N> constexpr size_t str_size(T (&)[N]) {
 
 // User-defined literals for K, M, and G (powers of 1024)
 
-constexpr unsigned long long operator"" _k(unsigned long long k) {
+constexpr unsigned long long operator""_k(unsigned long long k) {
   return k * 1024;
 }
 
-constexpr unsigned long long operator"" _m(unsigned long long m) {
+constexpr unsigned long long operator""_m(unsigned long long m) {
   return m * 1024 * 1024;
 }
 
-constexpr unsigned long long operator"" _g(unsigned long long g) {
+constexpr unsigned long long operator""_g(unsigned long long g) {
   return g * 1024 * 1024 * 1024;
 }
 


### PR DESCRIPTION
This change fixes the following deprecation warning from examples/template.h.

```
third-party/ngtcp2/examples/template.h:63:41: error: identifier '_m' preceded by whitespace in a literal operator declaration is deprecated [-Werror,-Wdeprecated-literal-operator]
   63 | constexpr unsigned long long operator"" _m(unsigned long long m) {
      |                              ~~~~~~~~~~~^~
      |     
```