### PR TITLE
ngtcp2_map: Fix bug that psl is not updated when an element is removed

### DIFF
--- a/lib/ngtcp2_map.c
+++ b/lib/ngtcp2_map.c
@@ -302,6 +302,7 @@ int ngtcp2_map_remove(ngtcp2_map *map, ngtcp2_map_key_type key) {
           break;
         }
 
+        --bkt->psl;
         map->table[didx] = *bkt;
         map_bucket_set_data(bkt, 0, 0, 0, NULL);
         didx = idx;


### PR DESCRIPTION
Fixes #1281 