### PR TITLE
tests: ngtcp2_transport_params_test: fix uninitialized variable

### DIFF
--- a/tests/ngtcp2_transport_params_test.c
+++ b/tests/ngtcp2_transport_params_test.c
@@ -417,7 +417,7 @@ void test_ngtcp2_transport_params_convert_to_latest(void) {
   const ngtcp2_transport_params *dest;
   size_t v1len;
   ngtcp2_cid rcid, scid, dcid;
-  uint8_t available_versions[sizeof(uint32_t) * 3];
+  uint8_t available_versions[sizeof(uint32_t) * 3] = {};
   ngtcp2_sockaddr_in6 *sa_in6;
 
   rcid_init(&rcid);


### PR DESCRIPTION
I noticed this when investigating another problem (still in-progress).

The test does:
```
  uint8_t available_versions[sizeof(uint32_t) * 3] = {};
[...]
  srcbuf.version_info.available_versions = available_versions;
  srcbuf.version_info.available_versionslen =
    ngtcp2_arraylen(available_versions);
[...]
   assert_memory_equal(srcbuf.version_info.available_versionslen,
	srcbuf.version_info.available_versions,
	dest->version_info.available_versions);
```

Reproted by Valgrind.

Bug: https://bugs.gentoo.org/947300 (comment 4)