### PR TITLE
examples: Bail out with ciphers option when TLS stack ignores it

### DIFF
--- a/examples/client.cc
+++ b/examples/client.cc
@@ -2704,6 +2704,10 @@ int main(int argc, char **argv) {
       switch (flag) {
       case 1:
         // --ciphers
+        if (util::crypto_default_ciphers()[0] == '\0') {
+          std::cerr << "ciphers: not supported" << std::endl;
+          exit(EXIT_FAILURE);
+        }
         config.ciphers = optarg;
         break;
       case 2:

--- a/examples/h09client.cc
+++ b/examples/h09client.cc
@@ -2243,6 +2243,10 @@ int main(int argc, char **argv) {
       switch (flag) {
       case 1:
         // --ciphers
+        if (util::crypto_default_ciphers()[0] == '\0') {
+          std::cerr << "ciphers: not supported" << std::endl;
+          exit(EXIT_FAILURE);
+        }
         config.ciphers = optarg;
         break;
       case 2:

--- a/examples/h09server.cc
+++ b/examples/h09server.cc
@@ -2894,6 +2894,10 @@ int main(int argc, char **argv) {
       switch (flag) {
       case 1:
         // --ciphers
+        if (util::crypto_default_ciphers()[0] == '\0') {
+          std::cerr << "ciphers: not supported" << std::endl;
+          exit(EXIT_FAILURE);
+        }
         config.ciphers = optarg;
         break;
       case 2:

--- a/examples/server.cc
+++ b/examples/server.cc
@@ -3618,6 +3618,10 @@ int main(int argc, char **argv) {
       switch (flag) {
       case 1:
         // --ciphers
+        if (util::crypto_default_ciphers()[0] == '\0') {
+          std::cerr << "ciphers: not supported" << std::endl;
+          exit(EXIT_FAILURE);
+        }
         config.ciphers = optarg;
         break;
       case 2:

--- a/examples/util_openssl.cc
+++ b/examples/util_openssl.cc
@@ -126,8 +126,16 @@ int write_pem(const std::string_view &filename, const std::string_view &name,
 }
 
 const char *crypto_default_ciphers() {
+#if defined(ENABLE_EXAMPLE_QUICTLS) && defined(WITH_EXAMPLE_QUICTLS)
   return "TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_"
-         "SHA256:TLS_AES_128_CCM_SHA256";
+         "SHA256"
+#  ifndef LIBRESSL_VERSION_NUMBER
+         ":TLS_AES_128_CCM_SHA256"
+#  endif // !defined(LIBRESSL_VERSION_NUMBER)
+    ;
+#else  // !(defined(ENABLE_EXAMPLE_QUICTLS) && defined(WITH_EXAMPLE_QUICTLS))
+  return "";
+#endif // !(defined(ENABLE_EXAMPLE_QUICTLS) && defined(WITH_EXAMPLE_QUICTLS))
 }
 
 const char *crypto_default_groups() { return "X25519:P-256:P-384:P-521"; }


### PR DESCRIPTION
Bail out if TLS backend does not allow changing ciphers and ciphers option is used.  Remove AES-128-CCM from default ciphers if libressl is used.