### PR TITLE
Loosen app-limited condition

### DIFF
--- a/lib/ngtcp2_conn.c
+++ b/lib/ngtcp2_conn.c
@@ -11724,7 +11724,10 @@ static ngtcp2_ssize conn_write_vmsg_wrapper(ngtcp2_conn *conn,
 
   if (cstat->bytes_in_flight >= cstat->cwnd) {
     conn->rst.is_cwnd_limited = 1;
-  } else if (nwrite == 0 && conn_pacing_pkt_tx_allowed(conn, ts)) {
+  } else if ((cstat->cwnd >= cstat->ssthresh ||
+              cstat->bytes_in_flight * 2 < cstat->cwnd) &&
+             nwrite == 0 && conn_pacing_pkt_tx_allowed(conn, ts) &&
+             (conn->flags & NGTCP2_CONN_FLAG_HANDSHAKE_COMPLETED)) {
     conn->rst.app_limited = conn->rst.delivered + cstat->bytes_in_flight;
 
     if (conn->rst.app_limited == 0) {


### PR DESCRIPTION
As TCP Linux does, during slow-start, only enter app-limited when less than half of CWND is used.  Also do not enter app-limited during handshake because we have not that much to send in that state, and it would be nicer to warm up CWND with handshake bytes for the upcoming application traffic.