### PR TITLE
Consistent macro comments

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -271,13 +271,13 @@ endif()
 
 # Checks for symbols.
 if(HAVE_ENDIAN_H)
-  check_symbol_exists(be64toh "endian.h" HAVE_BE64TOH)
+  check_symbol_exists(be64toh "endian.h" HAVE_DECL_BE64TOH)
 endif()
-if(HAVE_SYS_ENDIAN_H)
-  check_symbol_exists(be64toh "sys/endian.h" HAVE_BE64TOH)
+if(NOT HAVE_DECL_BE64TOH AND HAVE_SYS_ENDIAN_H)
+  check_symbol_exists(be64toh "sys/endian.h" HAVE_DECL_BE64TOH)
 endif()
 
-check_symbol_exists(bswap_64 "byteswap.h" HAVE_BSWAP_64)
+check_symbol_exists(bswap_64 "byteswap.h" HAVE_DECL_BSWAP_64)
 check_symbol_exists(explicit_bzero "string.h" HAVE_EXPLICIT_BZERO)
 check_symbol_exists(memset_s "string.h" HAVE_MEMSET_S)
 

--- a/cmakeconfig.h.in
+++ b/cmakeconfig.h.in
@@ -35,8 +35,11 @@
 /* Define to 1 if you have the <linux/rtnetlink.h> header file. */
 #cmakedefine HAVE_LINUX_RTNETLINK_H 1
 
-/* Define to 1 if you have the `be64toh' function. */
-#cmakedefine HAVE_BE64TOH 1
+/* Define to 1 if you have the `be64toh' function, otherwise 0. */
+#cmakedefine01 HAVE_DECL_BE64TOH
+
+/* Define to 1 if you have the `bswap_64' function, otherwise 0. */
+#cmakedefine01 HAVE_DECL_BSWAP_64
 
 /* Define WORDS_BIGENDIAN to 1 if target architecture is big
    endian. */

--- a/crypto/boringssl/boringssl.c
+++ b/crypto/boringssl/boringssl.c
@@ -24,7 +24,7 @@
  */
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #include <assert.h>
 #include <string.h>
@@ -413,12 +413,12 @@ int ngtcp2_crypto_hp_mask(uint8_t *dest, const ngtcp2_crypto_cipher *hp,
     AES_ecb_encrypt(sample, dest, &ctx->aes_key, 1);
     return 0;
   case NGTCP2_CRYPTO_BORINGSSL_CIPHER_TYPE_CHACHA20:
-#if defined(WORDS_BIGENDIAN)
+#ifdef WORDS_BIGENDIAN
     counter = (uint32_t)sample[0] + (uint32_t)(sample[1] << 8) +
               (uint32_t)(sample[2] << 16) + (uint32_t)(sample[3] << 24);
-#else  /* !WORDS_BIGENDIAN */
+#else  /* !defined(WORDS_BIGENDIAN) */
     memcpy(&counter, sample, sizeof(counter));
-#endif /* !WORDS_BIGENDIAN */
+#endif /* !defined(WORDS_BIGENDIAN) */
     CRYPTO_chacha_20(dest, PLAINTEXT, sizeof(PLAINTEXT) - 1, ctx->key,
                      sample + sizeof(counter), counter);
     return 0;

--- a/crypto/gnutls/gnutls.c
+++ b/crypto/gnutls/gnutls.c
@@ -24,7 +24,7 @@
  */
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #include <assert.h>
 

--- a/crypto/includes/ngtcp2/ngtcp2_crypto.h
+++ b/crypto/includes/ngtcp2/ngtcp2_crypto.h
@@ -29,14 +29,14 @@
 
 #ifdef __cplusplus
 extern "C" {
-#endif
+#endif /* defined(__cplusplus) */
 
 #ifdef WIN32
 #  ifndef WIN32_LEAN_AND_MEAN
 #    define WIN32_LEAN_AND_MEAN
-#  endif
+#  endif /* !defined(WIN32_LEAN_AND_MEAN) */
 #  include <ws2tcpip.h>
-#endif /* WIN32 */
+#endif /* defined(WIN32) */
 
 /**
  * @function
@@ -833,6 +833,6 @@ typedef struct ngtcp2_crypto_conn_ref {
 
 #ifdef __cplusplus
 }
-#endif
+#endif /* defined(__cplusplus) */
 
-#endif /* NGTCP2_CRYPTO_H */
+#endif /* !defined(NGTCP2_CRYPTO_H) */

--- a/crypto/includes/ngtcp2/ngtcp2_crypto_boringssl.h
+++ b/crypto/includes/ngtcp2/ngtcp2_crypto_boringssl.h
@@ -31,7 +31,7 @@
 
 #ifdef __cplusplus
 extern "C" {
-#endif
+#endif /* defined(__cplusplus) */
 
 /**
  * @function
@@ -99,6 +99,6 @@ ngtcp2_crypto_boringssl_configure_client_context(SSL_CTX *ssl_ctx);
 
 #ifdef __cplusplus
 }
-#endif
+#endif /* defined(__cplusplus) */
 
-#endif /* NGTCP2_CRYPTO_BORINGSSL_H */
+#endif /* !defined(NGTCP2_CRYPTO_BORINGSSL_H) */

--- a/crypto/includes/ngtcp2/ngtcp2_crypto_gnutls.h
+++ b/crypto/includes/ngtcp2/ngtcp2_crypto_gnutls.h
@@ -31,7 +31,7 @@
 
 #ifdef __cplusplus
 extern "C" {
-#endif
+#endif /* defined(__cplusplus) */
 
 /**
  * @function
@@ -103,6 +103,6 @@ ngtcp2_crypto_gnutls_configure_client_session(gnutls_session_t session);
 
 #ifdef __cplusplus
 }
-#endif
+#endif /* defined(__cplusplus) */
 
-#endif /* NGTCP2_CRYPTO_GNUTLS_H */
+#endif /* !defined(NGTCP2_CRYPTO_GNUTLS_H) */

--- a/crypto/includes/ngtcp2/ngtcp2_crypto_picotls.h
+++ b/crypto/includes/ngtcp2/ngtcp2_crypto_picotls.h
@@ -31,7 +31,7 @@
 
 #ifdef __cplusplus
 extern "C" {
-#endif
+#endif /* defined(__cplusplus) */
 
 /**
  * @struct
@@ -241,6 +241,6 @@ NGTCP2_EXTERN int ngtcp2_crypto_picotls_collected_extensions(
 
 #ifdef __cplusplus
 }
-#endif
+#endif /* defined(__cplusplus) */
 
-#endif /* NGTCP2_CRYPTO_PICOTLS_H */
+#endif /* !defined(NGTCP2_CRYPTO_PICOTLS_H) */

--- a/crypto/includes/ngtcp2/ngtcp2_crypto_quictls.h
+++ b/crypto/includes/ngtcp2/ngtcp2_crypto_quictls.h
@@ -31,7 +31,7 @@
 
 #ifdef __cplusplus
 extern "C" {
-#endif
+#endif /* defined(__cplusplus) */
 
 /**
  * @macrosection
@@ -142,6 +142,6 @@ NGTCP2_EXTERN int ngtcp2_crypto_quictls_init(void);
 
 #ifdef __cplusplus
 }
-#endif
+#endif /* defined(__cplusplus) */
 
-#endif /* NGTCP2_CRYPTO_QUICTLS_H */
+#endif /* !defined(NGTCP2_CRYPTO_QUICTLS_H) */

--- a/crypto/includes/ngtcp2/ngtcp2_crypto_wolfssl.h
+++ b/crypto/includes/ngtcp2/ngtcp2_crypto_wolfssl.h
@@ -33,7 +33,7 @@
 
 #ifdef __cplusplus
 extern "C" {
-#endif
+#endif /* defined(__cplusplus) */
 
 /**
  * @function
@@ -101,6 +101,6 @@ ngtcp2_crypto_wolfssl_configure_client_context(WOLFSSL_CTX *ssl_ctx);
 
 #ifdef __cplusplus
 }
-#endif
+#endif /* defined(__cplusplus) */
 
-#endif /* NGTCP2_CRYPTO_WOLFSSL_H */
+#endif /* !defined(NGTCP2_CRYPTO_WOLFSSL_H) */

--- a/crypto/picotls/picotls.c
+++ b/crypto/picotls/picotls.c
@@ -24,7 +24,7 @@
  */
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #include <assert.h>
 #include <string.h>
@@ -79,7 +79,7 @@ crypto_cipher_suite_get_aead_max_encryption(ptls_cipher_suite_t *cs) {
   if (cs->aead == &ptls_openssl_chacha20poly1305) {
     return NGTCP2_CRYPTO_MAX_ENCRYPTION_CHACHA20_POLY1305;
   }
-#endif /* PTLS_OPENSSL_HAVE_CHACHA20_POLY1305 */
+#endif /* defined(PTLS_OPENSSL_HAVE_CHACHA20_POLY1305) */
 
   return 0;
 }
@@ -95,7 +95,7 @@ crypto_cipher_suite_get_aead_max_decryption_failure(ptls_cipher_suite_t *cs) {
   if (cs->aead == &ptls_openssl_chacha20poly1305) {
     return NGTCP2_CRYPTO_MAX_DECRYPTION_FAILURE_CHACHA20_POLY1305;
   }
-#endif /* PTLS_OPENSSL_HAVE_CHACHA20_POLY1305 */
+#endif /* defined(PTLS_OPENSSL_HAVE_CHACHA20_POLY1305) */
 
   return 0;
 }
@@ -114,7 +114,7 @@ crypto_cipher_suite_get_hp(ptls_cipher_suite_t *cs) {
   if (cs->aead == &ptls_openssl_chacha20poly1305) {
     return &ptls_openssl_chacha20;
   }
-#endif /* PTLS_OPENSSL_HAVE_CHACHA20_POLY1305 */
+#endif /* defined(PTLS_OPENSSL_HAVE_CHACHA20_POLY1305) */
 
   return NULL;
 }
@@ -124,7 +124,7 @@ static int supported_cipher_suite(ptls_cipher_suite_t *cs) {
          cs->aead == &ptls_openssl_aes256gcm
 #ifdef PTLS_OPENSSL_HAVE_CHACHA20_POLY1305
          || cs->aead == &ptls_openssl_chacha20poly1305
-#endif /* PTLS_OPENSSL_HAVE_CHACHA20_POLY1305 */
+#endif /* defined(PTLS_OPENSSL_HAVE_CHACHA20_POLY1305) */
       ;
 }
 

--- a/crypto/quictls/quictls.c
+++ b/crypto/quictls/quictls.c
@@ -24,7 +24,7 @@
  */
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #include <assert.h>
 
@@ -991,7 +991,7 @@ static SSL_QUIC_METHOD quic_method = {
 #ifdef LIBRESSL_VERSION_NUMBER
   NULL,
   NULL,
-#endif /* LIBRESSL_VERSION_NUMBER */
+#endif /* defined(LIBRESSL_VERSION_NUMBER) */
 };
 
 static void crypto_quictls_configure_context(SSL_CTX *ssl_ctx) {

--- a/crypto/shared.c
+++ b/crypto/shared.c
@@ -29,7 +29,7 @@
 #  include <ws2tcpip.h>
 #elif defined(HAVE_NETINET_IN_H)
 #  include <netinet/in.h>
-#endif
+#endif /* defined(HAVE_NETINET_IN_H) */
 
 #include <string.h>
 #include <assert.h>

--- a/crypto/shared.h
+++ b/crypto/shared.h
@@ -22,12 +22,12 @@
  * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-#ifndef NGTCP2_SHARED_H
-#define NGTCP2_SHARED_H
+#ifndef SHARED_H
+#define SHARED_H
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #include <ngtcp2/ngtcp2_crypto.h>
 
@@ -394,4 +394,4 @@ int ngtcp2_crypto_hkdf_expand_label(uint8_t *dest, size_t destlen,
                                     const uint8_t *secret, size_t secretlen,
                                     const uint8_t *label, size_t labellen);
 
-#endif /* NGTCP2_SHARED_H */
+#endif /* !defined(SHARED_H) */

--- a/crypto/wolfssl/wolfssl.c
+++ b/crypto/wolfssl/wolfssl.c
@@ -24,7 +24,7 @@
  */
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #include <assert.h>
 
@@ -39,9 +39,9 @@
 #define PRINTF_DEBUG 0
 #if PRINTF_DEBUG
 #  define DEBUG_MSG(...) fprintf(stderr, __VA_ARGS__)
-#else
+#else /* !PRINTF_DEBUG */
 #  define DEBUG_MSG(...) (void)0
-#endif
+#endif /* !PRINTF_DEBUG */
 
 ngtcp2_crypto_aead *ngtcp2_crypto_aead_aes_128_gcm(ngtcp2_crypto_aead *aead) {
   return ngtcp2_crypto_aead_init(aead, (void *)wolfSSL_EVP_aes_128_gcm());
@@ -531,7 +531,7 @@ int ngtcp2_crypto_wolfssl_configure_server_context(WOLFSSL_CTX *ssl_ctx) {
   crypto_wolfssl_configure_context(ssl_ctx);
 #if PRINTF_DEBUG
   wolfSSL_Debugging_ON();
-#endif
+#endif /* PRINTF_DEBUG */
   return 0;
 }
 
@@ -540,6 +540,6 @@ int ngtcp2_crypto_wolfssl_configure_client_context(WOLFSSL_CTX *ssl_ctx) {
   wolfSSL_CTX_UseSessionTicket(ssl_ctx);
 #if PRINTF_DEBUG
   wolfSSL_Debugging_ON();
-#endif
+#endif /* PRINTF_DEBUG */
   return 0;
 }

--- a/examples/client.cc
+++ b/examples/client.cc
@@ -1233,7 +1233,7 @@ int bind_addr(Address &local_addr, int fd, const in_addr_union *iau,
   return 0;
 }
 } // namespace
-#endif // HAVE_LINUX_RTNETLINK_H
+#endif // defined(HAVE_LINUX_RTNETLINK_H)
 
 #ifndef HAVE_LINUX_RTNETLINK_H
 namespace {
@@ -1254,7 +1254,7 @@ int connect_sock(Address &local_addr, int fd, const Address &remote_addr) {
   return 0;
 }
 } // namespace
-#endif // !HAVE_LINUX_RTNETLINK_H
+#endif // !defined(HAVE_LINUX_RTNETLINK_H)
 
 namespace {
 int udp_sock(int family) {
@@ -1326,7 +1326,7 @@ std::optional<Endpoint *> Client::endpoint_for(const Address &remote_addr) {
   if (addreq(&current_ep->addr.su.sa, iau)) {
     return current_ep;
   }
-#endif // HAVE_LINUX_RTNETLINK_H
+#endif // defined(HAVE_LINUX_RTNETLINK_H)
 
   auto fd = udp_sock(remote_addr.su.sa.sa_family);
   if (fd == -1) {
@@ -1340,12 +1340,12 @@ std::optional<Endpoint *> Client::endpoint_for(const Address &remote_addr) {
     close(fd);
     return nullptr;
   }
-#else  // !HAVE_LINUX_RTNETLINK_H
+#else  // !defined(HAVE_LINUX_RTNETLINK_H)
   if (connect_sock(local_addr, fd, remote_addr) != 0) {
     close(fd);
     return nullptr;
   }
-#endif // !HAVE_LINUX_RTNETLINK_H
+#endif // !defined(HAVE_LINUX_RTNETLINK_H)
 
   endpoints_.emplace_back();
   auto &ep = endpoints_.back();
@@ -1389,12 +1389,12 @@ int Client::change_local_addr() {
     close(nfd);
     return -1;
   }
-#else  // !HAVE_LINUX_RTNETLINK_H
+#else  // !defined(HAVE_LINUX_RTNETLINK_H)
   if (connect_sock(local_addr, nfd, remote_addr_) != 0) {
     close(nfd);
     return -1;
   }
-#endif // !HAVE_LINUX_RTNETLINK_H
+#endif // !defined(HAVE_LINUX_RTNETLINK_H)
 
   if (!config.quiet) {
     std::cerr << "Local address is now "
@@ -1514,7 +1514,7 @@ int Client::send_packet(const Endpoint &ep, const ngtcp2_addr &remote_addr,
 #ifdef HAVE_LINUX_RTNETLINK_H
   msg.msg_name = const_cast<sockaddr *>(remote_addr.addr);
   msg.msg_namelen = remote_addr.addrlen;
-#endif // HAVE_LINUX_RTNETLINK_H
+#endif // defined(HAVE_LINUX_RTNETLINK_H)
   msg.msg_iov = &msg_iov;
   msg.msg_iovlen = 1;
 
@@ -2203,12 +2203,12 @@ int run(Client &c, const char *addr, const char *port,
     close(fd);
     return -1;
   }
-#else  // !HAVE_LINUX_RTNETLINK_H
+#else  // !defined(HAVE_LINUX_RTNETLINK_H)
   if (connect_sock(local_addr, fd, remote_addr) != 0) {
     close(fd);
     return -1;
   }
-#endif // !HAVE_LINUX_RTNETLINK_H
+#endif // !defined(HAVE_LINUX_RTNETLINK_H)
 
   if (c.init(fd, local_addr, remote_addr, addr, port, tls_ctx) != 0) {
     return -1;

--- a/examples/client.h
+++ b/examples/client.h
@@ -27,7 +27,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif // HAVE_CONFIG_H
+#endif // defined(HAVE_CONFIG_H)
 
 #include <vector>
 #include <deque>
@@ -186,4 +186,4 @@ private:
   } tx_;
 };
 
-#endif // CLIENT_H
+#endif // !defined(CLIENT_H)

--- a/examples/client_base.h
+++ b/examples/client_base.h
@@ -27,7 +27,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif // HAVE_CONFIG_H
+#endif // defined(HAVE_CONFIG_H)
 
 #include <vector>
 #include <deque>
@@ -222,4 +222,4 @@ protected:
 void qlog_write_cb(void *user_data, uint32_t flags, const void *data,
                    size_t datalen);
 
-#endif // CLIENT_BASE_H
+#endif // !defined(CLIENT_BASE_H)

--- a/examples/debug.h
+++ b/examples/debug.h
@@ -27,12 +27,12 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif // HAVE_CONFIG_H
+#endif // defined(HAVE_CONFIG_H)
 
 #ifndef __STDC_FORMAT_MACROS
 // For travis and PRIu64
 #  define __STDC_FORMAT_MACROS
-#endif // __STDC_FORMAT_MACROS
+#endif // !defined(__STDC_FORMAT_MACROS)
 
 #include <cinttypes>
 #include <string_view>
@@ -124,4 +124,4 @@ std::string_view secret_title(ngtcp2_encryption_level level);
 
 } // namespace ngtcp2
 
-#endif // DEBUG_H
+#endif // !defined(DEBUG_H)

--- a/examples/examplestest.cc
+++ b/examples/examplestest.cc
@@ -25,7 +25,7 @@
  */
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif // HAVE_CONFIG_H
+#endif // defined(HAVE_CONFIG_H)
 
 #include "munit.h"
 

--- a/examples/gtlssimpleclient.c
+++ b/examples/gtlssimpleclient.c
@@ -24,7 +24,7 @@
  */
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #include <time.h>
 #include <sys/types.h>
@@ -286,13 +286,13 @@ static int extend_max_local_streams_bidi(ngtcp2_conn *conn,
   c->stream.datalen = sizeof(MESSAGE) - 1;
 
   return 0;
-#else  /* !MESSAGE */
+#else  /* !defined(MESSAGE) */
   (void)conn;
   (void)max_streams;
   (void)user_data;
 
   return 0;
-#endif /* !MESSAGE */
+#endif /* !defined(MESSAGE) */
 }
 
 static void log_printf(void *user_data, const char *fmt, ...) {

--- a/examples/h09client.cc
+++ b/examples/h09client.cc
@@ -1140,7 +1140,7 @@ int bind_addr(Address &local_addr, int fd, const in_addr_union *iau,
   return 0;
 }
 } // namespace
-#endif // HAVE_LINUX_RTNETLINK_H
+#endif // defined(HAVE_LINUX_RTNETLINK_H)
 
 #ifndef HAVE_LINUX_RTNETLINK_H
 namespace {
@@ -1161,7 +1161,7 @@ int connect_sock(Address &local_addr, int fd, const Address &remote_addr) {
   return 0;
 }
 } // namespace
-#endif // !HAVE_LINUX_RTNETLINK_H
+#endif // !defined(HAVE_LINUX_RTNETLINK_H)
 
 namespace {
 int udp_sock(int family) {
@@ -1233,7 +1233,7 @@ std::optional<Endpoint *> Client::endpoint_for(const Address &remote_addr) {
   if (addreq(&current_ep->addr.su.sa, iau)) {
     return current_ep;
   }
-#endif // HAVE_LINUX_RTNETLINK_H
+#endif // defined(HAVE_LINUX_RTNETLINK_H)
 
   auto fd = udp_sock(remote_addr.su.sa.sa_family);
   if (fd == -1) {
@@ -1247,12 +1247,12 @@ std::optional<Endpoint *> Client::endpoint_for(const Address &remote_addr) {
     close(fd);
     return nullptr;
   }
-#else  // !HAVE_LINUX_RTNETLINK_H
+#else  // !defined(HAVE_LINUX_RTNETLINK_H)
   if (connect_sock(local_addr, fd, remote_addr) != 0) {
     close(fd);
     return nullptr;
   }
-#endif // !HAVE_LINUX_RTNETLINK_H
+#endif // !defined(HAVE_LINUX_RTNETLINK_H)
 
   endpoints_.emplace_back();
   auto &ep = endpoints_.back();
@@ -1296,12 +1296,12 @@ int Client::change_local_addr() {
     close(nfd);
     return -1;
   }
-#else  // !HAVE_LINUX_RTNETLINK_H
+#else  // !defined(HAVE_LINUX_RTNETLINK_H)
   if (connect_sock(local_addr, nfd, remote_addr_) != 0) {
     close(nfd);
     return -1;
   }
-#endif // !HAVE_LINUX_RTNETLINK_H
+#endif // !defined(HAVE_LINUX_RTNETLINK_H)
 
   if (!config.quiet) {
     std::cerr << "Local address is now "
@@ -1421,7 +1421,7 @@ int Client::send_packet(const Endpoint &ep, const ngtcp2_addr &remote_addr,
 #ifdef HAVE_LINUX_RTNETLINK_H
   msg.msg_name = const_cast<sockaddr *>(remote_addr.addr);
   msg.msg_namelen = remote_addr.addrlen;
-#endif // HAVE_LINUX_RTNETLINK_H
+#endif // defined(HAVE_LINUX_RTNETLINK_H)
   msg.msg_iov = &msg_iov;
   msg.msg_iovlen = 1;
 
@@ -1752,12 +1752,12 @@ int run(Client &c, const char *addr, const char *port,
     close(fd);
     return -1;
   }
-#else  // !HAVE_LINUX_RTNETLINK_H
+#else  // !defined(HAVE_LINUX_RTNETLINK_H)
   if (connect_sock(local_addr, fd, remote_addr) != 0) {
     close(fd);
     return -1;
   }
-#endif // !HAVE_LINUX_RTNETLINK_H
+#endif // !defined(HAVE_LINUX_RTNETLINK_H)
 
   if (c.init(fd, local_addr, remote_addr, addr, port, tls_ctx) != 0) {
     return -1;

--- a/examples/h09client.h
+++ b/examples/h09client.h
@@ -27,7 +27,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif // HAVE_CONFIG_H
+#endif // defined(HAVE_CONFIG_H)
 
 #include <vector>
 #include <deque>
@@ -190,4 +190,4 @@ private:
   } tx_;
 };
 
-#endif // CLIENT_H
+#endif // !defined(H09CLIENT_H)

--- a/examples/h09server.cc
+++ b/examples/h09server.cc
@@ -345,9 +345,9 @@ Handler::Handler(struct ev_loop *loop, Server *server)
     no_gso_{
 #ifdef UDP_SEGMENT
       false
-#else  // !UDP_SEGMENT
+#else  // !defined(UDP_SEGMENT)
       true
-#endif // !UDP_SEGMENT
+#endif // !defined(UDP_SEGMENT)
     },
     tx_{
       .data = std::unique_ptr<uint8_t[]>(new uint8_t[64_k]),
@@ -2412,7 +2412,7 @@ Server::send_packet(Endpoint &ep, bool &no_gso, const ngtcp2_addr &local_addr,
     uint16_t n = gso_size;
     memcpy(CMSG_DATA(cm), &n, sizeof(n));
   }
-#endif // UDP_SEGMENT
+#endif // defined(UDP_SEGMENT)
 
   controllen += CMSG_SPACE(sizeof(int));
   cm = CMSG_NXTHDR(&msg, cm);
@@ -2462,7 +2462,7 @@ Server::send_packet(Endpoint &ep, bool &no_gso, const ngtcp2_addr &local_addr,
                            gso_size);
       }
       break;
-#endif // UDP_SEGMENT
+#endif // defined(UDP_SEGMENT)
     }
 
     std::cerr << "sendmsg: " << strerror(errno) << std::endl;

--- a/examples/h09server.h
+++ b/examples/h09server.h
@@ -22,12 +22,12 @@
  * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-#ifndef SERVER_H
-#define SERVER_H
+#ifndef H09SERVER_H
+#define H09SERVER_H
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif // HAVE_CONFIG_H
+#endif // defined(HAVE_CONFIG_H)
 
 #include <vector>
 #include <unordered_map>
@@ -254,4 +254,4 @@ private:
   size_t stateless_reset_bucket_;
 };
 
-#endif // SERVER_H
+#endif // !defined(H09SERVER_H)

--- a/examples/http.h
+++ b/examples/http.h
@@ -27,7 +27,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif // HAVE_CONFIG_H
+#endif // defined(HAVE_CONFIG_H)
 
 #include <string>
 
@@ -41,4 +41,4 @@ std::string get_reason_phrase(unsigned int status_code);
 
 } // namespace ngtcp2
 
-#endif // HTTP_H
+#endif // !defined(HTTP_H)

--- a/examples/network.h
+++ b/examples/network.h
@@ -28,19 +28,19 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif // HAVE_CONFIG_H
+#endif // defined(HAVE_CONFIG_H)
 
 #include <sys/types.h>
 #ifdef HAVE_SYS_SOCKET_H
 #  include <sys/socket.h>
-#endif // HAVE_SYS_SOCKET_H
+#endif // defined(HAVE_SYS_SOCKET_H)
 #include <sys/un.h>
 #ifdef HAVE_NETINET_IN_H
 #  include <netinet/in.h>
-#endif // HAVE_NETINET_IN_H
+#endif // defined(HAVE_NETINET_IN_H)
 #ifdef HAVE_ARPA_INET_H
 #  include <arpa/inet.h>
-#endif // HAVE_ARPA_INET_H
+#endif // defined(HAVE_ARPA_INET_H)
 
 #include <array>
 
@@ -77,4 +77,4 @@ struct Address {
 
 } // namespace ngtcp2
 
-#endif // NETWORK_H
+#endif // !defined(NETWORK_H)

--- a/examples/server.cc
+++ b/examples/server.cc
@@ -646,9 +646,9 @@ Handler::Handler(struct ev_loop *loop, Server *server)
     no_gso_{
 #ifdef UDP_SEGMENT
       false
-#else  // !UDP_SEGMENT
+#else  // !defined(UDP_SEGMENT)
       true
-#endif // !UDP_SEGMENT
+#endif // !defined(UDP_SEGMENT)
     },
     tx_{
       .data = std::unique_ptr<uint8_t[]>(new uint8_t[64_k]),
@@ -3136,7 +3136,7 @@ Server::send_packet(Endpoint &ep, bool &no_gso, const ngtcp2_addr &local_addr,
     uint16_t n = gso_size;
     memcpy(CMSG_DATA(cm), &n, sizeof(n));
   }
-#endif // UDP_SEGMENT
+#endif // defined(UDP_SEGMENT)
 
   controllen += CMSG_SPACE(sizeof(int));
   cm = CMSG_NXTHDR(&msg, cm);
@@ -3186,7 +3186,7 @@ Server::send_packet(Endpoint &ep, bool &no_gso, const ngtcp2_addr &local_addr,
                            gso_size);
       }
       break;
-#endif // UDP_SEGMENT
+#endif // defined(UDP_SEGMENT)
     }
 
     std::cerr << "sendmsg: " << strerror(errno) << std::endl;

--- a/examples/server.h
+++ b/examples/server.h
@@ -27,7 +27,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif // HAVE_CONFIG_H
+#endif // defined(HAVE_CONFIG_H)
 
 #include <vector>
 #include <unordered_map>
@@ -273,4 +273,4 @@ private:
   size_t stateless_reset_bucket_;
 };
 
-#endif // SERVER_H
+#endif // !defined(SERVER_H)

--- a/examples/server_base.h
+++ b/examples/server_base.h
@@ -27,7 +27,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif // HAVE_CONFIG_H
+#endif // defined(HAVE_CONFIG_H)
 
 #include <vector>
 #include <deque>
@@ -195,4 +195,4 @@ protected:
   ngtcp2_ccerr last_error_;
 };
 
-#endif // SERVER_BASE_H
+#endif // !defined(SERVER_BASE_H)

--- a/examples/shared.cc
+++ b/examples/shared.cc
@@ -33,22 +33,22 @@
 #include <unistd.h>
 #ifdef HAVE_NETINET_IN_H
 #  include <netinet/in.h>
-#endif // HAVE_NETINET_IN_H
+#endif // defined(HAVE_NETINET_IN_H)
 #ifdef HAVE_NETINET_UDP_H
 #  include <netinet/udp.h>
-#endif // HAVE_NETINET_UDP_H
+#endif // defined(HAVE_NETINET_UDP_H)
 #ifdef HAVE_NETINET_IP_H
 #  include <netinet/ip.h>
-#endif // HAVE_NETINET_IP_H
+#endif // defined(HAVE_NETINET_IP_H)
 #ifdef HAVE_ASM_TYPES_H
 #  include <asm/types.h>
-#endif // HAVE_ASM_TYPES_H
+#endif // defined(HAVE_ASM_TYPES_H)
 #ifdef HAVE_LINUX_NETLINK_H
 #  include <linux/netlink.h>
-#endif // HAVE_LINUX_NETLINK_H
+#endif // defined(HAVE_LINUX_NETLINK_H)
 #ifdef HAVE_LINUX_RTNETLINK_H
 #  include <linux/rtnetlink.h>
-#endif // HAVE_LINUX_RTNETLINK_H
+#endif // defined(HAVE_LINUX_RTNETLINK_H)
 
 #include "template.h"
 
@@ -61,9 +61,9 @@ unsigned int msghdr_get_ecn(msghdr *msg, int family) {
       if (cmsg->cmsg_level == IPPROTO_IP &&
 #ifdef __APPLE__
           cmsg->cmsg_type == IP_RECVTOS
-#else  // !__APPLE__
+#else  // !defined(__APPLE__)
           cmsg->cmsg_type == IP_TOS
-#endif // !__APPLE__
+#endif // !defined(__APPLE__)
           && cmsg->cmsg_len) {
         return *reinterpret_cast<uint8_t *>(CMSG_DATA(cmsg)) & IPTOS_ECN_MASK;
       }
@@ -159,7 +159,7 @@ void fd_set_udp_gro(int fd) {
                  static_cast<socklen_t>(sizeof(val))) == -1) {
     std::cerr << "setsockopt: UDP_GRO: " << strerror(errno) << std::endl;
   }
-#endif // UDP_GRO
+#endif // defined(UDP_GRO)
 }
 
 std::optional<Address> msghdr_get_local_addr(msghdr *msg, int family) {
@@ -209,7 +209,7 @@ size_t msghdr_get_udp_gro(msghdr *msg) {
       break;
     }
   }
-#endif // UDP_GRO
+#endif // defined(UDP_GRO)
 
   return static_cast<size_t>(gso_size);
 }
@@ -470,7 +470,7 @@ int get_local_addr(in_addr_union &iau, const Address &remote_addr) {
   return recv_netlink_msg(iau, fd, seq);
 }
 
-#endif // HAVE_LINUX_NETLINK_H
+#endif // defined(HAVE_LINUX_NETLINK_H)
 
 bool addreq(const sockaddr *sa, const in_addr_union &iau) {
   switch (sa->sa_family) {

--- a/examples/shared.h
+++ b/examples/shared.h
@@ -27,7 +27,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif // HAVE_CONFIG_H
+#endif // defined(HAVE_CONFIG_H)
 
 #include <optional>
 
@@ -83,4 +83,4 @@ bool addreq(const sockaddr *sa, const in_addr_union &iau);
 
 } // namespace ngtcp2
 
-#endif // SHARED_H
+#endif // !defined(SHARED_H)

--- a/examples/simpleclient.c
+++ b/examples/simpleclient.c
@@ -24,7 +24,7 @@
  */
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #include <time.h>
 #include <sys/types.h>
@@ -244,13 +244,13 @@ static int extend_max_local_streams_bidi(ngtcp2_conn *conn,
   c->stream.datalen = sizeof(MESSAGE) - 1;
 
   return 0;
-#else  /* !MESSAGE */
+#else  /* !defined(MESSAGE) */
   (void)conn;
   (void)max_streams;
   (void)user_data;
 
   return 0;
-#endif /* !MESSAGE */
+#endif /* !defined(MESSAGE) */
 }
 
 static void log_printf(void *user_data, const char *fmt, ...) {

--- a/examples/template.h
+++ b/examples/template.h
@@ -68,4 +68,4 @@ constexpr unsigned long long operator""_g(unsigned long long g) {
   return g * 1024 * 1024 * 1024;
 }
 
-#endif // TEMPLATE_H
+#endif // !defined(TEMPLATE_H)

--- a/examples/tls_client_context.h
+++ b/examples/tls_client_context.h
@@ -27,26 +27,26 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif // HAVE_CONFIG_H
+#endif // defined(HAVE_CONFIG_H)
 
 #if defined(ENABLE_EXAMPLE_QUICTLS) && defined(WITH_EXAMPLE_QUICTLS)
 #  include "tls_client_context_quictls.h"
-#endif // ENABLE_EXAMPLE_QUICTLS && WITH_EXAMPLE_QUICTLS
+#endif // defined(ENABLE_EXAMPLE_QUICTLS) && defined(WITH_EXAMPLE_QUICTLS)
 
 #if defined(ENABLE_EXAMPLE_GNUTLS) && defined(WITH_EXAMPLE_GNUTLS)
 #  include "tls_client_context_gnutls.h"
-#endif // ENABLE_EXAMPLE_GNUTLS && WITH_EXAMPLE_GNUTLS
+#endif // defined(ENABLE_EXAMPLE_GNUTLS) && defined(WITH_EXAMPLE_GNUTLS)
 
 #if defined(ENABLE_EXAMPLE_BORINGSSL) && defined(WITH_EXAMPLE_BORINGSSL)
 #  include "tls_client_context_boringssl.h"
-#endif // ENABLE_EXAMPLE_BORINGSSL && WITH_EXAMPLE_BORINGSSL
+#endif // defined(ENABLE_EXAMPLE_BORINGSSL) && defined(WITH_EXAMPLE_BORINGSSL)
 
 #if defined(ENABLE_EXAMPLE_PICOTLS) && defined(WITH_EXAMPLE_PICOTLS)
 #  include "tls_client_context_picotls.h"
-#endif // ENABLE_EXAMPLE_PICOTLS && WITH_EXAMPLE_PICOTLS
+#endif // defined(ENABLE_EXAMPLE_PICOTLS) && defined(WITH_EXAMPLE_PICOTLS)
 
 #if defined(ENABLE_EXAMPLE_WOLFSSL) && defined(WITH_EXAMPLE_WOLFSSL)
 #  include "tls_client_context_wolfssl.h"
-#endif // ENABLE_EXAMPLE_WOLFSSL && WITH_EXAMPLE_WOLFSSL
+#endif // defined(ENABLE_EXAMPLE_WOLFSSL) && defined(WITH_EXAMPLE_WOLFSSL)
 
-#endif // TLS_CLIENT_CONTEXT_H
+#endif // !defined(TLS_CLIENT_CONTEXT_H)

--- a/examples/tls_client_context_boringssl.cc
+++ b/examples/tls_client_context_boringssl.cc
@@ -122,7 +122,7 @@ int TLSClientContext::init(const char *private_key_file,
     std::cerr << "SSL_CTX_add_cert_compression_alg failed" << std::endl;
     return -1;
   }
-#endif // HAVE_LIBBROTLI
+#endif // defined(HAVE_LIBBROTLI)
 
   return 0;
 }

--- a/examples/tls_client_context_boringssl.h
+++ b/examples/tls_client_context_boringssl.h
@@ -27,7 +27,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif // HAVE_CONFIG_H
+#endif // defined(HAVE_CONFIG_H)
 
 #include <openssl/ssl.h>
 
@@ -46,4 +46,4 @@ private:
   SSL_CTX *ssl_ctx_;
 };
 
-#endif // TLS_CLIENT_CONTEXT_BORINGSSL_H
+#endif // !defined(TLS_CLIENT_CONTEXT_BORINGSSL_H)

--- a/examples/tls_client_context_gnutls.h
+++ b/examples/tls_client_context_gnutls.h
@@ -27,7 +27,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif // HAVE_CONFIG_H
+#endif // defined(HAVE_CONFIG_H)
 
 #include <gnutls/gnutls.h>
 
@@ -47,4 +47,4 @@ private:
   gnutls_certificate_credentials_t cred_;
 };
 
-#endif // TLS_CLIENT_CONTEXT_GNUTLS_H
+#endif // !defined(TLS_CLIENT_CONTEXT_GNUTLS_H)

--- a/examples/tls_client_context_picotls.h
+++ b/examples/tls_client_context_picotls.h
@@ -27,7 +27,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif // HAVE_CONFIG_H
+#endif // defined(HAVE_CONFIG_H)
 
 #include <picotls.h>
 #include <picotls/openssl.h>
@@ -50,4 +50,4 @@ private:
   ptls_openssl_sign_certificate_t sign_cert_;
 };
 
-#endif // TLS_CLIENT_CONTEXT_PICOTLS_H
+#endif // !defined(TLS_CLIENT_CONTEXT_PICOTLS_H)

--- a/examples/tls_client_context_quictls.h
+++ b/examples/tls_client_context_quictls.h
@@ -27,7 +27,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif // HAVE_CONFIG_H
+#endif // defined(HAVE_CONFIG_H)
 
 #include <openssl/ssl.h>
 
@@ -46,4 +46,4 @@ private:
   SSL_CTX *ssl_ctx_;
 };
 
-#endif // TLS_CLIENT_CONTEXT_QUICTLS_H
+#endif // !defined(TLS_CLIENT_CONTEXT_QUICTLS_H)

--- a/examples/tls_client_context_wolfssl.cc
+++ b/examples/tls_client_context_wolfssl.cc
@@ -96,9 +96,9 @@ int new_session_cb(WOLFSSL *ssl, WOLFSSL_SESSION *session) {
   }
   std::cerr << "new_session_cb: wrote " << sz << " of session data"
             << std::endl;
-#else
+#else  // !defined(HAVE_SESSION_TICKET)
   std::cerr << "TLS session tickets not enabled in wolfSSL " << std::endl;
-#endif
+#endif // !defined(HAVE_SESSION_TICKET)
   return 0;
 }
 } // namespace
@@ -176,10 +176,10 @@ void keylog_callback(const WOLFSSL *ssl, const char *line) {
   keylog_file.flush();
 }
 } // namespace
-#endif
+#endif // defined(HAVE_SECRET_CALLBACK)
 
 void TLSClientContext::enable_keylog() {
 #ifdef HAVE_SECRET_CALLBACK
   wolfSSL_CTX_set_keylog_callback(ssl_ctx_, keylog_callback);
-#endif
+#endif // defined(HAVE_SECRET_CALLBACK)
 }

--- a/examples/tls_client_context_wolfssl.h
+++ b/examples/tls_client_context_wolfssl.h
@@ -27,7 +27,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif // HAVE_CONFIG_H
+#endif // defined(HAVE_CONFIG_H)
 
 #include <wolfssl/options.h>
 #include <wolfssl/ssl.h>
@@ -48,4 +48,4 @@ private:
   WOLFSSL_CTX *ssl_ctx_;
 };
 
-#endif // TLS_CLIENT_CONTEXT_WOLFSSL_H
+#endif // !defined(TLS_CLIENT_CONTEXT_WOLFSSL_H)

--- a/examples/tls_client_session.h
+++ b/examples/tls_client_session.h
@@ -27,26 +27,26 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif // HAVE_CONFIG_H
+#endif // defined(HAVE_CONFIG_H)
 
 #if defined(ENABLE_EXAMPLE_QUICTLS) && defined(WITH_EXAMPLE_QUICTLS)
 #  include "tls_client_session_quictls.h"
-#endif // ENABLE_EXAMPLE_QUICTLS && WITH_EXAMPLE_QUICTLS
+#endif // defined(ENABLE_EXAMPLE_QUICTLS) && defined(WITH_EXAMPLE_QUICTLS)
 
 #if defined(ENABLE_EXAMPLE_GNUTLS) && defined(WITH_EXAMPLE_GNUTLS)
 #  include "tls_client_session_gnutls.h"
-#endif // ENABLE_EXAMPLE_GNUTLS && WITH_EXAMPLE_GNUTLS
+#endif // defined(ENABLE_EXAMPLE_GNUTLS) && defined(WITH_EXAMPLE_GNUTLS)
 
 #if defined(ENABLE_EXAMPLE_BORINGSSL) && defined(WITH_EXAMPLE_BORINGSSL)
 #  include "tls_client_session_boringssl.h"
-#endif // ENABLE_EXAMPLE_BORINGSSL && WITH_EXAMPLE_BORINGSSL
+#endif // defined(ENABLE_EXAMPLE_BORINGSSL) && defined(WITH_EXAMPLE_BORINGSSL)
 
 #if defined(ENABLE_EXAMPLE_PICOTLS) && defined(WITH_EXAMPLE_PICOTLS)
 #  include "tls_client_session_picotls.h"
-#endif // ENABLE_EXAMPLE_PICOTLS && WITH_EXAMPLE_PICOTLS
+#endif // defined(ENABLE_EXAMPLE_PICOTLS) && defined(WITH_EXAMPLE_PICOTLS)
 
 #if defined(ENABLE_EXAMPLE_WOLFSSL) && defined(WITH_EXAMPLE_WOLFSSL)
 #  include "tls_client_session_wolfssl.h"
-#endif // ENABLE_EXAMPLE_WOLFSSL && WITH_EXAMPLE_WOLFSSL
+#endif // defined(ENABLE_EXAMPLE_WOLFSSL) && defined(WITH_EXAMPLE_WOLFSSL)
 
-#endif // TLS_CLIENT_SESSION_H
+#endif // !defined(TLS_CLIENT_SESSION_H)

--- a/examples/tls_client_session_boringssl.h
+++ b/examples/tls_client_session_boringssl.h
@@ -27,7 +27,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif // HAVE_CONFIG_H
+#endif // defined(HAVE_CONFIG_H)
 
 #include "tls_session_base_quictls.h"
 #include "shared.h"
@@ -49,4 +49,4 @@ public:
   bool get_early_data_accepted() const;
 };
 
-#endif // TLS_CLIENT_SESSION_BORINGSSL_H
+#endif // !defined(TLS_CLIENT_SESSION_BORINGSSL_H)

--- a/examples/tls_client_session_gnutls.h
+++ b/examples/tls_client_session_gnutls.h
@@ -27,7 +27,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif // HAVE_CONFIG_H
+#endif // defined(HAVE_CONFIG_H)
 
 #include "tls_session_base_gnutls.h"
 #include "shared.h"
@@ -49,4 +49,4 @@ public:
   bool get_early_data_accepted() const;
 };
 
-#endif // TLS_CLIENT_SESSION_GNUTLS_H
+#endif // !defined(TLS_CLIENT_SESSION_GNUTLS_H)

--- a/examples/tls_client_session_picotls.h
+++ b/examples/tls_client_session_picotls.h
@@ -27,7 +27,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif // HAVE_CONFIG_H
+#endif // defined(HAVE_CONFIG_H)
 
 #include "tls_session_base_picotls.h"
 #include "shared.h"
@@ -49,4 +49,4 @@ public:
   bool get_early_data_accepted() const;
 };
 
-#endif // TLS_CLIENT_SESSION_PICOTLS_H
+#endif // !defined(TLS_CLIENT_SESSION_PICOTLS_H)

--- a/examples/tls_client_session_quictls.cc
+++ b/examples/tls_client_session_quictls.cc
@@ -98,7 +98,7 @@ int TLSClientSession::init(bool &early_data_enabled,
           early_data_enabled = true;
           SSL_set_quic_early_data_enabled(ssl_, 1);
         }
-#endif // !LIBRESSL_VERSION_NUMBER
+#endif // !defined(LIBRESSL_VERSION_NUMBER)
         SSL_SESSION_free(session);
       }
     }

--- a/examples/tls_client_session_quictls.h
+++ b/examples/tls_client_session_quictls.h
@@ -27,7 +27,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif // HAVE_CONFIG_H
+#endif // defined(HAVE_CONFIG_H)
 
 #include "tls_session_base_quictls.h"
 #include "shared.h"
@@ -49,4 +49,4 @@ public:
   bool get_early_data_accepted() const;
 };
 
-#endif // TLS_CLIENT_SESSION_QUICTLS_H
+#endif // !defined(TLS_CLIENT_SESSION_QUICTLS_H)

--- a/examples/tls_client_session_wolfssl.cc
+++ b/examples/tls_client_session_wolfssl.cc
@@ -143,9 +143,9 @@ int TLSClientSession::init(bool &early_data_enabled,
     }
     wolfSSL_UseSessionTicket(ssl_);
     wolfSSL_set_SessionTicket_cb(ssl_, wolfssl_session_ticket_cb, nullptr);
-#else
+#else  // !defined(HAVE_SESSION_TICKET)
     std::cerr << "TLS session im-/export not enabled in wolfSSL" << std::endl;
-#endif
+#endif // !defined(HAVE_SESSION_TICKET)
   }
 
   return 0;
@@ -155,7 +155,7 @@ bool TLSClientSession::get_early_data_accepted() const {
   // wolfSSL_get_early_data_status works after handshake completes.
 #ifdef WOLFSSL_EARLY_DATA
   return wolfSSL_get_early_data_status(ssl_) == SSL_EARLY_DATA_ACCEPTED;
-#else
+#else  // !defined(WOLFSSL_EARLY_DATA)
   return 0;
-#endif
+#endif // !defined(WOLFSSL_EARLY_DATA)
 }

--- a/examples/tls_client_session_wolfssl.h
+++ b/examples/tls_client_session_wolfssl.h
@@ -27,7 +27,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif // HAVE_CONFIG_H
+#endif // defined(HAVE_CONFIG_H)
 
 #include "tls_session_base_wolfssl.h"
 #include "shared.h"
@@ -49,4 +49,4 @@ public:
   bool get_early_data_accepted() const;
 };
 
-#endif // TLS_CLIENT_SESSION_WOLFSSL_H
+#endif // !defined(TLS_CLIENT_SESSION_WOLFSSL_H)

--- a/examples/tls_server_context.h
+++ b/examples/tls_server_context.h
@@ -27,26 +27,26 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif // HAVE_CONFIG_H
+#endif // defined(HAVE_CONFIG_H)
 
 #if defined(ENABLE_EXAMPLE_QUICTLS) && defined(WITH_EXAMPLE_QUICTLS)
 #  include "tls_server_context_quictls.h"
-#endif // ENABLE_EXAMPLE_QUICTLS && WITH_EXAMPLE_QUICTLS
+#endif // defined(ENABLE_EXAMPLE_QUICTLS) && defined(WITH_EXAMPLE_QUICTLS)
 
 #if defined(ENABLE_EXAMPLE_GNUTLS) && defined(WITH_EXAMPLE_GNUTLS)
 #  include "tls_server_context_gnutls.h"
-#endif // ENABLE_EXAMPLE_GNUTLS && WITH_EXAMPLE_GNUTLS
+#endif // defined(ENABLE_EXAMPLE_GNUTLS) && defined(WITH_EXAMPLE_GNUTLS)
 
 #if defined(ENABLE_EXAMPLE_BORINGSSL) && defined(WITH_EXAMPLE_BORINGSSL)
 #  include "tls_server_context_boringssl.h"
-#endif // ENABLE_EXAMPLE_BORINGSSL && WITH_EXAMPLE_BORINGSSL
+#endif // defined(ENABLE_EXAMPLE_BORINGSSL) && defined(WITH_EXAMPLE_BORINGSSL)
 
 #if defined(ENABLE_EXAMPLE_PICOTLS) && defined(WITH_EXAMPLE_PICOTLS)
 #  include "tls_server_context_picotls.h"
-#endif // ENABLE_EXAMPLE_PICOTLS && WITH_EXAMPLE_PICOTLS
+#endif // defined(ENABLE_EXAMPLE_PICOTLS) && defined(WITH_EXAMPLE_PICOTLS)
 
 #if defined(ENABLE_EXAMPLE_WOLFSSL) && defined(WITH_EXAMPLE_WOLFSSL)
 #  include "tls_server_context_wolfssl.h"
-#endif // ENABLE_EXAMPLE_WOLFSSL && WITH_EXAMPLE_WOLFSSL
+#endif // defined(ENABLE_EXAMPLE_WOLFSSL) && defined(WITH_EXAMPLE_WOLFSSL)
 
-#endif // TLS_SERVER_CONTEXT_H
+#endif // !defined(TLS_SERVER_CONTEXT_H)

--- a/examples/tls_server_context_boringssl.cc
+++ b/examples/tls_server_context_boringssl.cc
@@ -216,7 +216,7 @@ int TLSServerContext::init(const char *private_key_file, const char *cert_file,
     std::cerr << "SSL_CTX_add_cert_compression_alg failed" << std::endl;
     return -1;
   }
-#endif // HAVE_LIBBROTLI
+#endif // defined(HAVE_LIBBROTLI)
 
   return 0;
 }

--- a/examples/tls_server_context_boringssl.h
+++ b/examples/tls_server_context_boringssl.h
@@ -27,7 +27,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif // HAVE_CONFIG_H
+#endif // defined(HAVE_CONFIG_H)
 
 #include <openssl/ssl.h>
 
@@ -51,4 +51,4 @@ private:
   SSL_CTX *ssl_ctx_;
 };
 
-#endif // TLS_SERVER_CONTEXT_BORINGSSL_H
+#endif // !defined(TLS_SERVER_CONTEXT_BORINGSSL_H)

--- a/examples/tls_server_context_gnutls.h
+++ b/examples/tls_server_context_gnutls.h
@@ -27,7 +27,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif // HAVE_CONFIG_H
+#endif // defined(HAVE_CONFIG_H)
 
 #include <gnutls/gnutls.h>
 
@@ -56,4 +56,4 @@ private:
   gnutls_anti_replay_t anti_replay_;
 };
 
-#endif // TLS_SERVER_CONTEXT_GNUTLS_H
+#endif // !defined(TLS_SERVER_CONTEXT_GNUTLS_H)

--- a/examples/tls_server_context_picotls.h
+++ b/examples/tls_server_context_picotls.h
@@ -27,7 +27,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif // HAVE_CONFIG_H
+#endif // defined(HAVE_CONFIG_H)
 
 #include <picotls.h>
 #include <picotls/openssl.h>
@@ -55,4 +55,4 @@ private:
   ptls_openssl_sign_certificate_t sign_cert_;
 };
 
-#endif // TLS_SERVER_CONTEXT_PICOTLS_H
+#endif // !defined(TLS_SERVER_CONTEXT_PICOTLS_H)

--- a/examples/tls_server_context_quictls.cc
+++ b/examples/tls_server_context_quictls.cc
@@ -219,7 +219,7 @@ SSL_TICKET_RETURN decrypt_ticket_cb(SSL *ssl, SSL_SESSION *session,
   }
 }
 } // namespace
-#endif // !LIBRESSL_VERSION_NUMBER
+#endif // !defined(LIBRESSL_VERSION_NUMBER)
 
 int TLSServerContext::init(const char *private_key_file, const char *cert_file,
                            AppProtocol app_proto) {
@@ -245,7 +245,7 @@ int TLSServerContext::init(const char *private_key_file, const char *cert_file,
                             SSL_OP_CIPHER_SERVER_PREFERENCE
 #ifndef LIBRESSL_VERSION_NUMBER
                             | SSL_OP_NO_ANTI_REPLAY
-#endif // !LIBRESSL_VERSION_NUMBER
+#endif // !defined(LIBRESSL_VERSION_NUMBER)
     ;
 
   SSL_CTX_set_options(ssl_ctx_, ssl_opts);
@@ -305,7 +305,7 @@ int TLSServerContext::init(const char *private_key_file, const char *cert_file,
 #ifndef LIBRESSL_VERSION_NUMBER
   SSL_CTX_set_session_ticket_cb(ssl_ctx_, gen_ticket_cb, decrypt_ticket_cb,
                                 nullptr);
-#endif // !LIBRESSL_VERSION_NUMBER
+#endif // !defined(LIBRESSL_VERSION_NUMBER)
 
   return 0;
 }

--- a/examples/tls_server_context_quictls.h
+++ b/examples/tls_server_context_quictls.h
@@ -27,7 +27,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif // HAVE_CONFIG_H
+#endif // defined(HAVE_CONFIG_H)
 
 #include <openssl/ssl.h>
 
@@ -51,4 +51,4 @@ private:
   SSL_CTX *ssl_ctx_;
 };
 
-#endif // TLS_SERVER_CONTEXT_QUICTLS_H
+#endif // !defined(TLS_SERVER_CONTEXT_QUICTLS_H)

--- a/examples/tls_server_context_wolfssl.cc
+++ b/examples/tls_server_context_wolfssl.cc
@@ -144,11 +144,11 @@ int TLSServerContext::init(const char *private_key_file, const char *cert_file,
                            AppProtocol app_proto) {
   constexpr static unsigned char sid_ctx[] = "ngtcp2 server";
 
-#if defined(DEBUG_WOLFSSL)
+#ifdef DEBUG_WOLFSSL
   if (!config.quiet) {
     /*wolfSSL_Debugging_ON();*/
   }
-#endif
+#endif // defined(DEBUG_WOLFSSL)
 
   ssl_ctx_ = wolfSSL_CTX_new(wolfTLSv1_3_server_method());
   if (!ssl_ctx_) {
@@ -166,7 +166,7 @@ int TLSServerContext::init(const char *private_key_file, const char *cert_file,
 
 #ifdef WOLFSSL_EARLY_DATA
   wolfSSL_CTX_set_max_early_data(ssl_ctx_, UINT32_MAX);
-#endif
+#endif // defined(WOLFSSL_EARLY_DATA)
 
   constexpr auto ssl_opts =
     (WOLFSSL_OP_ALL & ~WOLFSSL_OP_DONT_INSERT_EMPTY_FRAGMENTS) |
@@ -244,10 +244,10 @@ void keylog_callback(const WOLFSSL *ssl, const char *line) {
   keylog_file.flush();
 }
 } // namespace
-#endif
+#endif // defined(HAVE_SECRET_CALLBACK)
 
 void TLSServerContext::enable_keylog() {
 #ifdef HAVE_SECRET_CALLBACK
   wolfSSL_CTX_set_keylog_callback(ssl_ctx_, keylog_callback);
-#endif
+#endif // defined(HAVE_SECRET_CALLBACK)
 }

--- a/examples/tls_server_context_wolfssl.h
+++ b/examples/tls_server_context_wolfssl.h
@@ -27,7 +27,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif // HAVE_CONFIG_H
+#endif // defined(HAVE_CONFIG_H)
 
 #include <wolfssl/options.h>
 #include <wolfssl/ssl.h>
@@ -52,4 +52,4 @@ private:
   WOLFSSL_CTX *ssl_ctx_;
 };
 
-#endif // TLS_SERVER_CONTEXT_WOLFSSL_H
+#endif // !defined(TLS_SERVER_CONTEXT_WOLFSSL_H)

--- a/examples/tls_server_session.h
+++ b/examples/tls_server_session.h
@@ -27,26 +27,26 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif // HAVE_CONFIG_H
+#endif // defined(HAVE_CONFIG_H)
 
 #if defined(ENABLE_EXAMPLE_QUICTLS) && defined(WITH_EXAMPLE_QUICTLS)
 #  include "tls_server_session_quictls.h"
-#endif // ENABLE_EXAMPLE_QUICTLS && WITH_EXAMPLE_QUICTLS
+#endif // defined(ENABLE_EXAMPLE_QUICTLS) && defined(WITH_EXAMPLE_QUICTLS)
 
 #if defined(ENABLE_EXAMPLE_GNUTLS) && defined(WITH_EXAMPLE_GNUTLS)
 #  include "tls_server_session_gnutls.h"
-#endif // ENABLE_EXAMPLE_GNUTLS && WITH_EXAMPLE_GNUTLS
+#endif // defined(ENABLE_EXAMPLE_GNUTLS) && defined(WITH_EXAMPLE_GNUTLS)
 
 #if defined(ENABLE_EXAMPLE_BORINGSSL) && defined(WITH_EXAMPLE_BORINGSSL)
 #  include "tls_server_session_boringssl.h"
-#endif // ENABLE_EXAMPLE_BORINGSSL && WITH_EXAMPLE_BORINGSSL
+#endif // defined(ENABLE_EXAMPLE_BORINGSSL) && defined(WITH_EXAMPLE_BORINGSSL)
 
 #if defined(ENABLE_EXAMPLE_PICOTLS) && defined(WITH_EXAMPLE_PICOTLS)
 #  include "tls_server_session_picotls.h"
-#endif // ENABLE_EXAMPLE_PICOTLS && WITH_EXAMPLE_PICOTLS
+#endif // defined(ENABLE_EXAMPLE_PICOTLS) && defined(WITH_EXAMPLE_PICOTLS)
 
 #if defined(ENABLE_EXAMPLE_WOLFSSL) && defined(WITH_EXAMPLE_WOLFSSL)
 #  include "tls_server_session_wolfssl.h"
-#endif // ENABLE_EXAMPLE_WOLFSSL && WITH_EXAMPLE_WOLFSSL
+#endif // defined(ENABLE_EXAMPLE_WOLFSSL) && defined(WITH_EXAMPLE_WOLFSSL)
 
-#endif // TLS_SERVER_SESSION_H
+#endif // !defined(TLS_SERVER_SESSION_H)

--- a/examples/tls_server_session_boringssl.h
+++ b/examples/tls_server_session_boringssl.h
@@ -27,7 +27,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif // HAVE_CONFIG_H
+#endif // defined(HAVE_CONFIG_H)
 
 #include "tls_session_base_quictls.h"
 
@@ -44,4 +44,4 @@ public:
   int send_session_ticket() { return 0; }
 };
 
-#endif // TLS_SERVER_SESSION_BORINGSSL_H
+#endif // !defined(TLS_SERVER_SESSION_BORINGSSL_H)

--- a/examples/tls_server_session_gnutls.h
+++ b/examples/tls_server_session_gnutls.h
@@ -27,7 +27,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif // HAVE_CONFIG_H
+#endif // defined(HAVE_CONFIG_H)
 
 #include "tls_session_base_gnutls.h"
 
@@ -43,4 +43,4 @@ public:
   int send_session_ticket();
 };
 
-#endif // TLS_SERVER_SESSION_GNUTLS_H
+#endif // !defined(TLS_SERVER_SESSION_GNUTLS_H)

--- a/examples/tls_server_session_picotls.h
+++ b/examples/tls_server_session_picotls.h
@@ -27,7 +27,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif // HAVE_CONFIG_H
+#endif // defined(HAVE_CONFIG_H)
 
 #include "tls_session_base_picotls.h"
 
@@ -44,4 +44,4 @@ public:
   int send_session_ticket() { return 0; }
 };
 
-#endif // TLS_SERVER_SESSION_PICOTLS_H
+#endif // !defined(TLS_SERVER_SESSION_PICOTLS_H)

--- a/examples/tls_server_session_quictls.cc
+++ b/examples/tls_server_session_quictls.cc
@@ -50,7 +50,7 @@ int TLSServerSession::init(const TLSServerContext &tls_ctx,
   SSL_set_accept_state(ssl_);
 #ifndef LIBRESSL_VERSION_NUMBER
   SSL_set_quic_early_data_enabled(ssl_, 1);
-#endif // !LIBRESSL_VERSION_NUMBER
+#endif // !defined(LIBRESSL_VERSION_NUMBER)
 
   return 0;
 }

--- a/examples/tls_server_session_quictls.h
+++ b/examples/tls_server_session_quictls.h
@@ -27,7 +27,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif // HAVE_CONFIG_H
+#endif // defined(HAVE_CONFIG_H)
 
 #include "tls_session_base_quictls.h"
 
@@ -44,4 +44,4 @@ public:
   int send_session_ticket() { return 0; }
 };
 
-#endif // TLS_SERVER_SESSION_QUICTLS_H
+#endif // !defined(TLS_SERVER_SESSION_QUICTLS_H)

--- a/examples/tls_server_session_wolfssl.cc
+++ b/examples/tls_server_session_wolfssl.cc
@@ -49,7 +49,7 @@ int TLSServerSession::init(const TLSServerContext &tls_ctx,
   wolfSSL_set_accept_state(ssl_);
 #ifdef WOLFSSL_EARLY_DATA
   wolfSSL_set_quic_early_data_enabled(ssl_, 1);
-#endif
+#endif // defined(WOLFSSL_EARLY_DATA)
   // Just use QUIC v1
   wolfSSL_set_quic_transport_version(ssl_, 0x39);
 

--- a/examples/tls_server_session_wolfssl.h
+++ b/examples/tls_server_session_wolfssl.h
@@ -27,7 +27,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif // HAVE_CONFIG_H
+#endif // defined(HAVE_CONFIG_H)
 
 #include "tls_session_base_wolfssl.h"
 
@@ -44,4 +44,4 @@ public:
   int send_session_ticket() { return 0; }
 };
 
-#endif // TLS_SERVER_SESSION_WOLFSSL_H
+#endif // !defined(TLS_SERVER_SESSION_WOLFSSL_H)

--- a/examples/tls_session_base_gnutls.h
+++ b/examples/tls_session_base_gnutls.h
@@ -27,7 +27,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif // HAVE_CONFIG_H
+#endif // defined(HAVE_CONFIG_H)
 
 #include <string>
 #include <string_view>
@@ -50,4 +50,4 @@ protected:
   gnutls_session_t session_;
 };
 
-#endif // TLS_SESSION_BASE_GNUTLS_H
+#endif // !defined(TLS_SESSION_BASE_GNUTLS_H)

--- a/examples/tls_session_base_picotls.h
+++ b/examples/tls_session_base_picotls.h
@@ -27,7 +27,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif // HAVE_CONFIG_H
+#endif // defined(HAVE_CONFIG_H)
 
 #include <string>
 #include <string_view>
@@ -57,4 +57,4 @@ protected:
   ngtcp2_crypto_picotls_ctx cptls_;
 };
 
-#endif // TLS_SESSION_BASE_PICOTLS_H
+#endif // !defined(TLS_SESSION_BASE_PICOTLS_H)

--- a/examples/tls_session_base_quictls.cc
+++ b/examples/tls_session_base_quictls.cc
@@ -60,8 +60,9 @@ std::string_view TLSSessionBase::get_negotiated_group() const {
   return name;
 #elif defined(LIBRESSL_VERSION_NUMBER)
   return ""sv;
-#else  // !OPENSSL_IS_BORINGSSL && !OPENSSL_IS_AWSLC && OPENSSL_VERSION_NUMBER <
-       // 0x30000000L
+#else  // !(defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC) ||
+       // OPENSSL_VERSION_NUMBER >= 0x30000000L ||
+       // defined(LIBRESSL_VERSION_NUMBER))
   EVP_PKEY *key;
 
   if (!SSL_get_tmp_key(ssl_, &key)) {
@@ -84,8 +85,9 @@ std::string_view TLSSessionBase::get_negotiated_group() const {
   }
 
   return name;
-#endif // !OPENSSL_IS_BORINGSSL && !OPENSSL_IS_AWSLC && OPENSSL_VERSION_NUMBER <
-       // 0x30000000L
+#endif // !(defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC) ||
+       // OPENSSL_VERSION_NUMBER >= 0x30000000L ||
+       // defined(LIBRESSL_VERSION_NUMBER))
 }
 
 std::string TLSSessionBase::get_selected_alpn() const {

--- a/examples/tls_session_base_quictls.h
+++ b/examples/tls_session_base_quictls.h
@@ -27,7 +27,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif // HAVE_CONFIG_H
+#endif // defined(HAVE_CONFIG_H)
 
 #include <string>
 #include <string_view>
@@ -51,4 +51,4 @@ protected:
   SSL *ssl_;
 };
 
-#endif // TLS_SESSION_BASE_QUICTLS_H
+#endif // !defined(TLS_SESSION_BASE_QUICTLS_H)

--- a/examples/tls_session_base_wolfssl.h
+++ b/examples/tls_session_base_wolfssl.h
@@ -27,7 +27,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif // HAVE_CONFIG_H
+#endif // defined(HAVE_CONFIG_H)
 
 #include <string>
 #include <string_view>
@@ -57,4 +57,4 @@ protected:
   WOLFSSL *ssl_;
 };
 
-#endif // TLS_SESSION_BASE_WOLFSSL_H
+#endif // !defined(TLS_SESSION_BASE_WOLFSSL_H)

--- a/examples/tls_shared_boringssl.cc
+++ b/examples/tls_shared_boringssl.cc
@@ -27,7 +27,7 @@
 #ifdef HAVE_LIBBROTLI
 #  include <brotli/encode.h>
 #  include <brotli/decode.h>
-#endif // HAVE_LIBBROTLI
+#endif // defined(HAVE_LIBBROTLI)
 
 namespace ngtcp2 {
 
@@ -82,7 +82,7 @@ int cert_decompress(SSL *ssl, CRYPTO_BUFFER **out, size_t uncompressed_len,
 
   return 1;
 }
-#endif // HAVE_LIBBROTLI
+#endif // defined(HAVE_LIBBROTLI)
 
 } // namespace tls
 

--- a/examples/tls_shared_boringssl.h
+++ b/examples/tls_shared_boringssl.h
@@ -27,7 +27,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif // HAVE_CONFIG_H
+#endif // defined(HAVE_CONFIG_H)
 
 #include <openssl/ssl.h>
 
@@ -42,10 +42,10 @@ int cert_compress(SSL *ssl, CBB *out, const uint8_t *in, size_t in_len);
 
 int cert_decompress(SSL *ssl, CRYPTO_BUFFER **out, size_t uncompressed_len,
                     const uint8_t *in, size_t in_len);
-#endif // HAVE_LIBBROTLI
+#endif // defined(HAVE_LIBBROTLI)
 
 } // namespace tls
 
 } // namespace ngtcp2
 
-#endif // TLS_SHARED_BORINGSSL_H
+#endif // !defined(TLS_SHARED_BORINGSSL_H)

--- a/examples/tls_shared_picotls.h
+++ b/examples/tls_shared_picotls.h
@@ -27,10 +27,10 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif // HAVE_CONFIG_H
+#endif // defined(HAVE_CONFIG_H)
 
 #include <picotls.h>
 
 extern ptls_log_event_t log_event;
 
-#endif // TLS_SHARED_PICOTLS_H
+#endif // !defined(TLS_SHARED_PICOTLS_H)

--- a/examples/util.cc
+++ b/examples/util.cc
@@ -27,10 +27,10 @@
 
 #ifdef HAVE_ARPA_INET_H
 #  include <arpa/inet.h>
-#endif // HAVE_ARPA_INET_H
+#endif // defined(HAVE_ARPA_INET_H)
 #ifdef HAVE_NETINET_IN_H
 #  include <netinet/in.h>
-#endif
+#endif // defined(HAVE_NETINET_IN_H)
 #include <sys/types.h>
 #include <unistd.h>
 #include <fcntl.h>
@@ -716,14 +716,14 @@ int create_nonblock_socket(int domain, int type, int protocol) {
   if (fd == -1) {
     return -1;
   }
-#else  // !SOCK_NONBLOCK
+#else  // !defined(SOCK_NONBLOCK)
   auto fd = socket(domain, type, protocol);
   if (fd == -1) {
     return -1;
   }
 
   make_socket_nonblocking(fd);
-#endif // !SOCK_NONBLOCK
+#endif // !defined(SOCK_NONBLOCK)
 
   return fd;
 }

--- a/examples/util.h
+++ b/examples/util.h
@@ -28,7 +28,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif // HAVE_CONFIG_H
+#endif // defined(HAVE_CONFIG_H)
 
 #include <sys/socket.h>
 
@@ -360,4 +360,4 @@ std::ostream &operator<<(std::ostream &os, const ngtcp2_cid &cid);
 
 } // namespace ngtcp2
 
-#endif // UTIL_H
+#endif // !defined(UTIL_H)

--- a/examples/util_test.h
+++ b/examples/util_test.h
@@ -27,7 +27,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include "config.h"
-#endif // HAVE_CONFIG_H
+#endif // defined(HAVE_CONFIG_H)
 
 #define MUNIT_ENABLE_ASSERT_ALIASES
 
@@ -50,4 +50,4 @@ munit_void_test_decl(test_util_format_hex);
 
 } // namespace ngtcp2
 
-#endif // UTIL_TEST_H
+#endif // !defined(UTIL_TEST_H)

--- a/fuzz/decode_frame.cc
+++ b/fuzz/decode_frame.cc
@@ -1,12 +1,12 @@
 #ifdef __cplusplus
 extern "C" {
-#endif
+#endif // defined(__cplusplus)
 
 #include "ngtcp2_conn.h"
 
 #ifdef __cplusplus
 }
-#endif
+#endif // defined(__cplusplus)
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
   for (; size;) {

--- a/fuzz/ksl.cc
+++ b/fuzz/ksl.cc
@@ -5,13 +5,13 @@
 
 #ifdef __cplusplus
 extern "C" {
-#endif
+#endif // defined(__cplusplus)
 
 #include "ngtcp2_ksl.h"
 
 #ifdef __cplusplus
 }
-#endif
+#endif // defined(__cplusplus)
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
   using KeyType = uint64_t;

--- a/fuzz/read_write_handshake_pkt.cc
+++ b/fuzz/read_write_handshake_pkt.cc
@@ -32,14 +32,14 @@
 
 #ifdef __cplusplus
 extern "C" {
-#endif
+#endif // defined(__cplusplus)
 
 #include "ngtcp2_conn.h"
 #include "ngtcp2_transport_params.h"
 
 #ifdef __cplusplus
 }
-#endif
+#endif // defined(__cplusplus)
 
 namespace {
 constexpr size_t NGTCP2_FAKE_AEAD_OVERHEAD = NGTCP2_INITIAL_AEAD_OVERHEAD;

--- a/fuzz/read_write_pkt.cc
+++ b/fuzz/read_write_pkt.cc
@@ -32,14 +32,14 @@
 
 #ifdef __cplusplus
 extern "C" {
-#endif
+#endif // defined(__cplusplus)
 
 #include "ngtcp2_conn.h"
 #include "ngtcp2_transport_params.h"
 
 #ifdef __cplusplus
 }
-#endif
+#endif // defined(__cplusplus)
 
 namespace {
 constexpr size_t NGTCP2_FAKE_AEAD_OVERHEAD = NGTCP2_INITIAL_AEAD_OVERHEAD;

--- a/lib/includes/ngtcp2/ngtcp2.h
+++ b/lib/includes/ngtcp2/ngtcp2.h
@@ -30,12 +30,12 @@
    libcurl) */
 #if (defined(_WIN32) || defined(__WIN32__)) && !defined(WIN32)
 #  define WIN32
-#endif
+#endif /* (defined(_WIN32) || defined(__WIN32__)) && !defined(WIN32) */
 
 #ifdef _MSC_VER
 #  pragma warning(push)
 #  pragma warning(disable : 4324)
-#endif
+#endif /* defined(_MSC_VER) */
 
 #include <stdlib.h>
 #if defined(_MSC_VER) && (_MSC_VER < 1800)
@@ -54,13 +54,13 @@
 #  ifdef WIN32
 #    ifndef WIN32_LEAN_AND_MEAN
 #      define WIN32_LEAN_AND_MEAN
-#    endif /* WIN32_LEAN_AND_MEAN */
+#    endif /* !defined(WIN32_LEAN_AND_MEAN) */
 #    include <ws2tcpip.h>
-#  else /* !WIN32 */
+#  else /* !defined(WIN32) */
 #    include <sys/socket.h>
 #    include <netinet/in.h>
-#  endif /* !WIN32 */
-#endif   /* NGTCP2_USE_GENERIC_SOCKADDR */
+#  endif /* !defined(WIN32) */
+#endif   /* !defined(NGTCP2_USE_GENERIC_SOCKADDR) */
 
 #include <ngtcp2/version.h>
 
@@ -69,26 +69,26 @@
 #elif defined(WIN32)
 #  ifdef BUILDING_NGTCP2
 #    define NGTCP2_EXTERN __declspec(dllexport)
-#  else /* !BUILDING_NGTCP2 */
+#  else /* !defined(BUILDING_NGTCP2) */
 #    define NGTCP2_EXTERN __declspec(dllimport)
-#  endif /* !BUILDING_NGTCP2 */
-#else    /* !defined(WIN32) */
+#  endif /* !defined(BUILDING_NGTCP2) */
+#else    /* !(defined(NGTCP2_STATICLIB) || defined(WIN32)) */
 #  ifdef BUILDING_NGTCP2
 #    define NGTCP2_EXTERN __attribute__((visibility("default")))
-#  else /* !BUILDING_NGTCP2 */
+#  else /* !defined(BUILDING_NGTCP2) */
 #    define NGTCP2_EXTERN
-#  endif /* !BUILDING_NGTCP2 */
-#endif   /* !defined(WIN32) */
+#  endif /* !defined(BUILDING_NGTCP2) */
+#endif   /* !(defined(NGTCP2_STATICLIB) || defined(WIN32)) */
 
 #ifdef _MSC_VER
 #  define NGTCP2_ALIGN(N) __declspec(align(N))
-#else /* !_MSC_VER */
+#else /* !defined(_MSC_VER) */
 #  define NGTCP2_ALIGN(N) __attribute__((aligned(N)))
-#endif /* !_MSC_VER */
+#endif /* !defined(_MSC_VER) */
 
 #ifdef __cplusplus
 extern "C" {
-#endif
+#endif /* defined(__cplusplus) */
 
 /**
  * @typedef
@@ -1229,11 +1229,11 @@ typedef struct ngtcp2_pkt_stateless_reset {
 #ifdef NGTCP2_USE_GENERIC_SOCKADDR
 #  ifndef NGTCP2_AF_INET
 #    error NGTCP2_AF_INET must be defined
-#  endif /* !NGTCP2_AF_INET */
+#  endif /* !defined(NGTCP2_AF_INET) */
 
 #  ifndef NGTCP2_AF_INET6
 #    error NGTCP2_AF_INET6 must be defined
-#  endif /* !NGTCP2_AF_INET6 */
+#  endif /* !defined(NGTCP2_AF_INET6) */
 
 typedef unsigned short int ngtcp2_sa_family;
 typedef uint16_t ngtcp2_in_port;
@@ -1267,7 +1267,7 @@ typedef struct ngtcp2_sockaddr_in6 {
 } ngtcp2_sockaddr_in6;
 
 typedef uint32_t ngtcp2_socklen;
-#else /* !NGTCP2_USE_GENERIC_SOCKADDR */
+#else /* !defined(NGTCP2_USE_GENERIC_SOCKADDR) */
 #  define NGTCP2_AF_INET AF_INET
 #  define NGTCP2_AF_INET6 AF_INET6
 
@@ -1303,7 +1303,7 @@ typedef struct sockaddr_in6 ngtcp2_sockaddr_in6;
  * uint32_t.
  */
 typedef socklen_t ngtcp2_socklen;
-#endif /* !NGTCP2_USE_GENERIC_SOCKADDR */
+#endif /* !defined(NGTCP2_USE_GENERIC_SOCKADDR) */
 
 /**
  * @struct
@@ -5906,10 +5906,10 @@ NGTCP2_EXTERN uint32_t ngtcp2_select_version(const uint32_t *preferred_versions,
 
 #ifdef _MSC_VER
 #  pragma warning(pop)
-#endif
+#endif /* defined(_MSC_VER) */
 
 #ifdef __cplusplus
 }
-#endif
+#endif /* defined(__cplusplus) */
 
-#endif /* NGTCP2_H */
+#endif /* !defined(NGTCP2_H) */

--- a/lib/includes/ngtcp2/version.h.in
+++ b/lib/includes/ngtcp2/version.h.in
@@ -48,4 +48,4 @@
  */
 #define NGTCP2_VERSION_NUM @PACKAGE_VERSION_NUM@
 
-#endif /* VERSION_H */
+#endif /* !defined(VERSION_H) */

--- a/lib/ngtcp2_acktr.c
+++ b/lib/ngtcp2_acktr.c
@@ -78,7 +78,7 @@ void ngtcp2_acktr_init(ngtcp2_acktr *acktr, ngtcp2_log *log,
 void ngtcp2_acktr_free(ngtcp2_acktr *acktr) {
 #ifdef NOMEMPOOL
   ngtcp2_ksl_it it;
-#endif /* NOMEMPOOL */
+#endif /* defined(NOMEMPOOL) */
 
   if (acktr == NULL) {
     return;
@@ -89,7 +89,7 @@ void ngtcp2_acktr_free(ngtcp2_acktr *acktr) {
        ngtcp2_ksl_it_next(&it)) {
     ngtcp2_acktr_entry_objalloc_del(ngtcp2_ksl_it_get(&it), &acktr->objalloc);
   }
-#endif /* NOMEMPOOL */
+#endif /* defined(NOMEMPOOL) */
 
   ngtcp2_ksl_free(&acktr->ents);
 

--- a/lib/ngtcp2_acktr.h
+++ b/lib/ngtcp2_acktr.h
@@ -27,7 +27,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #include <ngtcp2/ngtcp2.h>
 
@@ -213,4 +213,4 @@ int ngtcp2_acktr_require_active_ack(const ngtcp2_acktr *acktr,
  */
 void ngtcp2_acktr_immediate_ack(ngtcp2_acktr *acktr);
 
-#endif /* NGTCP2_ACKTR_H */
+#endif /* !defined(NGTCP2_ACKTR_H) */

--- a/lib/ngtcp2_addr.h
+++ b/lib/ngtcp2_addr.h
@@ -27,7 +27,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #include <ngtcp2/ngtcp2.h>
 
@@ -68,4 +68,4 @@ uint32_t ngtcp2_addr_compare(const ngtcp2_addr *a, const ngtcp2_addr *b);
  */
 int ngtcp2_addr_empty(const ngtcp2_addr *addr);
 
-#endif /* NGTCP2_ADDR_H */
+#endif /* !defined(NGTCP2_ADDR_H) */

--- a/lib/ngtcp2_balloc.h
+++ b/lib/ngtcp2_balloc.h
@@ -27,7 +27,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #include <ngtcp2/ngtcp2.h>
 
@@ -91,4 +91,4 @@ int ngtcp2_balloc_get(ngtcp2_balloc *balloc, void **pbuf, size_t n);
  */
 void ngtcp2_balloc_clear(ngtcp2_balloc *balloc);
 
-#endif /* NGTCP2_BALLOC_H */
+#endif /* !defined(NGTCP2_BALLOC_H) */

--- a/lib/ngtcp2_bbr.h
+++ b/lib/ngtcp2_bbr.h
@@ -27,7 +27,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #include <ngtcp2/ngtcp2.h>
 
@@ -138,4 +138,4 @@ void ngtcp2_cc_bbr_init(ngtcp2_cc_bbr *bbr, ngtcp2_log *log,
                         ngtcp2_tstamp initial_ts, ngtcp2_rand rand,
                         const ngtcp2_rand_ctx *rand_ctx);
 
-#endif /* NGTCP2_BBR_H */
+#endif /* !defined(NGTCP2_BBR_H) */

--- a/lib/ngtcp2_buf.h
+++ b/lib/ngtcp2_buf.h
@@ -27,7 +27,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #include <ngtcp2/ngtcp2.h>
 
@@ -105,4 +105,4 @@ int ngtcp2_buf_chain_new(ngtcp2_buf_chain **pbufchain, size_t len,
  */
 void ngtcp2_buf_chain_del(ngtcp2_buf_chain *bufchain, const ngtcp2_mem *mem);
 
-#endif /* NGTCP2_BUF_H */
+#endif /* !defined(NGTCP2_BUF_H) */

--- a/lib/ngtcp2_cc.h
+++ b/lib/ngtcp2_cc.h
@@ -27,7 +27,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #include <ngtcp2/ngtcp2.h>
 
@@ -397,4 +397,4 @@ void ngtcp2_cc_cubic_cc_event(ngtcp2_cc *cc, ngtcp2_conn_stat *cstat,
 
 uint64_t ngtcp2_cbrt(uint64_t n);
 
-#endif /* NGTCP2_CC_H */
+#endif /* !defined(NGTCP2_CC_H) */

--- a/lib/ngtcp2_cid.h
+++ b/lib/ngtcp2_cid.h
@@ -27,7 +27,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #include <ngtcp2/ngtcp2.h>
 
@@ -173,4 +173,4 @@ int ngtcp2_dcid_verify_uniqueness(const ngtcp2_dcid *dcid, uint64_t seq,
 int ngtcp2_dcid_verify_stateless_reset_token(const ngtcp2_dcid *dcid,
                                              const uint8_t *token);
 
-#endif /* NGTCP2_CID_H */
+#endif /* !defined(NGTCP2_CID_H) */

--- a/lib/ngtcp2_conn.h
+++ b/lib/ngtcp2_conn.h
@@ -27,7 +27,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #include <ngtcp2/ngtcp2.h>
 
@@ -1171,4 +1171,4 @@ void ngtcp2_conn_discard_initial_state(ngtcp2_conn *conn, ngtcp2_tstamp ts);
  */
 void ngtcp2_conn_discard_handshake_state(ngtcp2_conn *conn, ngtcp2_tstamp ts);
 
-#endif /* NGTCP2_CONN_H */
+#endif /* !defined(NGTCP2_CONN_H) */

--- a/lib/ngtcp2_conn_stat.h
+++ b/lib/ngtcp2_conn_stat.h
@@ -27,7 +27,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #include <ngtcp2/ngtcp2.h>
 
@@ -130,4 +130,4 @@ typedef struct ngtcp2_conn_stat {
   size_t send_quantum;
 } ngtcp2_conn_stat;
 
-#endif /* NGTCP2_CONN_STAT_H */
+#endif /* !defined(NGTCP2_CONN_STAT_H) */

--- a/lib/ngtcp2_conv.h
+++ b/lib/ngtcp2_conv.h
@@ -27,7 +27,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #include <ngtcp2/ngtcp2.h>
 
@@ -191,4 +191,4 @@ int64_t ngtcp2_nth_client_uni_id(uint64_t n);
  */
 uint64_t ngtcp2_ord_stream_id(int64_t stream_id);
 
-#endif /* NGTCP2_CONV_H */
+#endif /* !defined(NGTCP2_CONV_H) */

--- a/lib/ngtcp2_crypto.c
+++ b/lib/ngtcp2_crypto.c
@@ -90,7 +90,7 @@ void ngtcp2_crypto_km_del(ngtcp2_crypto_km *ckm, const ngtcp2_mem *mem) {
     explicit_bzero(ckm->secret.base, ckm->secret.len);
 #elif defined(HAVE_MEMSET_S)
     memset_s(ckm->secret.base, ckm->secret.len, 0, ckm->secret.len);
-#endif /* HAVE_MEMSET_S */
+#endif /* defined(HAVE_MEMSET_S) */
   }
 
   ngtcp2_mem_free(mem, ckm);

--- a/lib/ngtcp2_crypto.h
+++ b/lib/ngtcp2_crypto.h
@@ -27,7 +27,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #include <ngtcp2/ngtcp2.h>
 
@@ -99,4 +99,4 @@ typedef struct ngtcp2_crypto_cc {
 void ngtcp2_crypto_create_nonce(uint8_t *dest, const uint8_t *iv, size_t ivlen,
                                 int64_t pkt_num);
 
-#endif /* NGTCP2_CRYPTO_H */
+#endif /* !defined(NGTCP2_CRYPTO_H) */

--- a/lib/ngtcp2_err.h
+++ b/lib/ngtcp2_err.h
@@ -27,8 +27,8 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #include <ngtcp2/ngtcp2.h>
 
-#endif /* NGTCP2_ERR_H */
+#endif /* !defined(NGTCP2_ERR_H) */

--- a/lib/ngtcp2_frame_chain.h
+++ b/lib/ngtcp2_frame_chain.h
@@ -27,7 +27,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #include <ngtcp2/ngtcp2.h>
 
@@ -185,4 +185,4 @@ void ngtcp2_frame_chain_list_objalloc_del(ngtcp2_frame_chain *frc,
                                           ngtcp2_objalloc *objalloc,
                                           const ngtcp2_mem *mem);
 
-#endif /* NGTCP2_FRAME_CHAIN_H */
+#endif /* !defined(NGTCP2_FRAME_CHAIN_H) */

--- a/lib/ngtcp2_gaptr.h
+++ b/lib/ngtcp2_gaptr.h
@@ -27,7 +27,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #include <ngtcp2/ngtcp2.h>
 
@@ -95,4 +95,4 @@ int ngtcp2_gaptr_is_pushed(const ngtcp2_gaptr *gaptr, uint64_t offset,
  */
 void ngtcp2_gaptr_drop_first_gap(ngtcp2_gaptr *gaptr);
 
-#endif /* NGTCP2_GAPTR_H */
+#endif /* !defined(NGTCP2_GAPTR_H) */

--- a/lib/ngtcp2_idtr.h
+++ b/lib/ngtcp2_idtr.h
@@ -27,7 +27,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #include <ngtcp2/ngtcp2.h>
 
@@ -73,4 +73,4 @@ int ngtcp2_idtr_open(ngtcp2_idtr *idtr, int64_t stream_id);
  */
 int ngtcp2_idtr_is_open(const ngtcp2_idtr *idtr, int64_t stream_id);
 
-#endif /* NGTCP2_IDTR_H */
+#endif /* !defined(NGTCP2_IDTR_H) */

--- a/lib/ngtcp2_ksl.c
+++ b/lib/ngtcp2_ksl.c
@@ -113,7 +113,7 @@ static void ksl_free_blk(ngtcp2_ksl *ksl, ngtcp2_ksl_blk *blk) {
 
   ksl_blk_objalloc_del(ksl, blk);
 }
-#endif /* NOMEMPOOL */
+#endif /* defined(NOMEMPOOL) */
 
 void ngtcp2_ksl_free(ngtcp2_ksl *ksl) {
   if (!ksl || !ksl->head) {
@@ -122,7 +122,7 @@ void ngtcp2_ksl_free(ngtcp2_ksl *ksl) {
 
 #ifdef NOMEMPOOL
   ksl_free_blk(ksl, ksl->head);
-#endif /* NOMEMPOOL */
+#endif /* defined(NOMEMPOOL) */
 
   ngtcp2_objalloc_free(&ksl->blkalloc);
 }
@@ -726,7 +726,7 @@ void ngtcp2_ksl_clear(ngtcp2_ksl *ksl) {
 
 #ifdef NOMEMPOOL
   ksl_free_blk(ksl, ksl->head);
-#endif /* NOMEMPOOL */
+#endif /* defined(NOMEMPOOL) */
 
   ksl->front = ksl->back = ksl->head = NULL;
   ksl->n = 0;
@@ -765,7 +765,7 @@ void ngtcp2_ksl_print(const ngtcp2_ksl *ksl) {
 
   ksl_print(ksl, ksl->head, 0);
 }
-#endif /* !WIN32 */
+#endif /* !defined(WIN32) */
 
 ngtcp2_ksl_it ngtcp2_ksl_begin(const ngtcp2_ksl *ksl) {
   ngtcp2_ksl_it it;

--- a/lib/ngtcp2_ksl.h
+++ b/lib/ngtcp2_ksl.h
@@ -27,7 +27,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #include <stdlib.h>
 
@@ -272,7 +272,7 @@ void ngtcp2_ksl_clear(ngtcp2_ksl *ksl);
  * the debugging purpose only.
  */
 void ngtcp2_ksl_print(const ngtcp2_ksl *ksl);
-#endif /* !WIN32 */
+#endif /* !defined(WIN32) */
 
 /*
  * ngtcp2_ksl_it_init initializes |it|.
@@ -346,4 +346,4 @@ int ngtcp2_ksl_range_compar(const ngtcp2_ksl_key *lhs,
 int ngtcp2_ksl_range_exclusive_compar(const ngtcp2_ksl_key *lhs,
                                       const ngtcp2_ksl_key *rhs);
 
-#endif /* NGTCP2_KSL_H */
+#endif /* !defined(NGTCP2_KSL_H) */

--- a/lib/ngtcp2_log.c
+++ b/lib/ngtcp2_log.c
@@ -27,7 +27,7 @@
 #include <stdio.h>
 #ifdef HAVE_UNISTD_H
 #  include <unistd.h>
-#endif
+#endif /* defined(HAVE_UNISTD_H) */
 #include <assert.h>
 #include <string.h>
 

--- a/lib/ngtcp2_log.h
+++ b/lib/ngtcp2_log.h
@@ -27,7 +27,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #include <ngtcp2/ngtcp2.h>
 
@@ -129,4 +129,4 @@ void ngtcp2_log_tx_cancel(ngtcp2_log *log, const ngtcp2_pkt_hd *hd);
 void ngtcp2_log_info(ngtcp2_log *log, ngtcp2_log_event ev, const char *fmt,
                      ...);
 
-#endif /* NGTCP2_LOG_H */
+#endif /* !defined(NGTCP2_LOG_H) */

--- a/lib/ngtcp2_macro.h
+++ b/lib/ngtcp2_macro.h
@@ -27,7 +27,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #include <stddef.h>
 
@@ -78,4 +78,4 @@ ngtcp2_min_def(uint32, uint32_t);
 ngtcp2_min_def(uint64, uint64_t);
 ngtcp2_min_def(size, size_t);
 
-#endif /* NGTCP2_MACRO_H */
+#endif /* !defined(NGTCP2_MACRO_H) */

--- a/lib/ngtcp2_map.c
+++ b/lib/ngtcp2_map.c
@@ -114,7 +114,7 @@ void ngtcp2_map_print_distance(const ngtcp2_map *map) {
             hash(bkt->key, map->hashbits), bkt->key, idx, bkt->psl);
   }
 }
-#endif /* !WIN32 */
+#endif /* !defined(WIN32) */
 
 static int insert(ngtcp2_map_bucket *table, size_t hashbits,
                   ngtcp2_map_key_type key, void *data) {

--- a/lib/ngtcp2_map.h
+++ b/lib/ngtcp2_map.h
@@ -28,7 +28,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #include <ngtcp2/ngtcp2.h>
 
@@ -123,6 +123,6 @@ int ngtcp2_map_each(const ngtcp2_map *map, int (*func)(void *data, void *ptr),
 
 #ifndef WIN32
 void ngtcp2_map_print_distance(const ngtcp2_map *map);
-#endif /* !WIN32 */
+#endif /* !defined(WIN32) */
 
-#endif /* NGTCP2_MAP_H */
+#endif /* !defined(NGTCP2_MAP_H) */

--- a/lib/ngtcp2_mem.c
+++ b/lib/ngtcp2_mem.c
@@ -72,7 +72,7 @@ void *ngtcp2_mem_calloc(const ngtcp2_mem *mem, size_t nmemb, size_t size) {
 void *ngtcp2_mem_realloc(const ngtcp2_mem *mem, void *ptr, size_t size) {
   return mem->realloc(ptr, size, mem->user_data);
 }
-#else  /* MEMDEBUG */
+#else  /* defined(MEMDEBUG) */
 void *ngtcp2_mem_malloc_debug(const ngtcp2_mem *mem, size_t size,
                               const char *func, const char *file, size_t line) {
   void *nptr = mem->malloc(size, mem->user_data);
@@ -110,4 +110,4 @@ void *ngtcp2_mem_realloc_debug(const ngtcp2_mem *mem, void *ptr, size_t size,
 
   return nptr;
 }
-#endif /* MEMDEBUG */
+#endif /* defined(MEMDEBUG) */

--- a/lib/ngtcp2_mem.h
+++ b/lib/ngtcp2_mem.h
@@ -28,7 +28,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #include <ngtcp2/ngtcp2.h>
 
@@ -42,7 +42,7 @@ void ngtcp2_mem_free(const ngtcp2_mem *mem, void *ptr);
 void *ngtcp2_mem_calloc(const ngtcp2_mem *mem, size_t nmemb, size_t size);
 
 void *ngtcp2_mem_realloc(const ngtcp2_mem *mem, void *ptr, size_t size);
-#else /* MEMDEBUG */
+#else /* defined(MEMDEBUG) */
 void *ngtcp2_mem_malloc_debug(const ngtcp2_mem *mem, size_t size,
                               const char *func, const char *file, size_t line);
 
@@ -67,6 +67,6 @@ void *ngtcp2_mem_realloc_debug(const ngtcp2_mem *mem, void *ptr, size_t size,
 
 #  define ngtcp2_mem_realloc(MEM, PTR, SIZE)                                   \
     ngtcp2_mem_realloc_debug((MEM), (PTR), (SIZE), __func__, __FILE__, __LINE__)
-#endif /* MEMDEBUG */
+#endif /* defined(MEMDEBUG) */
 
-#endif /* NGTCP2_MEM_H */
+#endif /* !defined(NGTCP2_MEM_H) */

--- a/lib/ngtcp2_net.h
+++ b/lib/ngtcp2_net.h
@@ -30,70 +30,68 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #ifdef HAVE_ARPA_INET_H
 #  include <arpa/inet.h>
-#endif /* HAVE_ARPA_INET_H */
+#endif /* defined(HAVE_ARPA_INET_H) */
 
 #ifdef HAVE_NETINET_IN_H
 #  include <netinet/in.h>
-#endif /* HAVE_NETINET_IN_H */
+#endif /* defined(HAVE_NETINET_IN_H) */
 
 #ifdef HAVE_BYTESWAP_H
 #  include <byteswap.h>
-#endif /* HAVE_BYTESWAP_H */
+#endif /* defined(HAVE_BYTESWAP_H) */
 
 #ifdef HAVE_ENDIAN_H
 #  include <endian.h>
-#endif /* HAVE_ENDIAN_H */
+#endif /* defined(HAVE_ENDIAN_H) */
 
 #ifdef HAVE_SYS_ENDIAN_H
 #  include <sys/endian.h>
-#endif /* HAVE_SYS_ENDIAN_H */
+#endif /* defined(HAVE_SYS_ENDIAN_H) */
 
-#if defined(__APPLE__)
+#ifdef __APPLE__
 #  include <libkern/OSByteOrder.h>
-#endif // __APPLE__
+#endif /* defined(__APPLE__) */
 
 #include <ngtcp2/ngtcp2.h>
 
-#if defined(HAVE_BE64TOH) ||                                                   \
-  (defined(HAVE_DECL_BE64TOH) && HAVE_DECL_BE64TOH > 0)
+#if HAVE_DECL_BE64TOH
 #  define ngtcp2_ntohl64(N) be64toh(N)
 #  define ngtcp2_htonl64(N) htobe64(N)
-#else /* !HAVE_BE64TOH */
+#else /* !HAVE_DECL_BE64TOH */
 #  if defined(WORDS_BIGENDIAN)
 #    define ngtcp2_ntohl64(N) (N)
 #    define ngtcp2_htonl64(N) (N)
-#  else /* !WORDS_BIGENDIAN */
-#    if defined(HAVE_BSWAP_64) ||                                              \
-      (defined(HAVE_DECL_BSWAP_64) && HAVE_DECL_BSWAP_64 > 0)
+#  else /* !defined(WORDS_BIGENDIAN) */
+#    if HAVE_DECL_BSWAP_64
 #      define ngtcp2_bswap64 bswap_64
 #    elif defined(WIN32)
 #      define ngtcp2_bswap64 _byteswap_uint64
 #    elif defined(__APPLE__)
 #      define ngtcp2_bswap64 OSSwapInt64
-#    else /* !HAVE_BSWAP_64 && !WIN32 && !__APPLE__ */
+#    else /* !(HAVE_DECL_BSWAP_64 || defined(WIN32) || defined(__APPLE__)) */
 #      define ngtcp2_bswap64(N)                                                \
         ((uint64_t)(ngtcp2_ntohl((uint32_t)(N))) << 32 |                       \
          ngtcp2_ntohl((uint32_t)((N) >> 32)))
-#    endif /* !HAVE_BSWAP_64 && !WIN32 && !__APPLE__ */
+#    endif /* !(HAVE_DECL_BSWAP_64 || defined(WIN32) || defined(__APPLE__)) */
 #    define ngtcp2_ntohl64(N) ngtcp2_bswap64(N)
 #    define ngtcp2_htonl64(N) ngtcp2_bswap64(N)
-#  endif /* !WORDS_BIGENDIAN */
-#endif   /* !HAVE_BE64TOH */
+#  endif /* !defined(WORDS_BIGENDIAN) */
+#endif   /* !HAVE_DECL_BE64TOH */
 
-#if defined(WIN32)
+#ifdef WIN32
 /* Windows requires ws2_32 library for ntonl family functions.  We
    define inline functions for those function so that we don't have
    dependency on that lib. */
 
 #  ifdef _MSC_VER
 #    define STIN static __inline
-#  else
+#  else /* !defined(_MSC_VER) */
 #    define STIN static inline
-#  endif
+#  endif /* !defined(_MSC_VER) */
 
 STIN uint32_t ngtcp2_htonl(uint32_t hostlong) {
   uint32_t res;
@@ -131,13 +129,13 @@ STIN uint16_t ngtcp2_ntohs(uint16_t netshort) {
   return res;
 }
 
-#else /* !WIN32 */
+#else /* !defined(WIN32) */
 
 #  define ngtcp2_htonl htonl
 #  define ngtcp2_htons htons
 #  define ngtcp2_ntohl ntohl
 #  define ngtcp2_ntohs ntohs
 
-#endif /* !WIN32 */
+#endif /* !defined(WIN32) */
 
-#endif /* NGTCP2_NET_H */
+#endif /* !defined(NGTCP2_NET_H) */

--- a/lib/ngtcp2_objalloc.h
+++ b/lib/ngtcp2_objalloc.h
@@ -27,7 +27,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #include <ngtcp2/ngtcp2.h>
 
@@ -118,7 +118,7 @@ void ngtcp2_objalloc_clear(ngtcp2_objalloc *objalloc);
                                                                                \
       return ngtcp2_struct_of(oplent, TYPE, OPLENTFIELD);                      \
     }
-#else /* NOMEMPOOL */
+#else /* defined(NOMEMPOOL) */
 #  define ngtcp2_objalloc_decl(NAME, TYPE, OPLENTFIELD)                        \
     inline static void ngtcp2_objalloc_##NAME##_init(                          \
       ngtcp2_objalloc *objalloc, size_t nmemb, const ngtcp2_mem *mem) {        \
@@ -142,6 +142,6 @@ void ngtcp2_objalloc_clear(ngtcp2_objalloc *objalloc);
     }
 
 #  define ngtcp2_objalloc_def(NAME, TYPE, OPLENTFIELD)
-#endif /* NOMEMPOOL */
+#endif /* defined(NOMEMPOOL) */
 
-#endif /* NGTCP2_OBJALLOC_H */
+#endif /* !defined(NGTCP2_OBJALLOC_H) */

--- a/lib/ngtcp2_opl.h
+++ b/lib/ngtcp2_opl.h
@@ -27,7 +27,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #include <ngtcp2/ngtcp2.h>
 
@@ -62,4 +62,4 @@ ngtcp2_opl_entry *ngtcp2_opl_pop(ngtcp2_opl *opl);
 
 void ngtcp2_opl_clear(ngtcp2_opl *opl);
 
-#endif /* NGTCP2_OPL_H */
+#endif /* !defined(NGTCP2_OPL_H) */

--- a/lib/ngtcp2_path.h
+++ b/lib/ngtcp2_path.h
@@ -27,7 +27,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #include <ngtcp2/ngtcp2.h>
 
@@ -46,4 +46,4 @@ void ngtcp2_path_init(ngtcp2_path *path, const ngtcp2_addr *local,
 void ngtcp2_path_storage_init2(ngtcp2_path_storage *ps,
                                const ngtcp2_path *path);
 
-#endif /* NGTCP2_PATH_H */
+#endif /* !defined(NGTCP2_PATH_H) */

--- a/lib/ngtcp2_pkt.c
+++ b/lib/ngtcp2_pkt.c
@@ -334,7 +334,7 @@ ngtcp2_ssize ngtcp2_pkt_decode_hd_long(ngtcp2_pkt_hd *dest, const uint8_t *pkt,
 
 #ifndef NDEBUG
   p += nlonglen;
-#endif /* NDEBUG */
+#endif /* !defined(NDEBUG) */
 
   assert((size_t)(p - pkt) == len);
 

--- a/lib/ngtcp2_pkt.h
+++ b/lib/ngtcp2_pkt.h
@@ -27,7 +27,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #include <ngtcp2/ngtcp2.h>
 
@@ -1220,4 +1220,4 @@ uint8_t ngtcp2_pkt_versioned_type(uint32_t version, uint32_t pkt_type);
  */
 uint8_t ngtcp2_pkt_get_type_long(uint32_t version, uint8_t c);
 
-#endif /* NGTCP2_PKT_H */
+#endif /* !defined(NGTCP2_PKT_H) */

--- a/lib/ngtcp2_pktns_id.h
+++ b/lib/ngtcp2_pktns_id.h
@@ -27,7 +27,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #include <ngtcp2/ngtcp2.h>
 
@@ -59,4 +59,4 @@ typedef enum ngtcp2_pktns_id {
   NGTCP2_PKTNS_ID_MAX
 } ngtcp2_pktns_id;
 
-#endif /* NGTCP2_PKTNS_ID_H */
+#endif /* !defined(NGTCP2_PKTNS_ID_H) */

--- a/lib/ngtcp2_pmtud.h
+++ b/lib/ngtcp2_pmtud.h
@@ -27,7 +27,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #include <ngtcp2/ngtcp2.h>
 
@@ -129,4 +129,4 @@ void ngtcp2_pmtud_handle_expiry(ngtcp2_pmtud *pmtud, ngtcp2_tstamp ts);
  */
 int ngtcp2_pmtud_finished(ngtcp2_pmtud *pmtud);
 
-#endif /* NGTCP2_PMTUD_H */
+#endif /* !defined(NGTCP2_PMTUD_H) */

--- a/lib/ngtcp2_ppe.h
+++ b/lib/ngtcp2_ppe.h
@@ -27,7 +27,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #include <ngtcp2/ngtcp2.h>
 
@@ -166,4 +166,4 @@ size_t ngtcp2_ppe_padding_size(ngtcp2_ppe *ppe, size_t n);
  */
 int ngtcp2_ppe_ensure_hp_sample(ngtcp2_ppe *ppe);
 
-#endif /* NGTCP2_PPE_H */
+#endif /* !defined(NGTCP2_PPE_H) */

--- a/lib/ngtcp2_pq.h
+++ b/lib/ngtcp2_pq.h
@@ -28,7 +28,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #include <ngtcp2/ngtcp2.h>
 
@@ -126,4 +126,4 @@ int ngtcp2_pq_each(const ngtcp2_pq *pq, ngtcp2_pq_item_cb fun, void *arg);
  */
 void ngtcp2_pq_remove(ngtcp2_pq *pq, ngtcp2_pq_entry *item);
 
-#endif /* NGTCP2_PQ_H */
+#endif /* !defined(NGTCP2_PQ_H) */

--- a/lib/ngtcp2_pv.h
+++ b/lib/ngtcp2_pv.h
@@ -27,7 +27,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #include <ngtcp2/ngtcp2.h>
 
@@ -191,4 +191,4 @@ ngtcp2_tstamp ngtcp2_pv_next_expiry(ngtcp2_pv *pv);
  */
 void ngtcp2_pv_cancel_expired_timer(ngtcp2_pv *pv, ngtcp2_tstamp ts);
 
-#endif /* NGTCP2_PV_H */
+#endif /* !defined(NGTCP2_PV_H) */

--- a/lib/ngtcp2_qlog.h
+++ b/lib/ngtcp2_qlog.h
@@ -27,7 +27,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #include <ngtcp2/ngtcp2.h>
 
@@ -158,4 +158,4 @@ void ngtcp2_qlog_version_negotiation_pkt_received(ngtcp2_qlog *qlog,
                                                   const uint32_t *sv,
                                                   size_t nsv);
 
-#endif /* NGTCP2_QLOG_H */
+#endif /* !defined(NGTCP2_QLOG_H) */

--- a/lib/ngtcp2_range.h
+++ b/lib/ngtcp2_range.h
@@ -27,7 +27,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #include <ngtcp2/ngtcp2.h>
 
@@ -77,4 +77,4 @@ void ngtcp2_range_cut(ngtcp2_range *left, ngtcp2_range *right,
  */
 int ngtcp2_range_not_after(const ngtcp2_range *a, const ngtcp2_range *b);
 
-#endif /* NGTCP2_RANGE_H */
+#endif /* !defined(NGTCP2_RANGE_H) */

--- a/lib/ngtcp2_rcvry.h
+++ b/lib/ngtcp2_rcvry.h
@@ -27,7 +27,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #include <ngtcp2/ngtcp2.h>
 
@@ -37,4 +37,4 @@
 /* NGTCP2_GRANULARITY is kGranularity described in RFC 9002. */
 #define NGTCP2_GRANULARITY NGTCP2_MILLISECONDS
 
-#endif /* NGTCP2_RCVRY_H */
+#endif /* !defined(NGTCP2_RCVRY_H) */

--- a/lib/ngtcp2_ringbuf.c
+++ b/lib/ngtcp2_ringbuf.c
@@ -27,7 +27,7 @@
 #include <assert.h>
 #ifdef WIN32
 #  include <intrin.h>
-#endif
+#endif /* defined(WIN32) */
 
 #include "ngtcp2_macro.h"
 
@@ -42,7 +42,8 @@ static unsigned int __popcnt(unsigned int x) {
 
   return c;
 }
-#endif
+#endif /* defined(_MSC_VER) && !defined(__clang__) && (defined(_M_ARM) ||      \
+          defined(_M_ARM64)) */
 
 int ngtcp2_ringbuf_init(ngtcp2_ringbuf *rb, size_t nmemb, size_t size,
                         const ngtcp2_mem *mem) {
@@ -61,9 +62,9 @@ void ngtcp2_ringbuf_buf_init(ngtcp2_ringbuf *rb, size_t nmemb, size_t size,
                              uint8_t *buf, const ngtcp2_mem *mem) {
 #ifdef WIN32
   assert(1 == __popcnt((unsigned int)nmemb));
-#else
+#else  /* !defined(WIN32) */
   assert(1 == __builtin_popcount((unsigned int)nmemb));
-#endif
+#endif /* !defined(WIN32) */
 
   rb->buf = buf;
   rb->mem = mem;

--- a/lib/ngtcp2_ringbuf.h
+++ b/lib/ngtcp2_ringbuf.h
@@ -27,7 +27,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #include <ngtcp2/ngtcp2.h>
 
@@ -129,4 +129,4 @@ int ngtcp2_ringbuf_full(ngtcp2_ringbuf *rb);
     ngtcp2_ringbuf_buf_init(&srb->rb, (NMEMB), (SIZE), srb->buf, NULL);        \
   }
 
-#endif /* NGTCP2_RINGBUF_H */
+#endif /* !defined(NGTCP2_RINGBUF_H) */

--- a/lib/ngtcp2_rob.h
+++ b/lib/ngtcp2_rob.h
@@ -27,7 +27,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #include <ngtcp2/ngtcp2.h>
 
@@ -188,4 +188,4 @@ uint64_t ngtcp2_rob_first_gap_offset(const ngtcp2_rob *rob);
  */
 int ngtcp2_rob_data_buffered(const ngtcp2_rob *rob);
 
-#endif /* NGTCP2_ROB_H */
+#endif /* !defined(NGTCP2_ROB_H) */

--- a/lib/ngtcp2_rst.h
+++ b/lib/ngtcp2_rst.h
@@ -27,7 +27,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #include <ngtcp2/ngtcp2.h>
 
@@ -89,4 +89,4 @@ void ngtcp2_rst_update_rate_sample(ngtcp2_rst *rst, const ngtcp2_rtb_entry *ent,
                                    ngtcp2_tstamp ts);
 void ngtcp2_rst_update_app_limited(ngtcp2_rst *rst, ngtcp2_conn_stat *cstat);
 
-#endif /* NGTCP2_RST_H */
+#endif /* !defined(NGTCP2_RST_H) */

--- a/lib/ngtcp2_rtb.h
+++ b/lib/ngtcp2_rtb.h
@@ -27,7 +27,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #include <ngtcp2/ngtcp2.h>
 
@@ -317,4 +317,4 @@ void ngtcp2_rtb_remove_excessive_lost_pkt(ngtcp2_rtb *rtb, size_t n);
 ngtcp2_ssize ngtcp2_rtb_reclaim_on_pto(ngtcp2_rtb *rtb, ngtcp2_conn *conn,
                                        ngtcp2_pktns *pktns, size_t num_pkts);
 
-#endif /* NGTCP2_RTB_H */
+#endif /* !defined(NGTCP2_RTB_H) */

--- a/lib/ngtcp2_settings.h
+++ b/lib/ngtcp2_settings.h
@@ -27,7 +27,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #include <ngtcp2/ngtcp2.h>
 
@@ -70,4 +70,4 @@ void ngtcp2_settings_convert_to_old(int settings_version, ngtcp2_settings *dest,
  */
 size_t ngtcp2_settingslen_version(int settings_version);
 
-#endif /* NGTCP2_SETTINGS_H */
+#endif /* !defined(NGTCP2_SETTINGS_H) */

--- a/lib/ngtcp2_str.h
+++ b/lib/ngtcp2_str.h
@@ -27,7 +27,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #include <ngtcp2/ngtcp2.h>
 
@@ -91,4 +91,4 @@ char *ngtcp2_encode_printable_ascii(char *dest, const uint8_t *data,
  */
 int ngtcp2_cmemeq(const uint8_t *a, const uint8_t *b, size_t n);
 
-#endif /* NGTCP2_STR_H */
+#endif /* !defined(NGTCP2_STR_H) */

--- a/lib/ngtcp2_strm.h
+++ b/lib/ngtcp2_strm.h
@@ -27,7 +27,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #include <ngtcp2/ngtcp2.h>
 
@@ -358,4 +358,4 @@ int ngtcp2_strm_require_retransmit_max_stream_data(
 int ngtcp2_strm_require_retransmit_stream_data_blocked(
   const ngtcp2_strm *strm, const ngtcp2_stream_data_blocked *fr);
 
-#endif /* NGTCP2_STRM_H */
+#endif /* !defined(NGTCP2_STRM_H) */

--- a/lib/ngtcp2_transport_params.h
+++ b/lib/ngtcp2_transport_params.h
@@ -27,7 +27,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #include <ngtcp2/ngtcp2.h>
 
@@ -115,4 +115,4 @@ void ngtcp2_transport_params_convert_to_old(int transport_params_version,
                                             ngtcp2_transport_params *dest,
                                             const ngtcp2_transport_params *src);
 
-#endif /* NGTCP2_TRANSPORT_PARAMS_H */
+#endif /* !defined(NGTCP2_TRANSPORT_PARAMS_H) */

--- a/lib/ngtcp2_tstamp.h
+++ b/lib/ngtcp2_tstamp.h
@@ -27,7 +27,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #include <ngtcp2/ngtcp2.h>
 
@@ -65,4 +65,4 @@ static inline int ngtcp2_tstamp_not_elapsed(ngtcp2_tstamp base,
   return base != UINT64_MAX && (base >= UINT64_MAX - d || base + d > ts);
 }
 
-#endif /* NGTCP2_TSTAMP_H */
+#endif /* !defined(NGTCP2_TSTAMP_H) */

--- a/lib/ngtcp2_unreachable.c
+++ b/lib/ngtcp2_unreachable.c
@@ -33,7 +33,7 @@
 #elif defined(WIN32)
 #  define NGTCP2_UNREACHABLE_LOG
 #  include <io.h>
-#endif
+#endif /* defined(WIN32) */
 
 void ngtcp2_unreachable_fail(const char *file, int line, const char *func) {
 #ifdef NGTCP2_UNREACHABLE_LOG
@@ -63,12 +63,12 @@ void ngtcp2_unreachable_fail(const char *file, int line, const char *func) {
 #  ifndef WIN32
   while (write(STDERR_FILENO, buf, (size_t)rv) == -1 && errno == EINTR)
     ;
-#  else  /* WIN32 */
+#  else  /* defined(WIN32) */
   _write(_fileno(stderr), buf, (unsigned int)rv);
-#  endif /* WIN32 */
+#  endif /* defined(WIN32) */
 
   free(buf);
-#endif /* NGTCP2_UNREACHABLE_LOG */
+#endif /* defined(NGTCP2_UNREACHABLE_LOG) */
 
   abort();
 }

--- a/lib/ngtcp2_unreachable.h
+++ b/lib/ngtcp2_unreachable.h
@@ -27,26 +27,26 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #include <ngtcp2/ngtcp2.h>
 
 #ifdef __FILE_NAME__
 #  define NGTCP2_FILE_NAME __FILE_NAME__
-#else /* !__FILE_NAME__ */
+#else /* !defined(__FILE_NAME__) */
 #  define NGTCP2_FILE_NAME "(file)"
-#endif /* !__FILE_NAME__ */
+#endif /* !defined(__FILE_NAME__) */
 
 #define ngtcp2_unreachable()                                                   \
   ngtcp2_unreachable_fail(NGTCP2_FILE_NAME, __LINE__, __func__)
 
 #ifdef _MSC_VER
 __declspec(noreturn)
-#endif /* _MSC_VER */
+#endif /* defined(_MSC_VER) */
     void ngtcp2_unreachable_fail(const char *file, int line, const char *func)
 #ifndef _MSC_VER
         __attribute__((noreturn))
-#endif /* !_MSC_VER */
+#endif /* !defined(_MSC_VER) */
         ;
 
-#endif /* NGTCP2_UNREACHABLE_H */
+#endif /* !defined(NGTCP2_UNREACHABLE_H) */

--- a/lib/ngtcp2_vec.h
+++ b/lib/ngtcp2_vec.h
@@ -27,7 +27,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #include <ngtcp2/ngtcp2.h>
 
@@ -119,4 +119,4 @@ size_t ngtcp2_vec_copy_at_most(ngtcp2_vec *dst, size_t dstcnt,
  */
 void ngtcp2_vec_copy(ngtcp2_vec *dst, const ngtcp2_vec *src, size_t cnt);
 
-#endif /* NGTCP2_VEC_H */
+#endif /* !defined(NGTCP2_VEC_H) */

--- a/lib/ngtcp2_version.c
+++ b/lib/ngtcp2_version.c
@@ -24,7 +24,7 @@
  */
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #include <ngtcp2/ngtcp2.h>
 

--- a/lib/ngtcp2_window_filter.h
+++ b/lib/ngtcp2_window_filter.h
@@ -37,7 +37,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #include <ngtcp2/ngtcp2.h>
 
@@ -62,4 +62,4 @@ void ngtcp2_window_filter_reset(ngtcp2_window_filter *wf, uint64_t new_sample,
 
 uint64_t ngtcp2_window_filter_get_best(ngtcp2_window_filter *wf);
 
-#endif /* NGTCP2_WINDOW_FILTER_H */
+#endif /* !defined(NGTCP2_WINDOW_FILTER_H) */

--- a/tests/main.c
+++ b/tests/main.c
@@ -25,7 +25,7 @@
  */
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #include "munit.h"
 

--- a/tests/ngtcp2_acktr_test.h
+++ b/tests/ngtcp2_acktr_test.h
@@ -27,7 +27,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #define MUNIT_ENABLE_ASSERT_ALIASES
 
@@ -40,4 +40,4 @@ munit_void_test_decl(test_ngtcp2_acktr_eviction);
 munit_void_test_decl(test_ngtcp2_acktr_forget);
 munit_void_test_decl(test_ngtcp2_acktr_recv_ack);
 
-#endif /* NGTCP2_ACKTR_TEST_H */
+#endif /* !defined(NGTCP2_ACKTR_TEST_H) */

--- a/tests/ngtcp2_cc_test.h
+++ b/tests/ngtcp2_cc_test.h
@@ -27,7 +27,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #define MUNIT_ENABLE_ASSERT_ALIASES
 
@@ -37,4 +37,4 @@ extern const MunitSuite cc_suite;
 
 munit_void_test_decl(test_ngtcp2_cbrt);
 
-#endif /* NGTCP2_CC_TEST_H */
+#endif /* !defined(NGTCP2_CC_TEST_H) */

--- a/tests/ngtcp2_conn_test.h
+++ b/tests/ngtcp2_conn_test.h
@@ -27,7 +27,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #define MUNIT_ENABLE_ASSERT_ALIASES
 
@@ -118,4 +118,4 @@ munit_void_test_decl(test_ngtcp2_select_version);
 munit_void_test_decl(test_ngtcp2_pkt_write_connection_close);
 munit_void_test_decl(test_ngtcp2_ccerr_set_liberr);
 
-#endif /* NGTCP2_CONN_TEST_H */
+#endif /* !defined(NGTCP2_CONN_TEST_H) */

--- a/tests/ngtcp2_conv_test.h
+++ b/tests/ngtcp2_conv_test.h
@@ -27,7 +27,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #define MUNIT_ENABLE_ASSERT_ALIASES
 
@@ -49,4 +49,4 @@ munit_void_test_decl(test_ngtcp2_nth_client_bidi_id);
 munit_void_test_decl(test_ngtcp2_nth_client_uni_id);
 munit_void_test_decl(test_ngtcp2_put_pkt_num);
 
-#endif /* NGTCP2_CONV_TEST_H */
+#endif /* !defined(NGTCP2_CONV_TEST_H) */

--- a/tests/ngtcp2_gaptr_test.h
+++ b/tests/ngtcp2_gaptr_test.h
@@ -27,7 +27,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #define MUNIT_ENABLE_ASSERT_ALIASES
 
@@ -40,4 +40,4 @@ munit_void_test_decl(test_ngtcp2_gaptr_is_pushed);
 munit_void_test_decl(test_ngtcp2_gaptr_drop_first_gap);
 munit_void_test_decl(test_ngtcp2_gaptr_get_first_gap_after);
 
-#endif /* NGTCP2_GAPTR_TEST_H */
+#endif /* !defined(NGTCP2_GAPTR_TEST_H) */

--- a/tests/ngtcp2_idtr_test.h
+++ b/tests/ngtcp2_idtr_test.h
@@ -27,7 +27,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #define MUNIT_ENABLE_ASSERT_ALIASES
 
@@ -37,4 +37,4 @@ extern const MunitSuite idtr_suite;
 
 munit_void_test_decl(test_ngtcp2_idtr_open);
 
-#endif /* NGTCP2_IDTR_TEST_H */
+#endif /* !defined(NGTCP2_IDTR_TEST_H) */

--- a/tests/ngtcp2_ksl_test.h
+++ b/tests/ngtcp2_ksl_test.h
@@ -27,7 +27,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #define MUNIT_ENABLE_ASSERT_ALIASES
 
@@ -42,4 +42,4 @@ munit_void_test_decl(test_ngtcp2_ksl_update_key_range);
 munit_void_test_decl(test_ngtcp2_ksl_dup);
 munit_void_test_decl(test_ngtcp2_ksl_remove_hint);
 
-#endif /* NGTCP2_KSL_TEST_H */
+#endif /* !defined(NGTCP2_KSL_TEST_H) */

--- a/tests/ngtcp2_map_test.h
+++ b/tests/ngtcp2_map_test.h
@@ -28,7 +28,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #define MUNIT_ENABLE_ASSERT_ALIASES
 
@@ -41,4 +41,4 @@ munit_void_test_decl(test_ngtcp2_map_functional);
 munit_void_test_decl(test_ngtcp2_map_each);
 munit_void_test_decl(test_ngtcp2_map_clear);
 
-#endif /* NGTCP2_MAP_TEST_H */
+#endif /* !defined(NGTCP2_MAP_TEST_H) */

--- a/tests/ngtcp2_pkt_test.h
+++ b/tests/ngtcp2_pkt_test.h
@@ -27,7 +27,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #define MUNIT_ENABLE_ASSERT_ALIASES
 
@@ -72,4 +72,4 @@ munit_void_test_decl(test_ngtcp2_pkt_write_retry);
 munit_void_test_decl(test_ngtcp2_pkt_write_version_negotiation);
 munit_void_test_decl(test_ngtcp2_pkt_stream_max_datalen);
 
-#endif /* NGTCP2_PKT_TEST_H */
+#endif /* !defined(NGTCP2_PKT_TEST_H) */

--- a/tests/ngtcp2_pmtud_test.h
+++ b/tests/ngtcp2_pmtud_test.h
@@ -27,7 +27,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #define MUNIT_ENABLE_ASSERT_ALIASES
 
@@ -37,4 +37,4 @@ extern const MunitSuite pmtud_suite;
 
 munit_void_test_decl(test_ngtcp2_pmtud_probe);
 
-#endif /* NGTCP2_PMTUD_TEST_H */
+#endif /* !defined(NGTCP2_PMTUD_TEST_H) */

--- a/tests/ngtcp2_ppe_test.h
+++ b/tests/ngtcp2_ppe_test.h
@@ -27,7 +27,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #define MUNIT_ENABLE_ASSERT_ALIASES
 
@@ -39,4 +39,4 @@ munit_void_test_decl(test_ngtcp2_ppe_dgram_padding_size);
 munit_void_test_decl(test_ngtcp2_ppe_padding_size);
 munit_void_test_decl(test_ngtcp2_ppe_padding_hp_sample);
 
-#endif /* NGTCP2_PPE_TEST_H */
+#endif /* !defined(NGTCP2_PPE_TEST_H) */

--- a/tests/ngtcp2_pv_test.h
+++ b/tests/ngtcp2_pv_test.h
@@ -27,7 +27,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #define MUNIT_ENABLE_ASSERT_ALIASES
 
@@ -38,4 +38,4 @@ extern const MunitSuite pv_suite;
 munit_void_test_decl(test_ngtcp2_pv_add_entry);
 munit_void_test_decl(test_ngtcp2_pv_validate);
 
-#endif /* NGTCP2_PV_TEST_H */
+#endif /* !defined(NGTCP2_PV_TEST_H) */

--- a/tests/ngtcp2_qlog_test.h
+++ b/tests/ngtcp2_qlog_test.h
@@ -27,7 +27,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #define MUNIT_ENABLE_ASSERT_ALIASES
 
@@ -37,4 +37,4 @@ extern const MunitSuite qlog_suite;
 
 munit_void_test_decl(test_ngtcp2_qlog_write_frame);
 
-#endif /* NGTCP2_QLOG_TEST_H */
+#endif /* !defined(NGTCP2_QLOG_TEST_H) */

--- a/tests/ngtcp2_range_test.h
+++ b/tests/ngtcp2_range_test.h
@@ -27,7 +27,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #define MUNIT_ENABLE_ASSERT_ALIASES
 
@@ -39,4 +39,4 @@ munit_void_test_decl(test_ngtcp2_range_intersect);
 munit_void_test_decl(test_ngtcp2_range_cut);
 munit_void_test_decl(test_ngtcp2_range_not_after);
 
-#endif /* NGTCP2_RANGE_TEST_H */
+#endif /* !defined(NGTCP2_RANGE_TEST_H) */

--- a/tests/ngtcp2_ringbuf_test.h
+++ b/tests/ngtcp2_ringbuf_test.h
@@ -27,7 +27,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #define MUNIT_ENABLE_ASSERT_ALIASES
 
@@ -38,4 +38,4 @@ extern const MunitSuite ringbuf_suite;
 munit_void_test_decl(test_ngtcp2_ringbuf_push_front);
 munit_void_test_decl(test_ngtcp2_ringbuf_pop_front);
 
-#endif /* NGTCP2_RINGBUF_TEST_H */
+#endif /* !defined(NGTCP2_RINGBUF_TEST_H) */

--- a/tests/ngtcp2_rob_test.h
+++ b/tests/ngtcp2_rob_test.h
@@ -27,7 +27,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #define MUNIT_ENABLE_ASSERT_ALIASES
 
@@ -40,4 +40,4 @@ munit_void_test_decl(test_ngtcp2_rob_push_random);
 munit_void_test_decl(test_ngtcp2_rob_data_at);
 munit_void_test_decl(test_ngtcp2_rob_remove_prefix);
 
-#endif /* NGTCP2_ROB_TEST_H */
+#endif /* !defined(NGTCP2_ROB_TEST_H) */

--- a/tests/ngtcp2_rtb_test.h
+++ b/tests/ngtcp2_rtb_test.h
@@ -27,7 +27,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #define MUNIT_ENABLE_ASSERT_ALIASES
 
@@ -41,4 +41,4 @@ munit_void_test_decl(test_ngtcp2_rtb_lost_pkt_ts);
 munit_void_test_decl(test_ngtcp2_rtb_remove_expired_lost_pkt);
 munit_void_test_decl(test_ngtcp2_rtb_remove_excessive_lost_pkt);
 
-#endif /* NGTCP2_RTB_TEST_H */
+#endif /* !defined(NGTCP2_RTB_TEST_H) */

--- a/tests/ngtcp2_settings_test.h
+++ b/tests/ngtcp2_settings_test.h
@@ -27,7 +27,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #define MUNIT_ENABLE_ASSERT_ALIASES
 
@@ -38,4 +38,4 @@ extern const MunitSuite settings_suite;
 munit_void_test_decl(test_ngtcp2_settings_convert_to_latest);
 munit_void_test_decl(test_ngtcp2_settings_convert_to_old);
 
-#endif /* NGTCP2_SETTINGS_TEST_H */
+#endif /* !defined(NGTCP2_SETTINGS_TEST_H) */

--- a/tests/ngtcp2_str_test.h
+++ b/tests/ngtcp2_str_test.h
@@ -27,7 +27,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #define MUNIT_ENABLE_ASSERT_ALIASES
 
@@ -39,4 +39,4 @@ munit_void_test_decl(test_ngtcp2_encode_ipv4);
 munit_void_test_decl(test_ngtcp2_encode_ipv6);
 munit_void_test_decl(test_ngtcp2_get_bytes);
 
-#endif /* NGTCP2_STR_TEST_H */
+#endif /* !defined(NGTCP2_STR_TEST_H) */

--- a/tests/ngtcp2_strm_test.h
+++ b/tests/ngtcp2_strm_test.h
@@ -27,7 +27,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #define MUNIT_ENABLE_ASSERT_ALIASES
 
@@ -40,4 +40,4 @@ munit_void_test_decl(test_ngtcp2_strm_streamfrq_unacked_offset);
 munit_void_test_decl(test_ngtcp2_strm_streamfrq_unacked_pop);
 munit_void_test_decl(test_ngtcp2_strm_discard_reordered_data);
 
-#endif /* NGTCP2_STRM_TEST_H */
+#endif /* !defined(NGTCP2_STRM_TEST_H) */

--- a/tests/ngtcp2_test_helper.h
+++ b/tests/ngtcp2_test_helper.h
@@ -27,7 +27,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #include <ngtcp2/ngtcp2.h>
 
@@ -224,4 +224,4 @@ size_t ngtcp2_tpe_write_0rtt(ngtcp2_tpe *tpe, uint8_t *out, size_t outlen,
 size_t ngtcp2_tpe_write_1rtt(ngtcp2_tpe *tpe, uint8_t *out, size_t outlen,
                              ngtcp2_frame *fr, size_t frlen);
 
-#endif /* NGTCP2_TEST_HELPER_H */
+#endif /* !defined(NGTCP2_TEST_HELPER_H) */

--- a/tests/ngtcp2_transport_params_test.h
+++ b/tests/ngtcp2_transport_params_test.h
@@ -27,7 +27,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #define MUNIT_ENABLE_ASSERT_ALIASES
 
@@ -40,4 +40,4 @@ munit_void_test_decl(test_ngtcp2_transport_params_decode_new);
 munit_void_test_decl(test_ngtcp2_transport_params_convert_to_latest);
 munit_void_test_decl(test_ngtcp2_transport_params_convert_to_old);
 
-#endif /* NGTCP2_TRANSPORT_PARAMS_TEST_H */
+#endif /* !defined(NGTCP2_TRANSPORT_PARAMS_TEST_H) */

--- a/tests/ngtcp2_tstamp_test.h
+++ b/tests/ngtcp2_tstamp_test.h
@@ -27,7 +27,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #define MUNIT_ENABLE_ASSERT_ALIASES
 
@@ -37,4 +37,4 @@ extern const MunitSuite tstamp_suite;
 
 munit_void_test_decl(test_ngtcp2_tstamp_elapsed);
 
-#endif /* NGTCP2_TSTAMP_TEST_H */
+#endif /* !defined(NGTCP2_TSTAMP_TEST_H) */

--- a/tests/ngtcp2_vec_test.h
+++ b/tests/ngtcp2_vec_test.h
@@ -27,7 +27,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #define MUNIT_ENABLE_ASSERT_ALIASES
 
@@ -39,4 +39,4 @@ munit_void_test_decl(test_ngtcp2_vec_split);
 munit_void_test_decl(test_ngtcp2_vec_merge);
 munit_void_test_decl(test_ngtcp2_vec_len_varint);
 
-#endif /* NGTCP2_VEC_TEST_H */
+#endif /* !defined(NGTCP2_VEC_TEST_H) */

--- a/tests/ngtcp2_window_filter_test.h
+++ b/tests/ngtcp2_window_filter_test.h
@@ -27,7 +27,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #define MUNIT_ENABLE_ASSERT_ALIASES
 
@@ -37,4 +37,4 @@ extern const MunitSuite window_filter_suite;
 
 munit_void_test_decl(test_ngtcp2_window_filter_update);
 
-#endif /* NGTCP2_WINDOW_FILTER_TEST_H */
+#endif /* !defined(NGTCP2_WINDOW_FILTER_TEST_H) */


### PR DESCRIPTION
Make macro comments consistent throughout the codebase.  Fixup HAVE_BE64TOH and HAVE_BSWAP_64 cmakedefine to match the semantics of autotools.