### PR TITLE
Introduce ngtcp2_ksl_search

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -233,6 +233,7 @@ StatementMacros:
   - Q_UNUSED
   - QT_REQUIRE_VERSION
   - munit_void_test_decl
+  - ngtcp2_ksl_search_def
   - ngtcp2_max_def
   - ngtcp2_min_def
   - ngtcp2_objalloc_decl

--- a/lib/ngtcp2_acktr.c
+++ b/lib/ngtcp2_acktr.c
@@ -56,10 +56,6 @@ void ngtcp2_acktr_entry_objalloc_del(ngtcp2_acktr_entry *ent,
   ngtcp2_objalloc_acktr_entry_release(objalloc, ent);
 }
 
-static int greater(const ngtcp2_ksl_key *lhs, const ngtcp2_ksl_key *rhs) {
-  return *(int64_t *)lhs > *(int64_t *)rhs;
-}
-
 void ngtcp2_acktr_init(ngtcp2_acktr *acktr, ngtcp2_log *log,
                        const ngtcp2_mem *mem) {
   ngtcp2_objalloc_acktr_entry_init(&acktr->objalloc, NGTCP2_ACKTR_MAX_ENT + 1,
@@ -67,7 +63,8 @@ void ngtcp2_acktr_init(ngtcp2_acktr *acktr, ngtcp2_log *log,
 
   ngtcp2_static_ringbuf_acks_init(&acktr->acks);
 
-  ngtcp2_ksl_init(&acktr->ents, greater, sizeof(int64_t), mem);
+  ngtcp2_ksl_init(&acktr->ents, ngtcp2_ksl_int64_greater,
+                  ngtcp2_ksl_int64_greater_search, sizeof(int64_t), mem);
 
   acktr->log = log;
   acktr->flags = NGTCP2_ACKTR_FLAG_NONE;

--- a/lib/ngtcp2_conn.c
+++ b/lib/ngtcp2_conn.c
@@ -771,6 +771,8 @@ static int cid_less(const ngtcp2_ksl_key *lhs, const ngtcp2_ksl_key *rhs) {
   return ngtcp2_cid_less(lhs, rhs);
 }
 
+ngtcp2_ksl_search_def(cid_less, cid_less)
+
 static int retired_ts_less(const ngtcp2_pq_entry *lhs,
                            const ngtcp2_pq_entry *rhs) {
   const ngtcp2_scid *a = ngtcp2_struct_of(lhs, ngtcp2_scid, pe);
@@ -1163,7 +1165,8 @@ static int conn_new(ngtcp2_conn **pconn, const ngtcp2_cid *dcid,
 
   ngtcp2_gaptr_init(&(*pconn)->dcid.seqgap, mem);
 
-  ngtcp2_ksl_init(&(*pconn)->scid.set, cid_less, sizeof(ngtcp2_cid), mem);
+  ngtcp2_ksl_init(&(*pconn)->scid.set, cid_less, ksl_cid_less_search,
+                  sizeof(ngtcp2_cid), mem);
 
   ngtcp2_pq_init(&(*pconn)->scid.used, retired_ts_less, mem);
 

--- a/lib/ngtcp2_gaptr.c
+++ b/lib/ngtcp2_gaptr.c
@@ -28,8 +28,8 @@
 #include <assert.h>
 
 void ngtcp2_gaptr_init(ngtcp2_gaptr *gaptr, const ngtcp2_mem *mem) {
-  ngtcp2_ksl_init(&gaptr->gap, ngtcp2_ksl_range_compar, sizeof(ngtcp2_range),
-                  mem);
+  ngtcp2_ksl_init(&gaptr->gap, ngtcp2_ksl_range_compar, ngtcp2_ksl_range_search,
+                  sizeof(ngtcp2_range), mem);
 
   gaptr->mem = mem;
 }
@@ -60,8 +60,8 @@ int ngtcp2_gaptr_push(ngtcp2_gaptr *gaptr, uint64_t offset, uint64_t datalen) {
     }
   }
 
-  it = ngtcp2_ksl_lower_bound_compar(&gaptr->gap, &q,
-                                     ngtcp2_ksl_range_exclusive_compar);
+  it = ngtcp2_ksl_lower_bound_search(&gaptr->gap, &q,
+                                     ngtcp2_ksl_range_exclusive_search);
 
   for (; !ngtcp2_ksl_it_end(&it);) {
     k = *(ngtcp2_range *)ngtcp2_ksl_it_key(&it);
@@ -118,8 +118,8 @@ ngtcp2_range ngtcp2_gaptr_get_first_gap_after(const ngtcp2_gaptr *gaptr,
     return r;
   }
 
-  it = ngtcp2_ksl_lower_bound_compar(&gaptr->gap, &q,
-                                     ngtcp2_ksl_range_exclusive_compar);
+  it = ngtcp2_ksl_lower_bound_search(&gaptr->gap, &q,
+                                     ngtcp2_ksl_range_exclusive_search);
 
   assert(!ngtcp2_ksl_it_end(&it));
 
@@ -136,8 +136,8 @@ int ngtcp2_gaptr_is_pushed(const ngtcp2_gaptr *gaptr, uint64_t offset,
     return 0;
   }
 
-  it = ngtcp2_ksl_lower_bound_compar(&gaptr->gap, &q,
-                                     ngtcp2_ksl_range_exclusive_compar);
+  it = ngtcp2_ksl_lower_bound_search(&gaptr->gap, &q,
+                                     ngtcp2_ksl_range_exclusive_search);
   m = ngtcp2_range_intersect(&q, (ngtcp2_range *)ngtcp2_ksl_it_key(&it));
 
   return ngtcp2_range_len(&m) == 0;

--- a/lib/ngtcp2_ksl.c
+++ b/lib/ngtcp2_ksl.c
@@ -57,7 +57,8 @@ static void ksl_node_set_key(ngtcp2_ksl *ksl, ngtcp2_ksl_node *node,
   memcpy(node->key, key, ksl->keylen);
 }
 
-void ngtcp2_ksl_init(ngtcp2_ksl *ksl, ngtcp2_ksl_compar compar, size_t keylen,
+void ngtcp2_ksl_init(ngtcp2_ksl *ksl, ngtcp2_ksl_compar compar,
+                     ngtcp2_ksl_search search, size_t keylen,
                      const ngtcp2_mem *mem) {
   size_t nodelen = ksl_nodelen(keylen);
 
@@ -67,6 +68,7 @@ void ngtcp2_ksl_init(ngtcp2_ksl *ksl, ngtcp2_ksl_compar compar, size_t keylen,
   ksl->head = NULL;
   ksl->front = ksl->back = NULL;
   ksl->compar = compar;
+  ksl->search = search;
   ksl->n = 0;
   ksl->keylen = keylen;
   ksl->nodelen = nodelen;
@@ -269,19 +271,6 @@ static void ksl_insert_node(ngtcp2_ksl *ksl, ngtcp2_ksl_blk *blk, size_t i,
   ++blk->n;
 }
 
-static size_t ksl_search(const ngtcp2_ksl *ksl, ngtcp2_ksl_blk *blk,
-                         const ngtcp2_ksl_key *key, ngtcp2_ksl_compar compar) {
-  size_t i;
-  ngtcp2_ksl_node *node;
-
-  for (i = 0, node = (ngtcp2_ksl_node *)(void *)blk->nodes;
-       i < blk->n && compar((ngtcp2_ksl_key *)node->key, key);
-       ++i, node = (ngtcp2_ksl_node *)(void *)((uint8_t *)node + ksl->nodelen))
-    ;
-
-  return i;
-}
-
 int ngtcp2_ksl_insert(ngtcp2_ksl *ksl, ngtcp2_ksl_it *it,
                       const ngtcp2_ksl_key *key, void *data) {
   ngtcp2_ksl_blk *blk;
@@ -306,7 +295,7 @@ int ngtcp2_ksl_insert(ngtcp2_ksl *ksl, ngtcp2_ksl_it *it,
   blk = ksl->head;
 
   for (;;) {
-    i = ksl_search(ksl, blk, key, ksl->compar);
+    i = ksl->search(ksl, blk, key);
 
     if (blk->leaf) {
       if (i < blk->n &&
@@ -565,7 +554,7 @@ int ngtcp2_ksl_remove(ngtcp2_ksl *ksl, ngtcp2_ksl_it *it,
   }
 
   for (;;) {
-    i = ksl_search(ksl, blk, key, ksl->compar);
+    i = ksl->search(ksl, blk, key);
 
     if (i == blk->n) {
       if (it) {
@@ -636,12 +625,12 @@ int ngtcp2_ksl_remove(ngtcp2_ksl *ksl, ngtcp2_ksl_it *it,
 
 ngtcp2_ksl_it ngtcp2_ksl_lower_bound(const ngtcp2_ksl *ksl,
                                      const ngtcp2_ksl_key *key) {
-  return ngtcp2_ksl_lower_bound_compar(ksl, key, ksl->compar);
+  return ngtcp2_ksl_lower_bound_search(ksl, key, ksl->search);
 }
 
-ngtcp2_ksl_it ngtcp2_ksl_lower_bound_compar(const ngtcp2_ksl *ksl,
+ngtcp2_ksl_it ngtcp2_ksl_lower_bound_search(const ngtcp2_ksl *ksl,
                                             const ngtcp2_ksl_key *key,
-                                            ngtcp2_ksl_compar compar) {
+                                            ngtcp2_ksl_search search) {
   ngtcp2_ksl_blk *blk = ksl->head;
   ngtcp2_ksl_it it;
   size_t i;
@@ -652,7 +641,7 @@ ngtcp2_ksl_it ngtcp2_ksl_lower_bound_compar(const ngtcp2_ksl *ksl,
   }
 
   for (;;) {
-    i = ksl_search(ksl, blk, key, compar);
+    i = search(ksl, blk, key);
 
     if (blk->leaf) {
       if (i == blk->n && blk->next) {
@@ -696,7 +685,7 @@ void ngtcp2_ksl_update_key(ngtcp2_ksl *ksl, const ngtcp2_ksl_key *old_key,
   assert(ksl->head);
 
   for (;;) {
-    i = ksl_search(ksl, blk, old_key, ksl->compar);
+    i = ksl->search(ksl, blk, old_key);
 
     assert(i < blk->n);
     node = ngtcp2_ksl_nth_node(ksl, blk, i);
@@ -819,9 +808,49 @@ int ngtcp2_ksl_range_compar(const ngtcp2_ksl_key *lhs,
   return a->begin < b->begin;
 }
 
+ngtcp2_ksl_search_def(range, ngtcp2_ksl_range_compar)
+
+size_t ngtcp2_ksl_range_search(const ngtcp2_ksl *ksl, ngtcp2_ksl_blk *blk,
+                               const ngtcp2_ksl_key *key) {
+  return ksl_range_search(ksl, blk, key);
+}
+
 int ngtcp2_ksl_range_exclusive_compar(const ngtcp2_ksl_key *lhs,
                                       const ngtcp2_ksl_key *rhs) {
   const ngtcp2_range *a = lhs, *b = rhs;
   return a->begin < b->begin && !(ngtcp2_max_uint64(a->begin, b->begin) <
                                   ngtcp2_min_uint64(a->end, b->end));
+}
+
+ngtcp2_ksl_search_def(range_exclusive, ngtcp2_ksl_range_exclusive_compar)
+
+size_t ngtcp2_ksl_range_exclusive_search(const ngtcp2_ksl *ksl,
+                                         ngtcp2_ksl_blk *blk,
+                                         const ngtcp2_ksl_key *key) {
+  return ksl_range_exclusive_search(ksl, blk, key);
+}
+
+int ngtcp2_ksl_int64_less(const ngtcp2_ksl_key *lhs,
+                          const ngtcp2_ksl_key *rhs) {
+  return *(int64_t *)lhs < *(int64_t *)rhs;
+}
+
+ngtcp2_ksl_search_def(int64_less, ngtcp2_ksl_int64_less)
+
+size_t ngtcp2_ksl_int64_less_search(const ngtcp2_ksl *ksl, ngtcp2_ksl_blk *blk,
+                                    const ngtcp2_ksl_key *key) {
+  return ksl_int64_less_search(ksl, blk, key);
+}
+
+int ngtcp2_ksl_int64_greater(const ngtcp2_ksl_key *lhs,
+                             const ngtcp2_ksl_key *rhs) {
+  return *(int64_t *)lhs > *(int64_t *)rhs;
+}
+
+ngtcp2_ksl_search_def(int64_greater, ngtcp2_ksl_int64_greater)
+
+size_t ngtcp2_ksl_int64_greater_search(const ngtcp2_ksl *ksl,
+                                       ngtcp2_ksl_blk *blk,
+                                       const ngtcp2_ksl_key *key) {
+  return ksl_int64_greater_search(ksl, blk, key);
 }

--- a/lib/ngtcp2_rob.c
+++ b/lib/ngtcp2_rob.c
@@ -68,8 +68,8 @@ int ngtcp2_rob_init(ngtcp2_rob *rob, size_t chunk, const ngtcp2_mem *mem) {
   int rv;
   ngtcp2_rob_gap *g;
 
-  ngtcp2_ksl_init(&rob->gapksl, ngtcp2_ksl_range_compar, sizeof(ngtcp2_range),
-                  mem);
+  ngtcp2_ksl_init(&rob->gapksl, ngtcp2_ksl_range_compar,
+                  ngtcp2_ksl_range_search, sizeof(ngtcp2_range), mem);
 
   rv = ngtcp2_rob_gap_new(&g, 0, UINT64_MAX, mem);
   if (rv != 0) {
@@ -81,8 +81,8 @@ int ngtcp2_rob_init(ngtcp2_rob *rob, size_t chunk, const ngtcp2_mem *mem) {
     goto fail_gapksl_ksl_insert;
   }
 
-  ngtcp2_ksl_init(&rob->dataksl, ngtcp2_ksl_range_compar, sizeof(ngtcp2_range),
-                  mem);
+  ngtcp2_ksl_init(&rob->dataksl, ngtcp2_ksl_range_compar,
+                  ngtcp2_ksl_range_search, sizeof(ngtcp2_range), mem);
 
   rob->chunk = chunk;
   rob->mem = mem;
@@ -125,8 +125,8 @@ static int rob_write_data(ngtcp2_rob *rob, uint64_t offset, const uint8_t *data,
   ngtcp2_range range = {offset, offset + len};
   ngtcp2_ksl_it it;
 
-  for (it = ngtcp2_ksl_lower_bound_compar(&rob->dataksl, &range,
-                                          ngtcp2_ksl_range_exclusive_compar);
+  for (it = ngtcp2_ksl_lower_bound_search(&rob->dataksl, &range,
+                                          ngtcp2_ksl_range_exclusive_search);
        len; ngtcp2_ksl_it_next(&it)) {
     if (ngtcp2_ksl_it_end(&it)) {
       d = NULL;
@@ -166,8 +166,8 @@ int ngtcp2_rob_push(ngtcp2_rob *rob, uint64_t offset, const uint8_t *data,
   ngtcp2_range m, l, r, q = {offset, offset + datalen};
   ngtcp2_ksl_it it;
 
-  it = ngtcp2_ksl_lower_bound_compar(&rob->gapksl, &q,
-                                     ngtcp2_ksl_range_exclusive_compar);
+  it = ngtcp2_ksl_lower_bound_search(&rob->gapksl, &q,
+                                     ngtcp2_ksl_range_exclusive_search);
 
   for (; !ngtcp2_ksl_it_end(&it);) {
     g = ngtcp2_ksl_it_get(&it);

--- a/lib/ngtcp2_rtb.c
+++ b/lib/ngtcp2_rtb.c
@@ -81,17 +81,14 @@ void ngtcp2_rtb_entry_objalloc_del(ngtcp2_rtb_entry *ent,
   ngtcp2_objalloc_rtb_entry_release(objalloc, ent);
 }
 
-static int greater(const ngtcp2_ksl_key *lhs, const ngtcp2_ksl_key *rhs) {
-  return *(int64_t *)lhs > *(int64_t *)rhs;
-}
-
 void ngtcp2_rtb_init(ngtcp2_rtb *rtb, ngtcp2_rst *rst, ngtcp2_cc *cc,
                      int64_t cc_pkt_num, ngtcp2_log *log, ngtcp2_qlog *qlog,
                      ngtcp2_objalloc *rtb_entry_objalloc,
                      ngtcp2_objalloc *frc_objalloc, const ngtcp2_mem *mem) {
   rtb->rtb_entry_objalloc = rtb_entry_objalloc;
   rtb->frc_objalloc = frc_objalloc;
-  ngtcp2_ksl_init(&rtb->ents, greater, sizeof(int64_t), mem);
+  ngtcp2_ksl_init(&rtb->ents, ngtcp2_ksl_int64_greater,
+                  ngtcp2_ksl_int64_greater_search, sizeof(int64_t), mem);
   rtb->rst = rst;
   rtb->cc = cc;
   rtb->log = log;

--- a/lib/ngtcp2_strm.c
+++ b/lib/ngtcp2_strm.c
@@ -32,10 +32,6 @@
 #include "ngtcp2_vec.h"
 #include "ngtcp2_frame_chain.h"
 
-static int offset_less(const ngtcp2_ksl_key *lhs, const ngtcp2_ksl_key *rhs) {
-  return *(int64_t *)lhs < *(int64_t *)rhs;
-}
-
 void ngtcp2_strm_init(ngtcp2_strm *strm, int64_t stream_id, uint32_t flags,
                       uint64_t max_rx_offset, uint64_t max_tx_offset,
                       void *stream_user_data, ngtcp2_objalloc *frc_objalloc,
@@ -180,7 +176,8 @@ static int strm_streamfrq_init(ngtcp2_strm *strm) {
     return NGTCP2_ERR_NOMEM;
   }
 
-  ngtcp2_ksl_init(streamfrq, offset_less, sizeof(uint64_t), strm->mem);
+  ngtcp2_ksl_init(streamfrq, ngtcp2_ksl_int64_less,
+                  ngtcp2_ksl_int64_less_search, sizeof(uint64_t), strm->mem);
 
   strm->tx.streamfrq = streamfrq;
 

--- a/tests/ngtcp2_ksl_test.c
+++ b/tests/ngtcp2_ksl_test.c
@@ -43,10 +43,6 @@ const MunitSuite ksl_suite = {
   "/ksl", tests, NULL, 1, MUNIT_SUITE_OPTION_NONE,
 };
 
-static int less(const ngtcp2_ksl_key *lhs, const ngtcp2_ksl_key *rhs) {
-  return *(int64_t *)lhs < *(int64_t *)rhs;
-}
-
 void test_ngtcp2_ksl_insert(void) {
   static const int64_t keys[] = {10, 3,  8, 11, 16, 12, 1, 5, 4,
                                  0,  13, 7, 9,  2,  14, 6, 15};
@@ -56,7 +52,8 @@ void test_ngtcp2_ksl_insert(void) {
   ngtcp2_ksl_it it;
   int64_t k;
 
-  ngtcp2_ksl_init(&ksl, less, sizeof(int64_t), mem);
+  ngtcp2_ksl_init(&ksl, ngtcp2_ksl_int64_less, ngtcp2_ksl_int64_less_search,
+                  sizeof(int64_t), mem);
 
   for (i = 0; i < ngtcp2_arraylen(keys); ++i) {
     assert_int(0, ==, ngtcp2_ksl_insert(&ksl, NULL, &keys[i], NULL));
@@ -76,7 +73,8 @@ void test_ngtcp2_ksl_insert(void) {
   ngtcp2_ksl_free(&ksl);
 
   /* check the case that the right end range is removed */
-  ngtcp2_ksl_init(&ksl, less, sizeof(int64_t), mem);
+  ngtcp2_ksl_init(&ksl, ngtcp2_ksl_int64_less, ngtcp2_ksl_int64_less_search,
+                  sizeof(int64_t), mem);
 
   for (i = 0; i < 32; ++i) {
     k = (int64_t)i;
@@ -102,7 +100,8 @@ void test_ngtcp2_ksl_insert(void) {
   /* Check the case that the intermediate node contains smaller key
      than ancestor node.  Make sure that inserting key larger than
      that still works.*/
-  ngtcp2_ksl_init(&ksl, less, sizeof(int64_t), mem);
+  ngtcp2_ksl_init(&ksl, ngtcp2_ksl_int64_less, ngtcp2_ksl_int64_less_search,
+                  sizeof(int64_t), mem);
 
   for (i = 0; i < 760; ++i) {
     k = (int64_t)i;
@@ -125,7 +124,8 @@ void test_ngtcp2_ksl_insert(void) {
   ngtcp2_ksl_free(&ksl);
 
   /* check merge node (head) */
-  ngtcp2_ksl_init(&ksl, less, sizeof(int64_t), mem);
+  ngtcp2_ksl_init(&ksl, ngtcp2_ksl_int64_less, ngtcp2_ksl_int64_less_search,
+                  sizeof(int64_t), mem);
 
   for (i = 0; i < 32; ++i) {
     k = (int64_t)i;
@@ -145,7 +145,8 @@ void test_ngtcp2_ksl_insert(void) {
   ngtcp2_ksl_free(&ksl);
 
   /* check merge node (non head) */
-  ngtcp2_ksl_init(&ksl, less, sizeof(int64_t), mem);
+  ngtcp2_ksl_init(&ksl, ngtcp2_ksl_int64_less, ngtcp2_ksl_int64_less_search,
+                  sizeof(int64_t), mem);
 
   for (i = 0; i < 32 + 18; ++i) {
     k = (int64_t)i;
@@ -167,7 +168,8 @@ void test_ngtcp2_ksl_insert(void) {
   ngtcp2_ksl_free(&ksl);
 
   /* Iterate backwards */
-  ngtcp2_ksl_init(&ksl, less, sizeof(int64_t), mem);
+  ngtcp2_ksl_init(&ksl, ngtcp2_ksl_int64_less, ngtcp2_ksl_int64_less_search,
+                  sizeof(int64_t), mem);
 
   /* split nodes */
   for (i = 0; i < 100; ++i) {
@@ -211,7 +213,8 @@ void test_ngtcp2_ksl_clear(void) {
   size_t i;
   int64_t k;
 
-  ngtcp2_ksl_init(&ksl, less, sizeof(int64_t), mem);
+  ngtcp2_ksl_init(&ksl, ngtcp2_ksl_int64_less, ngtcp2_ksl_int64_less_search,
+                  sizeof(int64_t), mem);
 
   for (i = 0; i < 100; ++i) {
     k = (int64_t)i;
@@ -248,12 +251,13 @@ void test_ngtcp2_ksl_range(void) {
   ngtcp2_ksl_it it;
   ngtcp2_ksl_node *node;
 
-  ngtcp2_ksl_init(&ksl, ngtcp2_ksl_range_compar, sizeof(ngtcp2_range), mem);
+  ngtcp2_ksl_init(&ksl, ngtcp2_ksl_range_compar, ngtcp2_ksl_range_search,
+                  sizeof(ngtcp2_range), mem);
 
   for (i = 0; i < ngtcp2_arraylen(keys); ++i) {
     assert_int(0, ==, ngtcp2_ksl_insert(&ksl, NULL, &keys[i], NULL));
-    it = ngtcp2_ksl_lower_bound_compar(&ksl, &keys[i],
-                                       ngtcp2_ksl_range_exclusive_compar);
+    it = ngtcp2_ksl_lower_bound_search(&ksl, &keys[i],
+                                       ngtcp2_ksl_range_exclusive_search);
     r = *(ngtcp2_range *)ngtcp2_ksl_it_key(&it);
 
     assert_true(ngtcp2_range_eq(&keys[i], &r));
@@ -261,8 +265,8 @@ void test_ngtcp2_ksl_range(void) {
 
   for (i = 0; i < ngtcp2_arraylen(keys); ++i) {
     assert_int(0, ==, ngtcp2_ksl_remove(&ksl, NULL, &keys[i]));
-    it = ngtcp2_ksl_lower_bound_compar(&ksl, &keys[i],
-                                       ngtcp2_ksl_range_exclusive_compar);
+    it = ngtcp2_ksl_lower_bound_search(&ksl, &keys[i],
+                                       ngtcp2_ksl_range_exclusive_search);
 
     if (!ngtcp2_ksl_it_end(&it)) {
       r = *(ngtcp2_range *)ngtcp2_ksl_it_key(&it);
@@ -274,7 +278,8 @@ void test_ngtcp2_ksl_range(void) {
   ngtcp2_ksl_free(&ksl);
 
   /* check merge node (head) */
-  ngtcp2_ksl_init(&ksl, ngtcp2_ksl_range_compar, sizeof(ngtcp2_range), mem);
+  ngtcp2_ksl_init(&ksl, ngtcp2_ksl_range_compar, ngtcp2_ksl_range_search,
+                  sizeof(ngtcp2_range), mem);
 
   for (i = 0; i < 32; ++i) {
     ngtcp2_range_init(&r, i, i + 1);
@@ -296,7 +301,8 @@ void test_ngtcp2_ksl_range(void) {
   ngtcp2_ksl_free(&ksl);
 
   /* check merge node (non head) */
-  ngtcp2_ksl_init(&ksl, ngtcp2_ksl_range_compar, sizeof(ngtcp2_range), mem);
+  ngtcp2_ksl_init(&ksl, ngtcp2_ksl_range_compar, ngtcp2_ksl_range_search,
+                  sizeof(ngtcp2_range), mem);
 
   for (i = 0; i < 32 + 18; ++i) {
     ngtcp2_range_init(&r, i, i + 1);
@@ -320,7 +326,8 @@ void test_ngtcp2_ksl_range(void) {
   ngtcp2_ksl_free(&ksl);
 
   /* shift_left */
-  ngtcp2_ksl_init(&ksl, ngtcp2_ksl_range_compar, sizeof(ngtcp2_range), mem);
+  ngtcp2_ksl_init(&ksl, ngtcp2_ksl_range_compar, ngtcp2_ksl_range_search,
+                  sizeof(ngtcp2_range), mem);
 
   for (i = 1; i < 6400; i += 100) {
     ngtcp2_range_init(&r, i, i + 1);
@@ -341,7 +348,8 @@ void test_ngtcp2_ksl_range(void) {
   ngtcp2_ksl_free(&ksl);
 
   /* shift_right */
-  ngtcp2_ksl_init(&ksl, ngtcp2_ksl_range_compar, sizeof(ngtcp2_range), mem);
+  ngtcp2_ksl_init(&ksl, ngtcp2_ksl_range_compar, ngtcp2_ksl_range_search,
+                  sizeof(ngtcp2_range), mem);
 
   for (i = 0; i < 32; ++i) {
     ngtcp2_range_init(&r, i, i + 1);
@@ -374,7 +382,8 @@ void test_ngtcp2_ksl_update_key_range(void) {
   ngtcp2_range r;
   ngtcp2_ksl_it it;
 
-  ngtcp2_ksl_init(&ksl, ngtcp2_ksl_range_compar, sizeof(ngtcp2_range), mem);
+  ngtcp2_ksl_init(&ksl, ngtcp2_ksl_range_compar, ngtcp2_ksl_range_search,
+                  sizeof(ngtcp2_range), mem);
 
   for (i = 0; i < ngtcp2_arraylen(ranges); ++i) {
     assert_int(0, ==, ngtcp2_ksl_insert(&ksl, NULL, &ranges[i], NULL));
@@ -395,7 +404,7 @@ void test_ngtcp2_ksl_update_key_range(void) {
   r.begin = 74;
   r.end = 75;
   it =
-    ngtcp2_ksl_lower_bound_compar(&ksl, &r, ngtcp2_ksl_range_exclusive_compar);
+    ngtcp2_ksl_lower_bound_search(&ksl, &r, ngtcp2_ksl_range_exclusive_search);
 
   r = *(ngtcp2_range *)ngtcp2_ksl_it_key(&it);
 
@@ -429,7 +438,8 @@ void test_ngtcp2_ksl_dup(void) {
   }
 
   for (j = 0; j < 10; ++j) {
-    ngtcp2_ksl_init(&ksl, less, sizeof(int64_t), mem);
+    ngtcp2_ksl_init(&ksl, ngtcp2_ksl_int64_less, ngtcp2_ksl_int64_less_search,
+                    sizeof(int64_t), mem);
 
     shuffle(keys, ngtcp2_arraylen(keys));
 
@@ -487,7 +497,8 @@ void test_ngtcp2_ksl_remove_hint(void) {
   }
 
   for (j = 0; j < 10; ++j) {
-    ngtcp2_ksl_init(&ksl, less, sizeof(int64_t), mem);
+    ngtcp2_ksl_init(&ksl, ngtcp2_ksl_int64_less, ngtcp2_ksl_int64_less_search,
+                    sizeof(int64_t), mem);
 
     shuffle(keys, ngtcp2_arraylen(keys));
 


### PR DESCRIPTION
Introduce ngtcp2_ksl_search to inline ngtcp2_ksl_compar that aims to reduce overhead.