### PR TITLE
Silence faulty 'uninitialized' GCC warning.

### DIFF
--- a/lib/ngtcp2_acktr.c
+++ b/lib/ngtcp2_acktr.c
@@ -283,6 +283,7 @@ void ngtcp2_acktr_recv_ack(ngtcp2_acktr *acktr, const ngtcp2_ack *fr) {
 
   min_ack = largest_ack - (int64_t)fr->first_ack_range;
 
+  assert(ent != NULL);
   if (min_ack <= ent->pkt_num) {
     acktr_on_ack(acktr, rb, j);
     return;
@@ -293,6 +294,7 @@ void ngtcp2_acktr_recv_ack(ngtcp2_acktr *acktr, const ngtcp2_ack *fr) {
     min_ack = largest_ack - (int64_t)fr->ranges[i].len;
 
     for (;;) {
+      assert(ent != NULL);
       if (ent->pkt_num > largest_ack) {
         if (++j == nacks) {
           return;


### PR DESCRIPTION
When compiling `lib/ngtcp2_acktr.c` with GCC 14.2.1 a faulty `-Wmaybe-uninitialized` appears. This PR remedies the issue.