### PR TITLE
Added options to command find_package

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -74,6 +74,30 @@ set(ngtcp2_INCLUDE_DIRS
   "${CMAKE_CURRENT_BINARY_DIR}/includes"
 )
 
+set(NGTCP2_GENERATED_DIR "${CMAKE_CURRENT_BINARY_DIR}/generated")
+set(NGTCP2_VERSION_CONFIG "${NGTCP2_GENERATED_DIR}/${PROJECT_NAME}ConfigVersion.cmake")
+set(NGTCP2_PROJECT_CONFIG "${NGTCP2_GENERATED_DIR}/${PROJECT_NAME}Config.cmake")
+set(NGTCP2_TARGETS_EXPORT_NAME "${PROJECT_NAME}Targets")
+set(NGTCP2_CONFIG_INSTALL_DIR "lib/cmake/${PROJECT_NAME}")
+set(NGTCP2_NAMESPACE "${PROJECT_NAME}::")
+set(NGTCP2_VERSION ${PROJECT_VERSION})
+
+include(CMakePackageConfigHelpers)
+write_basic_package_version_file(
+  "${NGTCP2_VERSION_CONFIG}" VERSION ${NGTCP2_VERSION} COMPATIBILITY SameMajorVersion
+)
+configure_file("${CMAKE_CURRENT_SOURCE_DIR}/config.cmake.in" "${NGTCP2_PROJECT_CONFIG}" @ONLY)
+
+# Install cmake config files
+install(
+  FILES "${NGTCP2_PROJECT_CONFIG}" "${NGTCP2_VERSION_CONFIG}"
+  DESTINATION "${NGTCP2_CONFIG_INSTALL_DIR}")
+
+install(
+  EXPORT "${NGTCP2_TARGETS_EXPORT_NAME}"
+  NAMESPACE "${NGTCP2_NAMESPACE}"
+  DESTINATION "${NGTCP2_CONFIG_INSTALL_DIR}")
+
 # Public shared library
 if(ENABLE_SHARED_LIB)
   add_library(ngtcp2 SHARED ${ngtcp2_SOURCES})
@@ -83,9 +107,14 @@ if(ENABLE_SHARED_LIB)
     C_VISIBILITY_PRESET hidden
     POSITION_INDEPENDENT_CODE ON
   )
-  target_include_directories(ngtcp2 PUBLIC ${ngtcp2_INCLUDE_DIRS})
+  foreach(include_DIR IN LISTS ngtcp2_INCLUDE_DIRS)
+    target_include_directories(ngtcp2 PUBLIC $<BUILD_INTERFACE:${include_DIR}>)
+  endforeach()
+  
+  target_include_directories(ngtcp2 PUBLIC $<INSTALL_INTERFACE:./include>)
 
   install(TARGETS ngtcp2
+    EXPORT ${NGTCP2_TARGETS_EXPORT_NAME} 
     ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
     LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
     RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")
@@ -101,9 +130,14 @@ if(ENABLE_STATIC_LIB)
     C_VISIBILITY_PRESET hidden
   )
   target_compile_definitions(ngtcp2_static PUBLIC "-DNGTCP2_STATICLIB")
-  target_include_directories(ngtcp2_static PUBLIC ${ngtcp2_INCLUDE_DIRS})
+  foreach(include_DIR IN LISTS ngtcp2_INCLUDE_DIRS)
+    target_include_directories(ngtcp2_static PUBLIC $<BUILD_INTERFACE:${include_DIR}>)
+  endforeach()
+  
+  target_include_directories(ngtcp2_static PUBLIC $<INSTALL_INTERFACE:./include>)
 
   install(TARGETS ngtcp2_static
+    EXPORT ${NGTCP2_TARGETS_EXPORT_NAME} 
     DESTINATION "${CMAKE_INSTALL_LIBDIR}")
 endif()
 

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -22,7 +22,7 @@
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 SUBDIRS = includes
 
-EXTRA_DIST = CMakeLists.txt
+EXTRA_DIST = CMakeLists.txt config.cmake.in
 
 AM_CFLAGS = $(WARNCFLAGS) $(DEBUGCFLAGS) $(EXTRACFLAG)
 AM_CPPFLAGS = -I$(srcdir)/includes -I$(builddir)/includes -DBUILDING_NGTCP2

--- a/lib/config.cmake.in
+++ b/lib/config.cmake.in
@@ -1,0 +1,3 @@
+include(CMakeFindDependencyMacro)
+
+include("${CMAKE_CURRENT_LIST_DIR}/@NGTCP2_TARGETS_EXPORT_NAME@.cmake")


### PR DESCRIPTION
Now is possible to use the command find_package with cmake to find ngtcp2, I've done the same to nghttp3 recently.