### PR TITLE
Remove len parameter from ngtcp2_pkt_hd_init

### DIFF
--- a/lib/ngtcp2_conn.c
+++ b/lib/ngtcp2_conn.c
@@ -2280,7 +2280,7 @@ conn_write_handshake_pkt(ngtcp2_conn *conn, ngtcp2_pkt_info *pi, uint8_t *dest,
 
   ngtcp2_pkt_hd_init(
     &hd, conn_pkt_flags_long(conn), type, &conn->dcid.current.cid, &conn->oscid,
-    pktns->tx.last_pkt_num + 1, pktns_select_pkt_numlen(pktns), version, 0);
+    pktns->tx.last_pkt_num + 1, pktns_select_pkt_numlen(pktns), version);
 
   if (!conn->server && type == NGTCP2_PKT_INITIAL &&
       conn->local.settings.tokenlen) {
@@ -3376,7 +3376,7 @@ static ngtcp2_ssize conn_write_pkt(ngtcp2_conn *conn, ngtcp2_pkt_info *pi,
 
     ngtcp2_pkt_hd_init(hd, hd_flags, type, &conn->dcid.current.cid, scid,
                        pktns->tx.last_pkt_num + 1,
-                       pktns_select_pkt_numlen(pktns), version, 0);
+                       pktns_select_pkt_numlen(pktns), version);
 
     ngtcp2_ppe_init(ppe, dest, destlen, dgram_offset, cc);
 
@@ -4342,7 +4342,7 @@ ngtcp2_ssize ngtcp2_conn_write_single_frame_pkt(
 
   ngtcp2_pkt_hd_init(&hd, hd_flags, type, dcid, scid,
                      pktns->tx.last_pkt_num + 1, pktns_select_pkt_numlen(pktns),
-                     version, 0);
+                     version);
 
   ngtcp2_ppe_init(&ppe, dest, destlen, 0, &cc);
 
@@ -13737,8 +13737,7 @@ ngtcp2_ssize ngtcp2_pkt_write_connection_close(
   int rv;
 
   ngtcp2_pkt_hd_init(&hd, NGTCP2_PKT_FLAG_LONG_FORM, NGTCP2_PKT_INITIAL, dcid,
-                     scid, /* pkt_num = */ 0, /* pkt_numlen = */ 1, version,
-                     /* len = */ 0);
+                     scid, /* pkt_num = */ 0, /* pkt_numlen = */ 1, version);
 
   ngtcp2_vec_init(&ckm.secret, NULL, 0);
   ngtcp2_vec_init(&ckm.iv, iv, 12);

--- a/lib/ngtcp2_pkt.c
+++ b/lib/ngtcp2_pkt.c
@@ -145,8 +145,7 @@ int ngtcp2_pkt_decode_version_cid(ngtcp2_version_cid *dest, const uint8_t *data,
 
 void ngtcp2_pkt_hd_init(ngtcp2_pkt_hd *hd, uint8_t flags, uint8_t type,
                         const ngtcp2_cid *dcid, const ngtcp2_cid *scid,
-                        int64_t pkt_num, size_t pkt_numlen, uint32_t version,
-                        size_t len) {
+                        int64_t pkt_num, size_t pkt_numlen, uint32_t version) {
   hd->flags = flags;
   hd->type = type;
 
@@ -167,7 +166,7 @@ void ngtcp2_pkt_hd_init(ngtcp2_pkt_hd *hd, uint8_t flags, uint8_t type,
   hd->tokenlen = 0;
   hd->pkt_numlen = pkt_numlen;
   hd->version = version;
-  hd->len = len;
+  hd->len = 0;
 }
 
 ngtcp2_ssize ngtcp2_pkt_decode_hd_long(ngtcp2_pkt_hd *dest, const uint8_t *pkt,
@@ -2285,8 +2284,7 @@ ngtcp2_ssize ngtcp2_pkt_write_retry(
   }
 
   ngtcp2_pkt_hd_init(&hd, NGTCP2_PKT_FLAG_LONG_FORM, NGTCP2_PKT_RETRY, dcid,
-                     scid, /* pkt_num = */ 0, /* pkt_numlen = */ 1, version,
-                     /* len = */ 0);
+                     scid, /* pkt_num = */ 0, /* pkt_numlen = */ 1, version);
 
   pseudo_retrylen =
     ngtcp2_pkt_encode_pseudo_retry(pseudo_retry, sizeof(pseudo_retry), &hd,

--- a/lib/ngtcp2_pkt.h
+++ b/lib/ngtcp2_pkt.h
@@ -407,13 +407,11 @@ void ngtcp2_pkt_chain_del(ngtcp2_pkt_chain *pc, const ngtcp2_mem *mem);
  * |dcid| and/or |scid| is NULL, Destination Connection ID and/or
  * Source Connection ID of |hd| is empty respectively.  |pkt_numlen|
  * is the number of bytes used to encode |pkt_num| and either 1, 2, or
- * 4.  |version| is QUIC version for long header.  |len| is the length
- * field of Initial, 0RTT, and Handshake packets.
+ * 4.  |version| is QUIC version for long header.
  */
 void ngtcp2_pkt_hd_init(ngtcp2_pkt_hd *hd, uint8_t flags, uint8_t type,
                         const ngtcp2_cid *dcid, const ngtcp2_cid *scid,
-                        int64_t pkt_num, size_t pkt_numlen, uint32_t version,
-                        size_t len);
+                        int64_t pkt_num, size_t pkt_numlen, uint32_t version);
 
 /*
  * ngtcp2_pkt_encode_hd_long encodes |hd| as QUIC long header into

--- a/tests/ngtcp2_pkt_test.c
+++ b/tests/ngtcp2_pkt_test.c
@@ -295,7 +295,8 @@ void test_ngtcp2_pkt_decode_hd_long(void) {
 
   /* Handshake */
   ngtcp2_pkt_hd_init(&hd, NGTCP2_PKT_FLAG_LONG_FORM, NGTCP2_PKT_HANDSHAKE,
-                     &dcid, &scid, 0xe1e2e3e4u, 4, NGTCP2_PROTO_VER_V1, 16383);
+                     &dcid, &scid, 0xe1e2e3e4u, 4, NGTCP2_PROTO_VER_V1);
+  hd.len = 16383;
 
   rv = ngtcp2_pkt_encode_hd_long(buf, sizeof(buf), &hd);
 
@@ -325,8 +326,8 @@ void test_ngtcp2_pkt_decode_hd_long(void) {
   /* Handshake without Fixed Bit set */
   ngtcp2_pkt_hd_init(
     &hd, NGTCP2_PKT_FLAG_LONG_FORM | NGTCP2_PKT_FLAG_FIXED_BIT_CLEAR,
-    NGTCP2_PKT_HANDSHAKE, &dcid, &scid, 0xe1e2e3e4u, 4, NGTCP2_PROTO_VER_V1,
-    16383);
+    NGTCP2_PKT_HANDSHAKE, &dcid, &scid, 0xe1e2e3e4u, 4, NGTCP2_PROTO_VER_V1);
+  hd.len = 16383;
 
   rv = ngtcp2_pkt_encode_hd_long(buf, sizeof(buf), &hd);
 
@@ -356,7 +357,7 @@ void test_ngtcp2_pkt_decode_hd_long(void) {
   /* VN */
   /* Set random packet type */
   ngtcp2_pkt_hd_init(&hd, NGTCP2_PKT_FLAG_LONG_FORM, NGTCP2_PKT_HANDSHAKE,
-                     &dcid, &scid, 0, 4, NGTCP2_PROTO_VER_V1, 0);
+                     &dcid, &scid, 0, 4, NGTCP2_PROTO_VER_V1);
 
   rv = ngtcp2_pkt_encode_hd_long(buf, sizeof(buf), &hd);
   /* Set version field to 0 */
@@ -399,7 +400,7 @@ void test_ngtcp2_pkt_decode_hd_short(void) {
 
   /* 4 bytes packet number */
   ngtcp2_pkt_hd_init(&hd, NGTCP2_PKT_FLAG_NONE, NGTCP2_PKT_1RTT, &dcid, NULL,
-                     0xe1e2e3e4u, 4, 0xd1d2d3d4u, 0);
+                     0xe1e2e3e4u, 4, 0xd1d2d3d4u);
 
   expectedlen = 1 + dcid.datalen + 4;
 
@@ -428,9 +429,9 @@ void test_ngtcp2_pkt_decode_hd_short(void) {
   }
 
   /* 4 bytes packet number without Fixed Bit set */
-  ngtcp2_pkt_hd_init(
-    &hd, NGTCP2_PKT_FLAG_NONE | NGTCP2_PKT_FLAG_FIXED_BIT_CLEAR,
-    NGTCP2_PKT_1RTT, &dcid, NULL, 0xe1e2e3e4u, 4, 0xd1d2d3d4u, 0);
+  ngtcp2_pkt_hd_init(&hd,
+                     NGTCP2_PKT_FLAG_NONE | NGTCP2_PKT_FLAG_FIXED_BIT_CLEAR,
+                     NGTCP2_PKT_1RTT, &dcid, NULL, 0xe1e2e3e4u, 4, 0xd1d2d3d4u);
 
   expectedlen = 1 + dcid.datalen + 4;
 
@@ -460,7 +461,7 @@ void test_ngtcp2_pkt_decode_hd_short(void) {
 
   /* 2 bytes packet number */
   ngtcp2_pkt_hd_init(&hd, NGTCP2_PKT_FLAG_NONE, NGTCP2_PKT_1RTT, &dcid, NULL,
-                     0xe1e2e3e4u, 2, 0xd1d2d3d4u, 0);
+                     0xe1e2e3e4u, 2, 0xd1d2d3d4u);
 
   expectedlen = 1 + dcid.datalen + 2;
 
@@ -489,7 +490,7 @@ void test_ngtcp2_pkt_decode_hd_short(void) {
 
   /* 1 byte packet number */
   ngtcp2_pkt_hd_init(&hd, NGTCP2_PKT_FLAG_NONE, NGTCP2_PKT_1RTT, &dcid, NULL,
-                     0xe1e2e3e4u, 1, 0xd1d2d3d4u, 0);
+                     0xe1e2e3e4u, 1, 0xd1d2d3d4u);
 
   expectedlen = 1 + dcid.datalen + 1;
 
@@ -518,7 +519,7 @@ void test_ngtcp2_pkt_decode_hd_short(void) {
 
   /* With Key Phase */
   ngtcp2_pkt_hd_init(&hd, NGTCP2_PKT_FLAG_KEY_PHASE, NGTCP2_PKT_1RTT, &dcid,
-                     NULL, 0xe1e2e3e4u, 4, 0xd1d2d3d4u, 0);
+                     NULL, 0xe1e2e3e4u, 4, 0xd1d2d3d4u);
 
   expectedlen = 1 + dcid.datalen + 4;
 
@@ -549,7 +550,7 @@ void test_ngtcp2_pkt_decode_hd_short(void) {
 
   /* With empty DCID */
   ngtcp2_pkt_hd_init(&hd, NGTCP2_PKT_FLAG_NONE, NGTCP2_PKT_1RTT, NULL, NULL,
-                     0xe1e2e3e4u, 4, 0xd1d2d3d4u, 0);
+                     0xe1e2e3e4u, 4, 0xd1d2d3d4u);
 
   expectedlen = 1 + 4;
 

--- a/tests/ngtcp2_rtb_test.c
+++ b/tests/ngtcp2_rtb_test.c
@@ -78,7 +78,7 @@ void test_ngtcp2_rtb_add(void) {
                   &frc_objalloc, mem);
 
   ngtcp2_pkt_hd_init(&hd, NGTCP2_PKT_FLAG_NONE, NGTCP2_PKT_1RTT, &dcid, NULL,
-                     1000000007, 1, NGTCP2_PROTO_VER_V1, 0);
+                     1000000007, 1, NGTCP2_PROTO_VER_V1);
 
   rv = ngtcp2_rtb_entry_objalloc_new(
     &ent, &hd, NULL, 10, 0, NGTCP2_RTB_ENTRY_FLAG_NONE, &rtb_entry_objalloc);
@@ -88,7 +88,7 @@ void test_ngtcp2_rtb_add(void) {
   ngtcp2_rtb_add(&rtb, ent, &cstat);
 
   ngtcp2_pkt_hd_init(&hd, NGTCP2_PKT_FLAG_NONE, NGTCP2_PKT_1RTT, &dcid, NULL,
-                     1000000008, 2, NGTCP2_PROTO_VER_V1, 0);
+                     1000000008, 2, NGTCP2_PROTO_VER_V1);
 
   rv = ngtcp2_rtb_entry_objalloc_new(
     &ent, &hd, NULL, 9, 0, NGTCP2_RTB_ENTRY_FLAG_NONE, &rtb_entry_objalloc);
@@ -98,7 +98,7 @@ void test_ngtcp2_rtb_add(void) {
   ngtcp2_rtb_add(&rtb, ent, &cstat);
 
   ngtcp2_pkt_hd_init(&hd, NGTCP2_PKT_FLAG_NONE, NGTCP2_PKT_1RTT, &dcid, NULL,
-                     1000000009, 4, NGTCP2_PROTO_VER_V1, 0);
+                     1000000009, 4, NGTCP2_PROTO_VER_V1);
 
   rv = ngtcp2_rtb_entry_objalloc_new(
     &ent, &hd, NULL, 11, 0, NGTCP2_RTB_ENTRY_FLAG_NONE, &rtb_entry_objalloc);
@@ -145,7 +145,7 @@ static void add_rtb_entry_range(ngtcp2_rtb *rtb, int64_t base_pkt_num,
 
   for (i = 0; i < len; ++i) {
     ngtcp2_pkt_hd_init(&hd, NGTCP2_PKT_FLAG_NONE, NGTCP2_PKT_1RTT, &dcid, NULL,
-                       base_pkt_num + (int64_t)i, 1, NGTCP2_PROTO_VER_V1, 0);
+                       base_pkt_num + (int64_t)i, 1, NGTCP2_PROTO_VER_V1);
     ngtcp2_rtb_entry_objalloc_new(&ent, &hd, NULL, 0, 0,
                                   NGTCP2_RTB_ENTRY_FLAG_NONE, objalloc);
     ngtcp2_rtb_add(rtb, ent, cstat);
@@ -193,7 +193,7 @@ void test_ngtcp2_rtb_recv_ack(void) {
 
   ngtcp2_log_init(&log, NULL, NULL, 0, NULL);
   ngtcp2_pkt_hd_init(&hd, NGTCP2_PKT_FLAG_NONE, NGTCP2_PKT_1RTT, NULL, NULL, 0,
-                     1, NGTCP2_PROTO_VER_V1, 0);
+                     1, NGTCP2_PROTO_VER_V1);
   pktns.id = NGTCP2_PKTNS_ID_HANDSHAKE;
 
   /* no ack block */

--- a/tests/ngtcp2_test_helper.c
+++ b/tests/ngtcp2_test_helper.c
@@ -134,7 +134,7 @@ static size_t write_short_pkt(uint8_t *out, size_t outlen, uint8_t flags,
   cc.aead.max_overhead = NGTCP2_FAKE_AEAD_OVERHEAD;
 
   ngtcp2_pkt_hd_init(&hd, flags, NGTCP2_PKT_1RTT, dcid, NULL, pkt_num, 4,
-                     NGTCP2_PROTO_VER_V1, 0);
+                     NGTCP2_PROTO_VER_V1);
 
   ngtcp2_ppe_init(&ppe, out, outlen, 0, &cc);
   rv = ngtcp2_ppe_encode_hd(&ppe, &hd);
@@ -193,8 +193,7 @@ static size_t write_long_pkt(uint8_t *out, size_t outlen, uint8_t flags,
     &hd, NGTCP2_PKT_FLAG_LONG_FORM | flags, pkt_type, dcid, scid, pkt_num, 4,
     version != NGTCP2_PROTO_VER_V1 && version != NGTCP2_PROTO_VER_V2
       ? NGTCP2_PROTO_VER_V1
-      : version,
-    0);
+      : version);
 
   hd.token = token;
   hd.tokenlen = tokenlen;


### PR DESCRIPTION
len parameter is always 0 in the production library code.  It is only used in unit tests.  Best to optimize to the production code usage.