### PR TITLE
ngtcp2_balloc: Optimize alignment space for 16 bytes boundary malloc

### DIFF
--- a/lib/ngtcp2_balloc.c
+++ b/lib/ngtcp2_balloc.c
@@ -66,7 +66,7 @@ int ngtcp2_balloc_get(ngtcp2_balloc *balloc, void **pbuf, size_t n) {
 
   if (ngtcp2_buf_left(&balloc->buf) < n) {
     p = ngtcp2_mem_malloc(balloc->mem,
-                          sizeof(ngtcp2_memblock_hd) + 0x10u + balloc->blklen);
+                          sizeof(ngtcp2_memblock_hd) + 0x8u + balloc->blklen);
     if (p == NULL) {
       return NGTCP2_ERR_NOMEM;
     }

--- a/lib/ngtcp2_balloc.h
+++ b/lib/ngtcp2_balloc.h
@@ -39,7 +39,10 @@ typedef struct ngtcp2_memblock_hd ngtcp2_memblock_hd;
  * ngtcp2_memblock_hd is the header of memory block.
  */
 struct ngtcp2_memblock_hd {
-  ngtcp2_memblock_hd *next;
+  union {
+    ngtcp2_memblock_hd *next;
+    uint64_t pad;
+  };
 };
 
 /*


### PR DESCRIPTION
Optimize alignment space for 16 bytes boundary malloc.  For 8 bytes boundary, it still waste 8 bytes, but it is better than previous 16 bytes.