### PR TITLE
Remove unused NGTCP2_MAX_RX_(INITIAL|HANDSHAKE)_CRYPTO_DATA

### DIFF
--- a/lib/ngtcp2_conn.h
+++ b/lib/ngtcp2_conn.h
@@ -74,15 +74,6 @@ typedef enum {
    unreceived data. */
 #define NGTCP2_MAX_REORDERED_CRYPTO_DATA 65536
 
-/* NGTCP2_MAX_RX_INITIAL_CRYPTO_DATA is the maximum offset of received
-   crypto stream in Initial packet.  We set this hard limit here
-   because crypto stream is unbounded. */
-#define NGTCP2_MAX_RX_INITIAL_CRYPTO_DATA 65536
-/* NGTCP2_MAX_RX_HANDSHAKE_CRYPTO_DATA is the maximum offset of
-   received crypto stream in Handshake packet.  We set this hard limit
-   here because crypto stream is unbounded. */
-#define NGTCP2_MAX_RX_HANDSHAKE_CRYPTO_DATA 65536
-
 /* NGTCP2_MAX_RETRIES is the number of Retry packet which client can
    accept. */
 #define NGTCP2_MAX_RETRIES 3


### PR DESCRIPTION
Remove unused NGTCP2_MAX_RX_INITIAL_CRYPTO_DATA and NGTCP2_MAX_RX_HANDSHAKE_CRYPTO_DATA.