### PR TITLE
Add #define WOLFSSL_QUIC for access wolfssl quic defines

### DIFF
--- a/crypto/includes/ngtcp2/ngtcp2_crypto_wolfssl.h
+++ b/crypto/includes/ngtcp2/ngtcp2_crypto_wolfssl.h
@@ -27,6 +27,7 @@
 
 #include <ngtcp2/ngtcp2.h>
 
+#define WOLFSSL_QUIC
 #include <wolfssl/options.h>
 #include <wolfssl/ssl.h>
 #include <wolfssl/quic.h>


### PR DESCRIPTION
Add #define WOLFSSL_QUIC for access wolfssl quic defines

https://github.com/wolfSSL/wolfssl/blob/master/wolfssl/quic.h#L33