### PR TITLE
Rename ngtcp2_put_uint* functions

### DIFF
--- a/lib/ngtcp2_conn.c
+++ b/lib/ngtcp2_conn.c
@@ -1003,7 +1003,7 @@ static void *available_versions_init(void *buf, const uint32_t *versions,
   size_t i;
 
   for (i = 0; i < versionslen; ++i) {
-    buf = ngtcp2_put_uint32be(buf, versions[i]);
+    buf = ngtcp2_put_uint32(buf, versions[i]);
   }
 
   return 0;

--- a/lib/ngtcp2_conv.c
+++ b/lib/ngtcp2_conv.c
@@ -133,32 +133,32 @@ int64_t ngtcp2_get_pkt_num(const uint8_t *p, size_t pkt_numlen) {
   }
 }
 
-uint8_t *ngtcp2_put_uint64be(uint8_t *p, uint64_t n) {
+uint8_t *ngtcp2_put_uint64(uint8_t *p, uint64_t n) {
   n = ngtcp2_htonl64(n);
   return ngtcp2_cpymem(p, (const uint8_t *)&n, sizeof(n));
 }
 
-uint8_t *ngtcp2_put_uint48be(uint8_t *p, uint64_t n) {
+uint8_t *ngtcp2_put_uint48(uint8_t *p, uint64_t n) {
   n = ngtcp2_htonl64(n);
   return ngtcp2_cpymem(p, ((const uint8_t *)&n) + 2, 6);
 }
 
-uint8_t *ngtcp2_put_uint32be(uint8_t *p, uint32_t n) {
+uint8_t *ngtcp2_put_uint32(uint8_t *p, uint32_t n) {
   n = ngtcp2_htonl(n);
   return ngtcp2_cpymem(p, (const uint8_t *)&n, sizeof(n));
 }
 
-uint8_t *ngtcp2_put_uint24be(uint8_t *p, uint32_t n) {
+uint8_t *ngtcp2_put_uint24(uint8_t *p, uint32_t n) {
   n = ngtcp2_htonl(n);
   return ngtcp2_cpymem(p, ((const uint8_t *)&n) + 1, 3);
 }
 
-uint8_t *ngtcp2_put_uint16be(uint8_t *p, uint16_t n) {
+uint8_t *ngtcp2_put_uint16(uint8_t *p, uint16_t n) {
   n = ngtcp2_htons(n);
   return ngtcp2_cpymem(p, (const uint8_t *)&n, sizeof(n));
 }
 
-uint8_t *ngtcp2_put_uint16(uint8_t *p, uint16_t n) {
+uint8_t *ngtcp2_put_uint16be(uint8_t *p, uint16_t n) {
   return ngtcp2_cpymem(p, (const uint8_t *)&n, sizeof(n));
 }
 
@@ -169,17 +169,17 @@ uint8_t *ngtcp2_put_uvarint(uint8_t *p, uint64_t n) {
     return p;
   }
   if (n < 16384) {
-    rv = ngtcp2_put_uint16be(p, (uint16_t)n);
+    rv = ngtcp2_put_uint16(p, (uint16_t)n);
     *p |= 0x40;
     return rv;
   }
   if (n < 1073741824) {
-    rv = ngtcp2_put_uint32be(p, (uint32_t)n);
+    rv = ngtcp2_put_uint32(p, (uint32_t)n);
     *p |= 0x80;
     return rv;
   }
   assert(n < 4611686018427387904ULL);
-  rv = ngtcp2_put_uint64be(p, n);
+  rv = ngtcp2_put_uint64(p, n);
   *p |= 0xc0;
   return rv;
 }
@@ -189,7 +189,7 @@ uint8_t *ngtcp2_put_uvarint30(uint8_t *p, uint32_t n) {
 
   assert(n < 1073741824);
 
-  rv = ngtcp2_put_uint32be(p, n);
+  rv = ngtcp2_put_uint32(p, n);
   *p |= 0x80;
 
   return rv;
@@ -201,11 +201,11 @@ uint8_t *ngtcp2_put_pkt_num(uint8_t *p, int64_t pkt_num, size_t len) {
     *p++ = (uint8_t)pkt_num;
     return p;
   case 2:
-    return ngtcp2_put_uint16be(p, (uint16_t)pkt_num);
+    return ngtcp2_put_uint16(p, (uint16_t)pkt_num);
   case 3:
-    return ngtcp2_put_uint24be(p, (uint32_t)pkt_num);
+    return ngtcp2_put_uint24(p, (uint32_t)pkt_num);
   case 4:
-    return ngtcp2_put_uint32be(p, (uint32_t)pkt_num);
+    return ngtcp2_put_uint32(p, (uint32_t)pkt_num);
   default:
     ngtcp2_unreachable();
   }

--- a/lib/ngtcp2_conv.h
+++ b/lib/ngtcp2_conv.h
@@ -96,45 +96,45 @@ const uint8_t *ngtcp2_get_varint(int64_t *dest, const uint8_t *p);
 int64_t ngtcp2_get_pkt_num(const uint8_t *p, size_t pkt_numlen);
 
 /*
- * ngtcp2_put_uint64be writes |n| in host byte order in |p| in network
+ * ngtcp2_put_uint64 writes |n| in host byte order in |p| in network
  * byte order.  It returns the one beyond of the last written
  * position.
  */
-uint8_t *ngtcp2_put_uint64be(uint8_t *p, uint64_t n);
+uint8_t *ngtcp2_put_uint64(uint8_t *p, uint64_t n);
 
 /*
- * ngtcp2_put_uint48be writes |n| in host byte order in |p| in network
+ * ngtcp2_put_uint48 writes |n| in host byte order in |p| in network
  * byte order.  It writes only least significant 48 bits.  It returns
  * the one beyond of the last written position.
  */
-uint8_t *ngtcp2_put_uint48be(uint8_t *p, uint64_t n);
+uint8_t *ngtcp2_put_uint48(uint8_t *p, uint64_t n);
 
 /*
- * ngtcp2_put_uint32be writes |n| in host byte order in |p| in network
+ * ngtcp2_put_uint32 writes |n| in host byte order in |p| in network
  * byte order.  It returns the one beyond of the last written
  * position.
  */
-uint8_t *ngtcp2_put_uint32be(uint8_t *p, uint32_t n);
+uint8_t *ngtcp2_put_uint32(uint8_t *p, uint32_t n);
 
 /*
- * ngtcp2_put_uint24be writes |n| in host byte order in |p| in network
+ * ngtcp2_put_uint24 writes |n| in host byte order in |p| in network
  * byte order.  It writes only least significant 24 bits.  It returns
  * the one beyond of the last written position.
  */
-uint8_t *ngtcp2_put_uint24be(uint8_t *p, uint32_t n);
+uint8_t *ngtcp2_put_uint24(uint8_t *p, uint32_t n);
 
 /*
- * ngtcp2_put_uint16be writes |n| in host byte order in |p| in network
+ * ngtcp2_put_uint16 writes |n| in host byte order in |p| in network
  * byte order.  It returns the one beyond of the last written
  * position.
  */
-uint8_t *ngtcp2_put_uint16be(uint8_t *p, uint16_t n);
+uint8_t *ngtcp2_put_uint16(uint8_t *p, uint16_t n);
 
 /*
- * ngtcp2_put_uint16 writes |n| as is in |p|.  It returns the one
+ * ngtcp2_put_uint16be writes |n| as is in |p|.  It returns the one
  * beyond of the last written position.
  */
-uint8_t *ngtcp2_put_uint16(uint8_t *p, uint16_t n);
+uint8_t *ngtcp2_put_uint16be(uint8_t *p, uint16_t n);
 
 /*
  * ngtcp2_put_uvarint writes |n| in |p| using variable-length integer

--- a/lib/ngtcp2_pkt.c
+++ b/lib/ngtcp2_pkt.c
@@ -416,7 +416,7 @@ ngtcp2_ssize ngtcp2_pkt_encode_hd_long(uint8_t *out, size_t outlen,
 
   ++p;
 
-  p = ngtcp2_put_uint32be(p, hd->version);
+  p = ngtcp2_put_uint32(p, hd->version);
   *p++ = (uint8_t)hd->dcid.datalen;
 
   if (hd->dcid.datalen) {
@@ -2109,7 +2109,7 @@ ngtcp2_ssize ngtcp2_pkt_write_version_negotiation(
   p = dest;
 
   *p++ = 0xc0 | unused_random;
-  p = ngtcp2_put_uint32be(p, 0);
+  p = ngtcp2_put_uint32(p, 0);
   *p++ = (uint8_t)dcidlen;
 
   if (dcidlen) {
@@ -2123,7 +2123,7 @@ ngtcp2_ssize ngtcp2_pkt_write_version_negotiation(
   }
 
   for (i = 0; i < nsv; ++i) {
-    p = ngtcp2_put_uint32be(p, sv[i]);
+    p = ngtcp2_put_uint32(p, sv[i]);
   }
 
   assert((size_t)(p - dest) == len);

--- a/lib/ngtcp2_transport_params.c
+++ b/lib/ngtcp2_transport_params.c
@@ -270,19 +270,19 @@ ngtcp2_ssize ngtcp2_transport_params_encode_versioned(
     if (params->preferred_addr.ipv4_present) {
       sa_in = &params->preferred_addr.ipv4;
       p = ngtcp2_cpymem(p, &sa_in->sin_addr, sizeof(sa_in->sin_addr));
-      p = ngtcp2_put_uint16(p, sa_in->sin_port);
+      p = ngtcp2_put_uint16be(p, sa_in->sin_port);
     } else {
       p = ngtcp2_cpymem(p, empty_address, sizeof(sa_in->sin_addr));
-      p = ngtcp2_put_uint16(p, 0);
+      p = ngtcp2_put_uint16be(p, 0);
     }
 
     if (params->preferred_addr.ipv6_present) {
       sa_in6 = &params->preferred_addr.ipv6;
       p = ngtcp2_cpymem(p, &sa_in6->sin6_addr, sizeof(sa_in6->sin6_addr));
-      p = ngtcp2_put_uint16(p, sa_in6->sin6_port);
+      p = ngtcp2_put_uint16be(p, sa_in6->sin6_port);
     } else {
       p = ngtcp2_cpymem(p, empty_address, sizeof(sa_in6->sin6_addr));
-      p = ngtcp2_put_uint16(p, 0);
+      p = ngtcp2_put_uint16be(p, 0);
     }
 
     *p++ = (uint8_t)params->preferred_addr.cid.datalen;
@@ -381,7 +381,7 @@ ngtcp2_ssize ngtcp2_transport_params_encode_versioned(
   if (params->version_info_present) {
     p = ngtcp2_put_uvarint(p, NGTCP2_TRANSPORT_PARAM_VERSION_INFORMATION);
     p = ngtcp2_put_uvarint(p, version_infolen);
-    p = ngtcp2_put_uint32be(p, params->version_info.chosen_version);
+    p = ngtcp2_put_uint32(p, params->version_info.chosen_version);
     if (params->version_info.available_versionslen) {
       p = ngtcp2_cpymem(p, params->version_info.available_versions,
                         params->version_info.available_versionslen);

--- a/tests/ngtcp2_conn_test.c
+++ b/tests/ngtcp2_conn_test.c
@@ -8829,9 +8829,8 @@ void test_ngtcp2_conn_set_remote_transport_params(void) {
   conn->local.settings.original_version = NGTCP2_PROTO_VER_V2;
   conn->negotiated_version = conn->client_chosen_version;
 
-  ngtcp2_put_uint32be(available_versions, NGTCP2_PROTO_VER_V1);
-  ngtcp2_put_uint32be(available_versions + sizeof(uint32_t),
-                      NGTCP2_PROTO_VER_V2);
+  ngtcp2_put_uint32(available_versions, NGTCP2_PROTO_VER_V1);
+  ngtcp2_put_uint32(available_versions + sizeof(uint32_t), NGTCP2_PROTO_VER_V2);
 
   memset(&params, 0, sizeof(params));
   params.active_connection_id_limit = NGTCP2_DEFAULT_ACTIVE_CONNECTION_ID_LIMIT;
@@ -8858,11 +8857,11 @@ void test_ngtcp2_conn_set_remote_transport_params(void) {
   conn->local.settings.original_version = NGTCP2_PROTO_VER_V2;
   conn->negotiated_version = 0xff000000u;
 
-  ngtcp2_put_uint32be(conn->vneg.available_versions, NGTCP2_PROTO_VER_V1);
-  ngtcp2_put_uint32be(conn->vneg.available_versions + sizeof(uint32_t),
-                      0xff000000u);
+  ngtcp2_put_uint32(conn->vneg.available_versions, NGTCP2_PROTO_VER_V1);
+  ngtcp2_put_uint32(conn->vneg.available_versions + sizeof(uint32_t),
+                    0xff000000u);
 
-  ngtcp2_put_uint32be(available_versions, 0xff000000u);
+  ngtcp2_put_uint32(available_versions, 0xff000000u);
 
   memset(&params, 0, sizeof(params));
   params.active_connection_id_limit = NGTCP2_DEFAULT_ACTIVE_CONNECTION_ID_LIMIT;
@@ -8891,11 +8890,11 @@ void test_ngtcp2_conn_set_remote_transport_params(void) {
 
   conn->vneg.preferred_versions[0] = 0xff000000u;
 
-  ngtcp2_put_uint32be(conn->vneg.available_versions, NGTCP2_PROTO_VER_V1);
-  ngtcp2_put_uint32be(conn->vneg.available_versions + sizeof(uint32_t),
-                      0xff000000u);
+  ngtcp2_put_uint32(conn->vneg.available_versions, NGTCP2_PROTO_VER_V1);
+  ngtcp2_put_uint32(conn->vneg.available_versions + sizeof(uint32_t),
+                    0xff000000u);
 
-  ngtcp2_put_uint32be(available_versions, 0xff000000u);
+  ngtcp2_put_uint32(available_versions, 0xff000000u);
 
   memset(&params, 0, sizeof(params));
   params.active_connection_id_limit = NGTCP2_DEFAULT_ACTIVE_CONNECTION_ID_LIMIT;
@@ -10921,8 +10920,8 @@ void test_ngtcp2_conn_version_negotiation(void) {
   uint32_t version;
   ngtcp2_tpe tpe;
 
-  ngtcp2_put_uint32be(&available_versions[0], NGTCP2_PROTO_VER_V1);
-  ngtcp2_put_uint32be(&available_versions[4], NGTCP2_PROTO_VER_V2);
+  ngtcp2_put_uint32(&available_versions[0], NGTCP2_PROTO_VER_V1);
+  ngtcp2_put_uint32(&available_versions[4], NGTCP2_PROTO_VER_V2);
 
   /* Client sees the change version in Initial packet which contains
      CRYPTO frame.  It generates new Initial keys and sets negotiated
@@ -11091,8 +11090,8 @@ void test_ngtcp2_conn_server_negotiate_version(void) {
 
   /* version_info.available_versions and preferred_versions do not
      share any version. */
-  ngtcp2_put_uint32be(&client_available_versions[0], 0xff000001);
-  ngtcp2_put_uint32be(&client_available_versions[4], 0xff000002);
+  ngtcp2_put_uint32(&client_available_versions[0], 0xff000001);
+  ngtcp2_put_uint32(&client_available_versions[4], 0xff000002);
 
   version_info.available_versions = client_available_versions;
   version_info.available_versionslen = sizeof(uint32_t) * 2;
@@ -11102,8 +11101,8 @@ void test_ngtcp2_conn_server_negotiate_version(void) {
 
   /* version_info.available_versions and preferred_versions share the
      version. */
-  ngtcp2_put_uint32be(&client_available_versions[0], 0xff000001);
-  ngtcp2_put_uint32be(&client_available_versions[4], NGTCP2_PROTO_VER_V2);
+  ngtcp2_put_uint32(&client_available_versions[0], 0xff000001);
+  ngtcp2_put_uint32(&client_available_versions[4], NGTCP2_PROTO_VER_V2);
 
   version_info.available_versions = client_available_versions;
   version_info.available_versionslen = sizeof(uint32_t) * 2;
@@ -11119,8 +11118,8 @@ void test_ngtcp2_conn_server_negotiate_version(void) {
   conn->vneg.preferred_versions = NULL;
   conn->vneg.preferred_versionslen = 0;
 
-  ngtcp2_put_uint32be(&client_available_versions[0], 0xff000001);
-  ngtcp2_put_uint32be(&client_available_versions[4], NGTCP2_PROTO_VER_V2);
+  ngtcp2_put_uint32(&client_available_versions[0], 0xff000001);
+  ngtcp2_put_uint32(&client_available_versions[4], NGTCP2_PROTO_VER_V2);
 
   version_info.available_versions = client_available_versions;
   version_info.available_versionslen = sizeof(uint32_t) * 2;
@@ -11136,8 +11135,8 @@ void test_ngtcp2_conn_server_negotiate_version(void) {
   conn->vneg.preferred_versions[0] = NGTCP2_PROTO_VER_V1;
   conn->vneg.preferred_versions[1] = NGTCP2_PROTO_VER_V2;
 
-  ngtcp2_put_uint32be(&client_available_versions[0], NGTCP2_PROTO_VER_V2);
-  ngtcp2_put_uint32be(&client_available_versions[4], NGTCP2_PROTO_VER_V1);
+  ngtcp2_put_uint32(&client_available_versions[0], NGTCP2_PROTO_VER_V2);
+  ngtcp2_put_uint32(&client_available_versions[4], NGTCP2_PROTO_VER_V1);
 
   version_info.available_versions = client_available_versions;
   version_info.available_versionslen = sizeof(uint32_t) * 2;

--- a/tests/ngtcp2_conv_test.c
+++ b/tests/ngtcp2_conv_test.c
@@ -185,7 +185,7 @@ void test_ngtcp2_get_uint64(void) {
 
   /* 0 */
   n = 1;
-  p = ngtcp2_put_uint64be(buf, 0);
+  p = ngtcp2_put_uint64(buf, 0);
 
   assert_ptrdiff(sizeof(n), ==, p - buf);
 
@@ -196,7 +196,7 @@ void test_ngtcp2_get_uint64(void) {
 
   /* 12345678900 */
   n = 0;
-  p = ngtcp2_put_uint64be(buf, 12345678900ULL);
+  p = ngtcp2_put_uint64(buf, 12345678900ULL);
 
   assert_ptrdiff(sizeof(n), ==, p - buf);
 
@@ -207,7 +207,7 @@ void test_ngtcp2_get_uint64(void) {
 
   /* 18446744073709551615 */
   n = 0;
-  p = ngtcp2_put_uint64be(buf, 18446744073709551615ULL);
+  p = ngtcp2_put_uint64(buf, 18446744073709551615ULL);
 
   assert_ptrdiff(sizeof(n), ==, p - buf);
 
@@ -224,7 +224,7 @@ void test_ngtcp2_get_uint48(void) {
 
   /* 0 */
   n = 1;
-  p = ngtcp2_put_uint48be(buf, 0);
+  p = ngtcp2_put_uint48(buf, 0);
 
   assert_ptrdiff(6, ==, p - buf);
 
@@ -235,7 +235,7 @@ void test_ngtcp2_get_uint48(void) {
 
   /* 123456789 */
   n = 0;
-  p = ngtcp2_put_uint48be(buf, 123456789);
+  p = ngtcp2_put_uint48(buf, 123456789);
 
   assert_ptrdiff(6, ==, p - buf);
 
@@ -246,7 +246,7 @@ void test_ngtcp2_get_uint48(void) {
 
   /* 281474976710655 */
   n = 0;
-  p = ngtcp2_put_uint48be(buf, 281474976710655ULL);
+  p = ngtcp2_put_uint48(buf, 281474976710655ULL);
 
   assert_ptrdiff(6, ==, p - buf);
 
@@ -263,7 +263,7 @@ void test_ngtcp2_get_uint32(void) {
 
   /* 0 */
   n = 1;
-  p = ngtcp2_put_uint32be(buf, 0);
+  p = ngtcp2_put_uint32(buf, 0);
 
   assert_ptrdiff(sizeof(n), ==, p - buf);
 
@@ -274,7 +274,7 @@ void test_ngtcp2_get_uint32(void) {
 
   /* 123456 */
   n = 0;
-  p = ngtcp2_put_uint32be(buf, 123456);
+  p = ngtcp2_put_uint32(buf, 123456);
 
   assert_ptrdiff(sizeof(n), ==, p - buf);
 
@@ -285,7 +285,7 @@ void test_ngtcp2_get_uint32(void) {
 
   /* 4294967295 */
   n = 0;
-  p = ngtcp2_put_uint32be(buf, 4294967295UL);
+  p = ngtcp2_put_uint32(buf, 4294967295UL);
 
   assert_ptrdiff(sizeof(n), ==, p - buf);
 
@@ -302,7 +302,7 @@ void test_ngtcp2_get_uint24(void) {
 
   /* 0 */
   n = 1;
-  p = ngtcp2_put_uint24be(buf, 0);
+  p = ngtcp2_put_uint24(buf, 0);
 
   assert_ptrdiff(3, ==, p - buf);
 
@@ -313,7 +313,7 @@ void test_ngtcp2_get_uint24(void) {
 
   /* 12345 */
   n = 0;
-  p = ngtcp2_put_uint24be(buf, 12345);
+  p = ngtcp2_put_uint24(buf, 12345);
 
   assert_ptrdiff(3, ==, p - buf);
 
@@ -324,7 +324,7 @@ void test_ngtcp2_get_uint24(void) {
 
   /* 16777215 */
   n = 0;
-  p = ngtcp2_put_uint24be(buf, 16777215);
+  p = ngtcp2_put_uint24(buf, 16777215);
 
   assert_ptrdiff(3, ==, p - buf);
 
@@ -341,7 +341,7 @@ void test_ngtcp2_get_uint16(void) {
 
   /* 0 */
   n = 1;
-  p = ngtcp2_put_uint16be(buf, 0);
+  p = ngtcp2_put_uint16(buf, 0);
 
   assert_ptrdiff(sizeof(n), ==, p - buf);
 
@@ -352,7 +352,7 @@ void test_ngtcp2_get_uint16(void) {
 
   /* 1234 */
   n = 0;
-  p = ngtcp2_put_uint16be(buf, 1234);
+  p = ngtcp2_put_uint16(buf, 1234);
 
   assert_ptrdiff(sizeof(n), ==, p - buf);
 
@@ -363,7 +363,7 @@ void test_ngtcp2_get_uint16(void) {
 
   /* 65535 */
   n = 0;
-  p = ngtcp2_put_uint16be(buf, 65535);
+  p = ngtcp2_put_uint16(buf, 65535);
 
   assert_ptrdiff(sizeof(n), ==, p - buf);
 
@@ -380,7 +380,7 @@ void test_ngtcp2_get_uint16be(void) {
 
   /* 0 */
   n = 1;
-  p = ngtcp2_put_uint16(buf, 0);
+  p = ngtcp2_put_uint16be(buf, 0);
 
   assert_ptrdiff(sizeof(n), ==, p - buf);
 
@@ -391,7 +391,7 @@ void test_ngtcp2_get_uint16be(void) {
 
   /* 1234 */
   n = 0;
-  p = ngtcp2_put_uint16(buf, ngtcp2_htons(1234));
+  p = ngtcp2_put_uint16be(buf, ngtcp2_htons(1234));
 
   assert_ptrdiff(sizeof(n), ==, p - buf);
 
@@ -402,7 +402,7 @@ void test_ngtcp2_get_uint16be(void) {
 
   /* 65535 */
   n = 0;
-  p = ngtcp2_put_uint16(buf, 65535);
+  p = ngtcp2_put_uint16be(buf, 65535);
 
   assert_ptrdiff(sizeof(n), ==, p - buf);
 

--- a/tests/ngtcp2_pkt_test.c
+++ b/tests/ngtcp2_pkt_test.c
@@ -109,7 +109,7 @@ void test_ngtcp2_pkt_decode_version_cid(void) {
   /* Supported QUIC version */
   p = buf;
   *p++ = NGTCP2_HEADER_FORM_BIT;
-  p = ngtcp2_put_uint32be(p, NGTCP2_PROTO_VER_V1);
+  p = ngtcp2_put_uint32(p, NGTCP2_PROTO_VER_V1);
   *p++ = NGTCP2_MAX_CIDLEN;
   p = ngtcp2_setmem(p, 0xf1, NGTCP2_MAX_CIDLEN);
   *p++ = NGTCP2_MAX_CIDLEN - 1;
@@ -135,7 +135,7 @@ void test_ngtcp2_pkt_decode_version_cid(void) {
   memset(buf, 0, sizeof(buf));
   p = buf;
   *p++ = NGTCP2_HEADER_FORM_BIT;
-  p = ngtcp2_put_uint32be(p, 0xffffff00);
+  p = ngtcp2_put_uint32(p, 0xffffff00);
   *p++ = NGTCP2_MAX_CIDLEN;
   p = ngtcp2_setmem(p, 0xf1, NGTCP2_MAX_CIDLEN);
   *p++ = NGTCP2_MAX_CIDLEN - 1;
@@ -160,7 +160,7 @@ void test_ngtcp2_pkt_decode_version_cid(void) {
   /* Unsupported QUIC version with UDP payload size < 1200 */
   p = buf;
   *p++ = NGTCP2_HEADER_FORM_BIT;
-  p = ngtcp2_put_uint32be(p, 0xffffff00);
+  p = ngtcp2_put_uint32(p, 0xffffff00);
   *p++ = NGTCP2_MAX_CIDLEN;
   p = ngtcp2_setmem(p, 0xf1, NGTCP2_MAX_CIDLEN);
   *p++ = NGTCP2_MAX_CIDLEN - 1;
@@ -173,7 +173,7 @@ void test_ngtcp2_pkt_decode_version_cid(void) {
   /* Supported QUIC version with long CID */
   p = buf;
   *p++ = NGTCP2_HEADER_FORM_BIT;
-  p = ngtcp2_put_uint32be(p, NGTCP2_PROTO_VER_V1);
+  p = ngtcp2_put_uint32(p, NGTCP2_PROTO_VER_V1);
   *p++ = NGTCP2_MAX_CIDLEN + 1;
   p = ngtcp2_setmem(p, 0xf1, NGTCP2_MAX_CIDLEN + 1);
   *p++ = NGTCP2_MAX_CIDLEN;
@@ -187,7 +187,7 @@ void test_ngtcp2_pkt_decode_version_cid(void) {
   memset(buf, 0, sizeof(buf));
   p = buf;
   *p++ = NGTCP2_HEADER_FORM_BIT;
-  p = ngtcp2_put_uint32be(p, 0xffffff00);
+  p = ngtcp2_put_uint32(p, 0xffffff00);
   *p++ = NGTCP2_MAX_CIDLEN + 1;
   p = ngtcp2_setmem(p, 0xf1, NGTCP2_MAX_CIDLEN + 1);
   *p++ = NGTCP2_MAX_CIDLEN;
@@ -205,7 +205,7 @@ void test_ngtcp2_pkt_decode_version_cid(void) {
   /* VN */
   p = buf;
   *p++ = NGTCP2_HEADER_FORM_BIT;
-  p = ngtcp2_put_uint32be(p, 0);
+  p = ngtcp2_put_uint32(p, 0);
   *p++ = NGTCP2_MAX_CIDLEN;
   p = ngtcp2_setmem(p, 0xf1, NGTCP2_MAX_CIDLEN);
   *p++ = NGTCP2_MAX_CIDLEN - 1;
@@ -230,7 +230,7 @@ void test_ngtcp2_pkt_decode_version_cid(void) {
   /* VN with long CID */
   p = buf;
   *p++ = NGTCP2_HEADER_FORM_BIT;
-  p = ngtcp2_put_uint32be(p, 0);
+  p = ngtcp2_put_uint32(p, 0);
   *p++ = NGTCP2_MAX_CIDLEN + 1;
   p = ngtcp2_setmem(p, 0xf1, NGTCP2_MAX_CIDLEN + 1);
   *p++ = NGTCP2_MAX_CIDLEN;
@@ -248,7 +248,7 @@ void test_ngtcp2_pkt_decode_version_cid(void) {
   /* Malformed Long packet */
   p = buf;
   *p++ = NGTCP2_HEADER_FORM_BIT;
-  p = ngtcp2_put_uint32be(p, NGTCP2_PROTO_VER_V1);
+  p = ngtcp2_put_uint32(p, NGTCP2_PROTO_VER_V1);
   *p++ = NGTCP2_MAX_CIDLEN;
   p = ngtcp2_setmem(p, 0xf1, NGTCP2_MAX_CIDLEN);
   *p++ = NGTCP2_MAX_CIDLEN - 1;

--- a/tests/ngtcp2_test_helper.c
+++ b/tests/ngtcp2_test_helper.c
@@ -202,7 +202,7 @@ static size_t write_long_pkt(uint8_t *out, size_t outlen, uint8_t flags,
   ngtcp2_ppe_init(&ppe, out, outlen, 0, &cc);
   rv = ngtcp2_ppe_encode_hd(&ppe, &hd);
   assert(0 == rv);
-  ngtcp2_put_uint32be(&out[1], version);
+  ngtcp2_put_uint32(&out[1], version);
 
   for (i = 0; i < frlen; ++i, ++fr) {
     rv = ngtcp2_ppe_encode_frame(&ppe, fr);

--- a/tests/ngtcp2_transport_params_test.c
+++ b/tests/ngtcp2_transport_params_test.c
@@ -67,7 +67,7 @@ void test_ngtcp2_transport_params_encode(void) {
   memset(&nparams, 0, sizeof(nparams));
 
   for (i = 0; i < sizeof(available_versions); i += sizeof(uint32_t)) {
-    ngtcp2_put_uint32be(&available_versions[i], (uint32_t)(0xff000000u + i));
+    ngtcp2_put_uint32(&available_versions[i], (uint32_t)(0xff000000u + i));
   }
 
   params.initial_max_stream_data_bidi_local = 1000000007;
@@ -254,7 +254,7 @@ void test_ngtcp2_transport_params_decode_new(void) {
   memset(&nparams, 0, sizeof(nparams));
 
   for (i = 0; i < sizeof(available_versions); i += sizeof(uint32_t)) {
-    ngtcp2_put_uint32be(&available_versions[i], (uint32_t)(0xff000000u + i));
+    ngtcp2_put_uint32(&available_versions[i], (uint32_t)(0xff000000u + i));
   }
 
   params.initial_max_stream_data_bidi_local = 1000000007;


### PR DESCRIPTION
- ngtcp2_put_uint16be, ngtcp2_put_uint24be, ngtcp2_put_uint32be, ngtcp2_put_uint48be, and ngtcp2_put_uint64be functions are renamed to ngtcp2_put_uint16, ngtcp2_put_uint24, ngtcp2_put_uint32, ngtcp2_put_uint48, and ngtcp2_put_uint64 respectively.

- The existing ngtcp2_put_uint16be is renamed to ngtcp2_put_uint16

to make consistent with the naming scheme applied to ngtcp2_get_uint* functions.