### PR TITLE
ngtcp2_idtr: Remove server field

### DIFF
--- a/lib/ngtcp2_conn.c
+++ b/lib/ngtcp2_conn.c
@@ -1167,9 +1167,9 @@ static int conn_new(ngtcp2_conn **pconn, const ngtcp2_cid *dcid,
 
   ngtcp2_pq_init(&(*pconn)->tx.strmq, cycle_less, mem);
 
-  ngtcp2_idtr_init(&(*pconn)->remote.bidi.idtr, !server, mem);
+  ngtcp2_idtr_init(&(*pconn)->remote.bidi.idtr, mem);
 
-  ngtcp2_idtr_init(&(*pconn)->remote.uni.idtr, !server, mem);
+  ngtcp2_idtr_init(&(*pconn)->remote.uni.idtr, mem);
 
   ngtcp2_static_ringbuf_path_challenge_init(&(*pconn)->rx.path_challenge);
 

--- a/lib/ngtcp2_idtr.c
+++ b/lib/ngtcp2_idtr.c
@@ -26,10 +26,8 @@
 
 #include <assert.h>
 
-void ngtcp2_idtr_init(ngtcp2_idtr *idtr, int server, const ngtcp2_mem *mem) {
+void ngtcp2_idtr_init(ngtcp2_idtr *idtr, const ngtcp2_mem *mem) {
   ngtcp2_gaptr_init(&idtr->gap, mem);
-
-  idtr->server = server;
 }
 
 void ngtcp2_idtr_free(ngtcp2_idtr *idtr) {
@@ -50,9 +48,6 @@ static uint64_t id_from_stream_id(int64_t stream_id) {
 int ngtcp2_idtr_open(ngtcp2_idtr *idtr, int64_t stream_id) {
   uint64_t q;
 
-  assert((idtr->server && (stream_id & 1)) ||
-         (!idtr->server && !(stream_id & 1)));
-
   q = id_from_stream_id(stream_id);
 
   if (ngtcp2_gaptr_is_pushed(&idtr->gap, q, 1)) {
@@ -64,9 +59,6 @@ int ngtcp2_idtr_open(ngtcp2_idtr *idtr, int64_t stream_id) {
 
 int ngtcp2_idtr_is_open(ngtcp2_idtr *idtr, int64_t stream_id) {
   uint64_t q;
-
-  assert((idtr->server && (stream_id & 1)) ||
-         (!idtr->server && !(stream_id & 1)));
 
   q = id_from_stream_id(stream_id);
 

--- a/lib/ngtcp2_idtr.h
+++ b/lib/ngtcp2_idtr.h
@@ -43,18 +43,12 @@ typedef struct ngtcp2_idtr {
      stream ID are in the different number spaces.  See
      id_from_stream_id to convert a stream ID to an internal ID. */
   ngtcp2_gaptr gap;
-  /* server is nonzero if this object records server initiated stream
-     ID. */
-  int server;
 } ngtcp2_idtr;
 
 /*
  * ngtcp2_idtr_init initializes |idtr|.
- *
- * If this object records server initiated stream ID (odd number), set
- * |server| to nonzero.
  */
-void ngtcp2_idtr_init(ngtcp2_idtr *idtr, int server, const ngtcp2_mem *mem);
+void ngtcp2_idtr_init(ngtcp2_idtr *idtr, const ngtcp2_mem *mem);
 
 /*
  * ngtcp2_idtr_free frees resources allocated for |idtr|.

--- a/tests/ngtcp2_idtr_test.c
+++ b/tests/ngtcp2_idtr_test.c
@@ -48,7 +48,7 @@ void test_ngtcp2_idtr_open(void) {
   ngtcp2_ksl_it it;
   ngtcp2_range key;
 
-  ngtcp2_idtr_init(&idtr, 0, mem);
+  ngtcp2_idtr_init(&idtr, mem);
 
   rv = ngtcp2_idtr_open(&idtr, stream_id_from_id(0));
 


### PR DESCRIPTION
Remove server field because it is only used in assertion.