### PR TITLE
Remove outdated PMTUD probe packet handling when it is lost

### DIFF
--- a/lib/ngtcp2_rtb.c
+++ b/lib/ngtcp2_rtb.c
@@ -1287,14 +1287,6 @@ static int rtb_on_pkt_lost_resched_move(ngtcp2_rtb *rtb, ngtcp2_conn *conn,
     return 0;
   }
 
-  if (ent->flags & NGTCP2_RTB_ENTRY_FLAG_PMTUD_PROBE) {
-    ngtcp2_log_info(rtb->log, NGTCP2_LOG_EVENT_LDC,
-                    "pkn=%" PRId64
-                    " is a PMTUD probe packet, no retransmission is necessary",
-                    ent->hd.pkt_num);
-    return 0;
-  }
-
   if (ent->flags & NGTCP2_RTB_ENTRY_FLAG_LOST_RETRANSMITTED) {
     --rtb->num_lost_pkts;
 


### PR DESCRIPTION
It seems this is an oversight in
cbd6f5815c0c6e8ae8040e1ce255103f3ff3cc6a.  This relevant part of code should have been removed in that commit.  Because this function is only called when Retry packet is received, and PMTUD packet is not sent in this phase, this extra code should not cause any issue.