### PR TITLE
Revert "ngtcp2_rst: Remove window filter and ineffective next_round_delivered"

### DIFF
--- a/lib/ngtcp2_rst.c
+++ b/lib/ngtcp2_rst.c
@@ -47,10 +47,13 @@ void ngtcp2_rs_init(ngtcp2_rs *rs) {
 
 void ngtcp2_rst_init(ngtcp2_rst *rst) {
   ngtcp2_rs_init(&rst->rs);
+  ngtcp2_window_filter_init(&rst->wf, 12);
   rst->delivered = 0;
   rst->delivered_ts = 0;
   rst->first_sent_ts = 0;
   rst->app_limited = 0;
+  rst->next_round_delivered = 0;
+  rst->round_count = 0;
   rst->is_cwnd_limited = 0;
   rst->lost = 0;
   rst->last_seq = -1;
@@ -70,11 +73,18 @@ void ngtcp2_rst_on_pkt_sent(ngtcp2_rst *rst, ngtcp2_rtb_entry *ent,
   ent->rst.end_seq = ++rst->last_seq;
 }
 
-void ngtcp2_rst_on_ack_recv(ngtcp2_rst *rst, ngtcp2_conn_stat *cstat) {
+void ngtcp2_rst_on_ack_recv(ngtcp2_rst *rst, ngtcp2_conn_stat *cstat,
+                            uint64_t pkt_delivered) {
   ngtcp2_rs *rs = &rst->rs;
+  uint64_t rate;
 
   if (rst->app_limited && rst->delivered > rst->app_limited) {
     rst->app_limited = 0;
+  }
+
+  if (pkt_delivered >= rst->next_round_delivered) {
+    rst->next_round_delivered = pkt_delivered;
+    ++rst->round_count;
   }
 
   if (rs->prior_ts == UINT64_MAX) {
@@ -95,7 +105,12 @@ void ngtcp2_rst_on_ack_recv(ngtcp2_rst *rst, ngtcp2_conn_stat *cstat) {
     return;
   }
 
-  cstat->delivery_rate_sec = rs->delivered * NGTCP2_SECONDS / rs->interval;
+  rate = rs->delivered * NGTCP2_SECONDS / rs->interval;
+
+  if (rate >= ngtcp2_window_filter_get_best(&rst->wf) || !rst->app_limited) {
+    ngtcp2_window_filter_update(&rst->wf, rate, rst->round_count);
+    cstat->delivery_rate_sec = ngtcp2_window_filter_get_best(&rst->wf);
+  }
 }
 
 static int rst_is_newest_pkt(const ngtcp2_rst *rst, const ngtcp2_rtb_entry *ent,

--- a/lib/ngtcp2_rst.h
+++ b/lib/ngtcp2_rst.h
@@ -31,6 +31,8 @@
 
 #include <ngtcp2/ngtcp2.h>
 
+#include "ngtcp2_window_filter.h"
+
 typedef struct ngtcp2_rtb_entry ngtcp2_rtb_entry;
 typedef struct ngtcp2_conn_stat ngtcp2_conn_stat;
 
@@ -61,10 +63,13 @@ void ngtcp2_rs_init(ngtcp2_rs *rs);
  */
 typedef struct ngtcp2_rst {
   ngtcp2_rs rs;
+  ngtcp2_window_filter wf;
   uint64_t delivered;
   ngtcp2_tstamp delivered_ts;
   ngtcp2_tstamp first_sent_ts;
   uint64_t app_limited;
+  uint64_t next_round_delivered;
+  uint64_t round_count;
   uint64_t lost;
   /* last_seq is the sequence number of packets across all packet
      number spaces.  If we would adopt single packet number sequence
@@ -78,7 +83,8 @@ void ngtcp2_rst_init(ngtcp2_rst *rst);
 
 void ngtcp2_rst_on_pkt_sent(ngtcp2_rst *rst, ngtcp2_rtb_entry *ent,
                             const ngtcp2_conn_stat *cstat);
-void ngtcp2_rst_on_ack_recv(ngtcp2_rst *rst, ngtcp2_conn_stat *cstat);
+void ngtcp2_rst_on_ack_recv(ngtcp2_rst *rst, ngtcp2_conn_stat *cstat,
+                            uint64_t pkt_delivered);
 void ngtcp2_rst_update_rate_sample(ngtcp2_rst *rst, const ngtcp2_rtb_entry *ent,
                                    ngtcp2_tstamp ts);
 void ngtcp2_rst_update_app_limited(ngtcp2_rst *rst, ngtcp2_conn_stat *cstat);

--- a/lib/ngtcp2_rtb.c
+++ b/lib/ngtcp2_rtb.c
@@ -923,7 +923,7 @@ ngtcp2_ssize ngtcp2_rtb_recv_ack(ngtcp2_rtb *rtb, const ngtcp2_ack *fr,
   }
 
   if (num_acked) {
-    ngtcp2_rst_on_ack_recv(rtb->rst, cstat);
+    ngtcp2_rst_on_ack_recv(rtb->rst, cstat, cc_ack.pkt_delivered);
 
     if (conn) {
       rv = rtb_detect_lost_pkt(rtb, &cc_ack.bytes_lost, conn, pktns, cstat, ts);


### PR DESCRIPTION
This reverts commit 2cab537ce8ec1a4c16a5493a9c03c4a1bb68052b.