### PR TITLE
Extract code around Destination Connection ID to ngtcp2_dcidtr

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -67,6 +67,7 @@ set(ngtcp2_SOURCES
   ngtcp2_unreachable.c
   ngtcp2_transport_params.c
   ngtcp2_settings.c
+  ngtcp2_dcidtr.c
 )
 
 set(ngtcp2_INCLUDE_DIRS

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -74,7 +74,8 @@ OBJECTS = \
 	ngtcp2_objalloc.c \
 	ngtcp2_unreachable.c \
 	ngtcp2_transport_params.c \
-	ngtcp2_settings.c
+	ngtcp2_settings.c \
+	ngtcp2_dcidtr.c
 
 HFILES = \
 	ngtcp2_pkt.h \
@@ -119,6 +120,7 @@ HFILES = \
 	ngtcp2_unreachable.h \
 	ngtcp2_transport_params.h \
 	ngtcp2_settings.h \
+	ngtcp2_dcidtr.h \
 	ngtcp2_conn_stat.h \
 	ngtcp2_pktns_id.h \
 	ngtcp2_tstamp.h

--- a/lib/ngtcp2_cid.c
+++ b/lib/ngtcp2_cid.c
@@ -141,8 +141,10 @@ int ngtcp2_dcid_verify_uniqueness(const ngtcp2_dcid *dcid, uint64_t seq,
 }
 
 int ngtcp2_dcid_verify_stateless_reset_token(const ngtcp2_dcid *dcid,
+                                             const ngtcp2_path *path,
                                              const uint8_t *token) {
-  return (dcid->flags & NGTCP2_DCID_FLAG_TOKEN_PRESENT) &&
+  return ngtcp2_path_eq(&dcid->ps.path, path) &&
+             (dcid->flags & NGTCP2_DCID_FLAG_TOKEN_PRESENT) &&
              ngtcp2_cmemeq(dcid->token, token, NGTCP2_STATELESS_RESET_TOKENLEN)
            ? 0
            : NGTCP2_ERR_INVALID_ARGUMENT;

--- a/lib/ngtcp2_cid.h
+++ b/lib/ngtcp2_cid.h
@@ -162,15 +162,16 @@ int ngtcp2_dcid_verify_uniqueness(const ngtcp2_dcid *dcid, uint64_t seq,
 
 /*
  * ngtcp2_dcid_verify_stateless_reset_token verifies stateless reset
- * token |token| against the one included in |dcid|.  Tokens are
- * compared in constant time.  This function returns 0 if the
- * verification succeeds, or one of the following negative error
- * codes:
+ * token |token| received on |path| against the one included in
+ * |dcid|.  Tokens are compared in constant time.  This function
+ * returns 0 if the verification succeeds, or one of the following
+ * negative error codes:
  *
  * NGTCP2_ERR_INVALID_ARGUMENT
  *     Tokens do not match; or |dcid| does not contain a token.
  */
 int ngtcp2_dcid_verify_stateless_reset_token(const ngtcp2_dcid *dcid,
+                                             const ngtcp2_path *path,
                                              const uint8_t *token);
 
 #endif /* !defined(NGTCP2_CID_H) */

--- a/lib/ngtcp2_dcidtr.c
+++ b/lib/ngtcp2_dcidtr.c
@@ -1,0 +1,497 @@
+/*
+ * ngtcp2
+ *
+ * Copyright (c) 2025 ngtcp2 contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+#include "ngtcp2_dcidtr.h"
+
+#include <assert.h>
+
+#include "ngtcp2_tstamp.h"
+#include "ngtcp2_macro.h"
+
+void ngtcp2_dcidtr_init(ngtcp2_dcidtr *dtr) {
+  ngtcp2_static_ringbuf_dcid_unused_init(&dtr->unused);
+  ngtcp2_static_ringbuf_dcid_bound_init(&dtr->bound);
+  ngtcp2_static_ringbuf_dcid_retired_init(&dtr->retired);
+
+  dtr->zerolen_seq = 0;
+  dtr->retire_unacked.len = 0;
+}
+
+int ngtcp2_dcidtr_track_retired_seq(ngtcp2_dcidtr *dtr, uint64_t seq) {
+  if (dtr->retire_unacked.len >= ngtcp2_arraylen(dtr->retire_unacked.seqs)) {
+    return NGTCP2_ERR_CONNECTION_ID_LIMIT;
+  }
+
+  dtr->retire_unacked.seqs[dtr->retire_unacked.len++] = seq;
+
+  return 0;
+}
+
+void ngtcp2_dcidtr_untrack_retired_seq(ngtcp2_dcidtr *dtr, uint64_t seq) {
+  size_t i;
+
+  for (i = 0; i < dtr->retire_unacked.len; ++i) {
+    if (dtr->retire_unacked.seqs[i] != seq) {
+      continue;
+    }
+
+    if (i != dtr->retire_unacked.len - 1) {
+      dtr->retire_unacked.seqs[i] =
+        dtr->retire_unacked.seqs[dtr->retire_unacked.len - 1];
+    }
+
+    --dtr->retire_unacked.len;
+
+    return;
+  }
+}
+
+int ngtcp2_dcidtr_check_retired_seq_tracked(const ngtcp2_dcidtr *dtr,
+                                            uint64_t seq) {
+  size_t i;
+
+  for (i = 0; i < dtr->retire_unacked.len; ++i) {
+    if (dtr->retire_unacked.seqs[i] == seq) {
+      return 1;
+    }
+  }
+
+  return 0;
+}
+
+static int dcidtr_on_retire(ngtcp2_dcidtr *dtr, const ngtcp2_dcid *dcid,
+                            ngtcp2_dcidtr_cb on_retire, void *user_data) {
+  int rv;
+
+  if (ngtcp2_dcidtr_check_retired_seq_tracked(dtr, dcid->seq)) {
+    return 0;
+  }
+
+  rv = ngtcp2_dcidtr_track_retired_seq(dtr, dcid->seq);
+  if (rv != 0) {
+    return rv;
+  }
+
+  if (!on_retire) {
+    return 0;
+  }
+
+  return on_retire(dcid, user_data);
+}
+
+ngtcp2_dcid *ngtcp2_dcidtr_find_bound_dcid(const ngtcp2_dcidtr *dtr,
+                                           const ngtcp2_path *path) {
+  ngtcp2_dcid *dcid;
+  const ngtcp2_ringbuf *rb = &dtr->bound.rb;
+  size_t i, len = ngtcp2_ringbuf_len(rb);
+
+  for (i = 0; i < len; ++i) {
+    dcid = ngtcp2_ringbuf_get(rb, i);
+
+    if (ngtcp2_path_eq(&dcid->ps.path, path)) {
+      return dcid;
+    }
+  }
+
+  return NULL;
+}
+
+ngtcp2_dcid *ngtcp2_dcidtr_bind_zerolen_dcid(ngtcp2_dcidtr *dtr,
+                                             const ngtcp2_path *path) {
+  ngtcp2_dcid *dcid = ngtcp2_ringbuf_push_back(&dtr->bound.rb);
+  ngtcp2_cid cid;
+
+  ngtcp2_cid_zero(&cid);
+  ngtcp2_dcid_init(dcid, ++dtr->zerolen_seq, &cid, NULL);
+  ngtcp2_dcid_set_path(dcid, path);
+
+  return dcid;
+}
+
+int ngtcp2_dcidtr_bind_dcid(ngtcp2_dcidtr *dtr, ngtcp2_dcid **pdest,
+                            const ngtcp2_path *path, ngtcp2_tstamp ts,
+                            ngtcp2_dcidtr_cb on_retire, void *user_data) {
+  const ngtcp2_dcid *src;
+  ngtcp2_dcid *dest;
+  int rv;
+
+  if (ngtcp2_ringbuf_full(&dtr->bound.rb)) {
+    rv = dcidtr_on_retire(dtr, ngtcp2_ringbuf_get(&dtr->bound.rb, 0), on_retire,
+                          user_data);
+    if (rv != 0) {
+      return rv;
+    }
+  }
+
+  src = ngtcp2_ringbuf_get(&dtr->unused.rb, 0);
+  dest = ngtcp2_ringbuf_push_back(&dtr->bound.rb);
+
+  ngtcp2_dcid_copy(dest, src);
+  dest->bound_ts = ts;
+  ngtcp2_dcid_set_path(dest, path);
+
+  ngtcp2_ringbuf_pop_front(&dtr->unused.rb);
+
+  *pdest = dest;
+
+  return 0;
+}
+
+static int verify_stateless_reset(const ngtcp2_ringbuf *rb,
+                                  const ngtcp2_path *path,
+                                  const uint8_t *token) {
+  const ngtcp2_dcid *dcid;
+  size_t i, len = ngtcp2_ringbuf_len(rb);
+
+  for (i = 0; i < len; ++i) {
+    dcid = ngtcp2_ringbuf_get(rb, i);
+    if (ngtcp2_dcid_verify_stateless_reset_token(dcid, path, token) == 0) {
+      return 0;
+    }
+  }
+
+  return NGTCP2_ERR_INVALID_ARGUMENT;
+}
+
+int ngtcp2_dcidtr_verify_stateless_reset(const ngtcp2_dcidtr *dtr,
+                                         const ngtcp2_path *path,
+                                         const uint8_t *token) {
+  int rv;
+
+  rv = verify_stateless_reset(&dtr->retired.rb, path, token);
+  if (rv == 0) {
+    return 0;
+  }
+
+  return verify_stateless_reset(&dtr->bound.rb, path, token);
+}
+
+static int verify_token_uniqueness(const ngtcp2_ringbuf *rb, int *pfound,
+                                   uint64_t seq, const ngtcp2_cid *cid,
+                                   const uint8_t *token) {
+  const ngtcp2_dcid *dcid;
+  size_t i, len = ngtcp2_ringbuf_len(rb);
+  int rv;
+
+  for (i = 0; i < len; ++i) {
+    dcid = ngtcp2_ringbuf_get(rb, i);
+    rv = ngtcp2_dcid_verify_uniqueness(dcid, seq, cid, token);
+    if (rv != 0) {
+      return NGTCP2_ERR_PROTO;
+    }
+
+    if (ngtcp2_cid_eq(&dcid->cid, cid)) {
+      *pfound = 1;
+    }
+  }
+
+  return 0;
+}
+
+int ngtcp2_dcidtr_verify_token_uniqueness(const ngtcp2_dcidtr *dtr, int *pfound,
+                                          uint64_t seq, const ngtcp2_cid *cid,
+                                          const uint8_t *token) {
+  int rv;
+
+  rv = verify_token_uniqueness(&dtr->bound.rb, pfound, seq, cid, token);
+  if (rv != 0) {
+    return rv;
+  }
+
+  return verify_token_uniqueness(&dtr->unused.rb, pfound, seq, cid, token);
+}
+
+static void remove_dcid_at(ngtcp2_ringbuf *rb, size_t at) {
+  const ngtcp2_dcid *src;
+  ngtcp2_dcid *dest;
+
+  if (at == 0) {
+    ngtcp2_ringbuf_pop_front(rb);
+    return;
+  }
+
+  if (at == ngtcp2_ringbuf_len(rb) - 1) {
+    ngtcp2_ringbuf_pop_back(rb);
+    return;
+  }
+
+  src = ngtcp2_ringbuf_get(rb, ngtcp2_ringbuf_len(rb) - 1);
+  dest = ngtcp2_ringbuf_get(rb, at);
+
+  ngtcp2_dcid_copy(dest, src);
+  ngtcp2_ringbuf_pop_back(rb);
+}
+
+static int dcidtr_retire_dcid_prior_to(ngtcp2_dcidtr *dtr, ngtcp2_ringbuf *rb,
+                                       uint64_t seq, ngtcp2_dcidtr_cb on_retire,
+                                       void *user_data) {
+  size_t i;
+  const ngtcp2_dcid *dcid;
+  int rv;
+
+  for (i = 0; i < ngtcp2_ringbuf_len(rb);) {
+    dcid = ngtcp2_ringbuf_get(rb, i);
+    if (dcid->seq >= seq) {
+      ++i;
+      continue;
+    }
+
+    rv = dcidtr_on_retire(dtr, dcid, on_retire, user_data);
+    if (rv != 0) {
+      return rv;
+    }
+
+    remove_dcid_at(rb, i);
+  }
+
+  return 0;
+}
+
+int ngtcp2_dcidtr_retire_inactive_dcid_prior_to(ngtcp2_dcidtr *dtr,
+                                                uint64_t seq,
+                                                ngtcp2_dcidtr_cb on_retire,
+                                                void *user_data) {
+  int rv;
+
+  rv =
+    dcidtr_retire_dcid_prior_to(dtr, &dtr->bound.rb, seq, on_retire, user_data);
+  if (rv != 0) {
+    return rv;
+  }
+
+  return dcidtr_retire_dcid_prior_to(dtr, &dtr->unused.rb, seq, on_retire,
+                                     user_data);
+}
+
+int ngtcp2_dcidtr_retire_active_dcid(ngtcp2_dcidtr *dtr,
+                                     const ngtcp2_dcid *dcid, ngtcp2_tstamp ts,
+                                     ngtcp2_dcidtr_cb on_deactivate,
+                                     void *user_data) {
+  ngtcp2_ringbuf *rb = &dtr->retired.rb;
+  const ngtcp2_dcid *stale_dcid;
+  ngtcp2_dcid *dest;
+  int rv;
+
+  assert(dcid->cid.datalen);
+
+  if (ngtcp2_ringbuf_full(rb)) {
+    stale_dcid = ngtcp2_ringbuf_get(rb, 0);
+    rv = on_deactivate(stale_dcid, user_data);
+    if (rv != 0) {
+      return rv;
+    }
+  }
+
+  dest = ngtcp2_ringbuf_push_back(rb);
+  ngtcp2_dcid_copy(dest, dcid);
+  dest->retired_ts = ts;
+
+  return dcidtr_on_retire(dtr, dest, NULL, NULL);
+}
+
+int ngtcp2_dcidtr_remove_stale_retired_dcid(ngtcp2_dcidtr *dtr,
+                                            ngtcp2_duration timeout,
+                                            ngtcp2_tstamp ts,
+                                            ngtcp2_dcidtr_cb on_deactivate,
+                                            void *user_data) {
+  ngtcp2_ringbuf *rb = &dtr->retired.rb;
+  const ngtcp2_dcid *dcid;
+  int rv;
+
+  for (; ngtcp2_ringbuf_len(rb);) {
+    dcid = ngtcp2_ringbuf_get(rb, 0);
+    if (ngtcp2_tstamp_not_elapsed(dcid->retired_ts, timeout, ts)) {
+      break;
+    }
+
+    rv = on_deactivate(dcid, user_data);
+    if (rv != 0) {
+      return rv;
+    }
+
+    ngtcp2_ringbuf_pop_front(rb);
+  }
+
+  return 0;
+}
+
+int ngtcp2_dcidtr_pop_bound_dcid(ngtcp2_dcidtr *dtr, ngtcp2_dcid *dest,
+                                 const ngtcp2_path *path) {
+  const ngtcp2_dcid *src;
+  ngtcp2_ringbuf *rb = &dtr->bound.rb;
+  size_t len = ngtcp2_ringbuf_len(rb);
+  size_t i;
+
+  for (i = 0; i < len; ++i) {
+    src = ngtcp2_ringbuf_get(rb, i);
+    if (ngtcp2_path_eq(&src->ps.path, path)) {
+      ngtcp2_dcid_copy(dest, src);
+      remove_dcid_at(rb, i);
+
+      return 0;
+    }
+  }
+
+  return NGTCP2_ERR_INVALID_ARGUMENT;
+}
+
+int ngtcp2_dcidtr_retire_stale_bound_dcid(ngtcp2_dcidtr *dtr,
+                                          ngtcp2_duration timeout,
+                                          ngtcp2_tstamp ts,
+                                          ngtcp2_dcidtr_cb on_retire,
+                                          void *user_data) {
+  ngtcp2_ringbuf *rb = &dtr->bound.rb;
+  size_t i;
+  const ngtcp2_dcid *dcid;
+  int rv;
+
+  for (i = 0; i < ngtcp2_ringbuf_len(rb);) {
+    dcid = ngtcp2_ringbuf_get(rb, i);
+
+    assert(dcid->cid.datalen);
+
+    if (ngtcp2_tstamp_not_elapsed(dcid->bound_ts, timeout, ts)) {
+      ++i;
+      continue;
+    }
+
+    rv = dcidtr_on_retire(dtr, dcid, on_retire, user_data);
+    if (rv != 0) {
+      return rv;
+    }
+
+    remove_dcid_at(rb, i);
+  }
+
+  return 0;
+}
+
+ngtcp2_tstamp ngtcp2_dcidtr_earliest_bound_ts(const ngtcp2_dcidtr *dtr) {
+  const ngtcp2_ringbuf *rb = &dtr->bound.rb;
+  size_t i, len = ngtcp2_ringbuf_len(rb);
+  ngtcp2_tstamp res = UINT64_MAX;
+  const ngtcp2_dcid *dcid;
+
+  for (i = 0; i < len; ++i) {
+    dcid = ngtcp2_ringbuf_get(rb, i);
+
+    assert(dcid->cid.datalen);
+    assert(dcid->bound_ts != UINT64_MAX);
+
+    res = ngtcp2_min_uint64(res, dcid->bound_ts);
+  }
+
+  return res;
+}
+
+ngtcp2_tstamp ngtcp2_dcidtr_earliest_retired_ts(const ngtcp2_dcidtr *dtr) {
+  const ngtcp2_ringbuf *rb = &dtr->retired.rb;
+  const ngtcp2_dcid *dcid;
+
+  if (ngtcp2_ringbuf_len(rb) == 0) {
+    return UINT64_MAX;
+  }
+
+  dcid = ngtcp2_ringbuf_get(rb, 0);
+
+  return dcid->retired_ts;
+}
+
+void ngtcp2_dcidtr_push_unused(ngtcp2_dcidtr *dtr, uint64_t seq,
+                               const ngtcp2_cid *cid, const uint8_t *token) {
+  ngtcp2_dcid *dcid = ngtcp2_ringbuf_push_back(&dtr->unused.rb);
+
+  ngtcp2_dcid_init(dcid, seq, cid, token);
+}
+
+void ngtcp2_dcidtr_pop_unused_cid_token(ngtcp2_dcidtr *dtr, ngtcp2_dcid *dest) {
+  ngtcp2_ringbuf *rb = &dtr->unused.rb;
+  const ngtcp2_dcid *src;
+
+  assert(ngtcp2_ringbuf_len(rb));
+
+  src = ngtcp2_ringbuf_get(rb, 0);
+
+  ngtcp2_dcid_copy_cid_token(dest, src);
+
+  ngtcp2_ringbuf_pop_front(rb);
+}
+
+void ngtcp2_dcidtr_pop_unused(ngtcp2_dcidtr *dtr, ngtcp2_dcid *dest) {
+  ngtcp2_ringbuf *rb = &dtr->unused.rb;
+  const ngtcp2_dcid *src;
+
+  assert(ngtcp2_ringbuf_len(rb));
+
+  src = ngtcp2_ringbuf_get(rb, 0);
+
+  ngtcp2_dcid_copy(dest, src);
+
+  ngtcp2_ringbuf_pop_front(rb);
+}
+
+int ngtcp2_dcidtr_check_path_retired(const ngtcp2_dcidtr *dtr,
+                                     const ngtcp2_path *path) {
+  const ngtcp2_ringbuf *rb = &dtr->retired.rb;
+  size_t i, len = ngtcp2_ringbuf_len(rb);
+  const ngtcp2_dcid *dcid;
+
+  for (i = 0; i < len; ++i) {
+    dcid = ngtcp2_ringbuf_get(rb, i);
+    if (ngtcp2_path_eq(&dcid->ps.path, path)) {
+      return 1;
+    }
+  }
+
+  return 0;
+}
+
+size_t ngtcp2_dcidtr_unused_len(const ngtcp2_dcidtr *dtr) {
+  return ngtcp2_ringbuf_len(&dtr->unused.rb);
+}
+
+size_t ngtcp2_dcidtr_bound_len(const ngtcp2_dcidtr *dtr) {
+  return ngtcp2_ringbuf_len(&dtr->bound.rb);
+}
+
+size_t ngtcp2_dcidtr_retired_len(const ngtcp2_dcidtr *dtr) {
+  return ngtcp2_ringbuf_len(&dtr->retired.rb);
+}
+
+size_t ngtcp2_dcidtr_inactive_len(const ngtcp2_dcidtr *dtr) {
+  return ngtcp2_ringbuf_len(&dtr->unused.rb) +
+         ngtcp2_ringbuf_len(&dtr->bound.rb);
+}
+
+int ngtcp2_dcidtr_unused_full(const ngtcp2_dcidtr *dtr) {
+  return ngtcp2_ringbuf_full(&dtr->unused.rb);
+}
+
+int ngtcp2_dcidtr_unused_empty(const ngtcp2_dcidtr *dtr) {
+  return ngtcp2_ringbuf_len(&dtr->unused.rb) == 0;
+}
+
+int ngtcp2_dcidtr_bound_full(const ngtcp2_dcidtr *dtr) {
+  return ngtcp2_ringbuf_full(&dtr->bound.rb);
+}

--- a/lib/ngtcp2_dcidtr.h
+++ b/lib/ngtcp2_dcidtr.h
@@ -1,0 +1,347 @@
+/*
+ * ngtcp2
+ *
+ * Copyright (c) 2025 ngtcp2 contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+#ifndef NGTCP2_DCIDTR_H
+#define NGTCP2_DCIDTR_H
+
+#ifdef HAVE_CONFIG_H
+#  include <config.h>
+#endif /* defined(HAVE_CONFIG_H) */
+
+#include <ngtcp2/ngtcp2.h>
+
+#include "ngtcp2_cid.h"
+#include "ngtcp2_ringbuf.h"
+
+/* NGTCP2_DCIDTR_MAX_BOUND_DCID_SIZE is the maximum number of
+   Destination Connection ID which has been bound to a particular
+   path, but not yet used as primary path, and path validation is not
+   performed from the local endpoint.  It must be the power of 2. */
+#define NGTCP2_DCIDTR_MAX_BOUND_DCID_SIZE 4
+/* NGTCP2_DCIDTR_MAX_UNUSED_DCID_SIZE is the maximum number of
+   Destination Connection ID the remote endpoint provides to store.
+   It must be the power of 2. */
+#define NGTCP2_DCIDTR_MAX_UNUSED_DCID_SIZE 8
+/* NGTCP2_DCIDTR_MAX_RETIRED_DCID_SIZE is the maximum number of
+   retired Destination Connection ID kept to catch in-flight packet on
+   a retired path.  It must be the power of 2. */
+#define NGTCP2_DCIDTR_MAX_RETIRED_DCID_SIZE 2
+
+ngtcp2_static_ringbuf_def(dcid_bound, NGTCP2_DCIDTR_MAX_BOUND_DCID_SIZE,
+                          sizeof(ngtcp2_dcid))
+ngtcp2_static_ringbuf_def(dcid_unused, NGTCP2_DCIDTR_MAX_UNUSED_DCID_SIZE,
+                          sizeof(ngtcp2_dcid))
+ngtcp2_static_ringbuf_def(dcid_retired, NGTCP2_DCIDTR_MAX_RETIRED_DCID_SIZE,
+                          sizeof(ngtcp2_dcid))
+
+/*
+ * ngtcp2_dcidtr stores unused, bound, and retired Destination
+ * Connection IDs.
+ */
+typedef struct ngtcp2_dcidtr {
+  /* unused is a set of unused Destination Connection ID received from
+     a remote endpoint.  They are considered inactive. */
+  ngtcp2_static_ringbuf_dcid_unused unused;
+  /* bound is a set of Destination Connection IDs which are bound to
+     particular paths.  These paths are not validated yet.  They are
+     considered inactive. */
+  ngtcp2_static_ringbuf_dcid_bound bound;
+  /* retired is a set of Destination Connection ID retired by local
+     endpoint.  Keep them in 3*PTO to catch packets in flight along
+     the old path.  They are considered active. */
+  ngtcp2_static_ringbuf_dcid_retired retired;
+  /* zerolen_seq is a pseudo sequence number of zero-length
+     Destination Connection ID in order to distinguish between
+     them. */
+  uint64_t zerolen_seq;
+  struct {
+    /* seqs contains sequence number of Destination Connection ID
+       whose retirement is not acknowledged by the remote endpoint
+       yet. */
+    uint64_t seqs[NGTCP2_DCIDTR_MAX_UNUSED_DCID_SIZE * 2];
+    /* len is the number of sequence numbers that seq contains. */
+    size_t len;
+  } retire_unacked;
+} ngtcp2_dcidtr;
+
+typedef int (*ngtcp2_dcidtr_cb)(const ngtcp2_dcid *dcid, void *user_data);
+
+/*
+ * ngtcp2_dcidtr_init initializes |dtr|.
+ */
+void ngtcp2_dcidtr_init(ngtcp2_dcidtr *dtr);
+
+/*
+ * ngtcp2_dcidtr_track_retired_seq tracks the sequence number |seq| of
+ * unacknowledged retiring Destination Connection ID.
+ *
+ * This function returns 0 if it succeeds, or one of the following
+ * negative error codes:
+ *
+ * NGTCP2_ERR_CONNECTION_ID_LIMIT
+ *     The number of unacknowledged retirement exceeds the limit.
+ */
+int ngtcp2_dcidtr_track_retired_seq(ngtcp2_dcidtr *dtr, uint64_t seq);
+
+/*
+ * ngtcp2_dcidtr_untrack_retired_seq deletes the sequence number |seq|
+ * of unacknowledged retiring Destination Connection ID.  It is fine
+ * if such sequence number is not found.
+ */
+void ngtcp2_dcidtr_untrack_retired_seq(ngtcp2_dcidtr *dtr, uint64_t seq);
+
+/*
+ * ngtcp2_dcidtr_check_retired_seq_tracked returns nonzero if |seq|
+ * has already been tracked.
+ */
+int ngtcp2_dcidtr_check_retired_seq_tracked(const ngtcp2_dcidtr *dtr,
+                                            uint64_t seq);
+
+/*
+ * ngtcp2_dcidtr_find_bound_dcid returns the pointer to ngtcp2_dcid
+ * that bound to |path|.  It returns NULL if there is no such
+ * ngtcp2_dcid.
+ */
+ngtcp2_dcid *ngtcp2_dcidtr_find_bound_dcid(const ngtcp2_dcidtr *dtr,
+                                           const ngtcp2_path *path);
+
+/*
+ * ngtcp2_dcidtr_bind_zerolen_dcid binds zero-length Destination
+ * Connection ID to |path|, and returns the pointer to the bound
+ * ngtcp2_dcid.
+ */
+ngtcp2_dcid *ngtcp2_dcidtr_bind_zerolen_dcid(ngtcp2_dcidtr *dtr,
+                                             const ngtcp2_path *path);
+
+/*
+ * ngtcp2_dcidtr_bind_dcid binds non-zero Destination Connection ID to
+ * |path|.  |ts| is the current timestamp.  The buffer space of bound
+ * Destination Connection ID is limited.  If it is full, the earliest
+ * one is removed.  |on_retire|, if specified, is called for the
+ * removed ngtcp2_dcid with |user_data|.  This function assigns the
+ * pointer to bound ngtcp2_dcid to |*pdest|.
+ *
+ * This function returns 0 if it succeeds, or negative error code that
+ * |on_retire| returns.
+ */
+int ngtcp2_dcidtr_bind_dcid(ngtcp2_dcidtr *dtr, ngtcp2_dcid **pdest,
+                            const ngtcp2_path *path, ngtcp2_tstamp ts,
+                            ngtcp2_dcidtr_cb on_retire, void *user_data);
+
+/*
+ * ngtcp2_dcidtr_verify_stateless_reset verifies the stateless reset
+ * token |token| received from |path|.  It returns 0 if it succeeds,
+ * or one of the following negative error codes:
+ *
+ * NGTCP2_ERR_INVALID_ARGUMENT
+ *     There is no Destination Connection ID that matches the given
+ *     |path| and |token|.
+ */
+int ngtcp2_dcidtr_verify_stateless_reset(const ngtcp2_dcidtr *dtr,
+                                         const ngtcp2_path *path,
+                                         const uint8_t *token);
+
+/*
+ * ngtcp2_dcidtr_verify_token_uniqueness verifies that the uniqueness
+ * of the combination of |seq|, |cid|, and |token| against the exiting
+ * Destination Connection IDs.  That is:
+ *
+ * - If they do not share the same seq, then their Connection IDs must
+ *   be different.
+ *
+ * - If they share the same seq, then their Connection IDs and tokens
+ *   must be the same.
+ *
+ * If this function succeeds, and there is Destination Connection ID
+ * which shares |seq|, |cid|, and |token|, |*pfound| is set to
+ * nonzero.
+ *
+ * This function returns 0 if it succeeds, or one of the following
+ * negative error codes:
+ *
+ * NGTCP2_ERR_PROTO
+ *     The given combination of values does not satisfy the above
+ *     conditions.
+ */
+int ngtcp2_dcidtr_verify_token_uniqueness(const ngtcp2_dcidtr *dtr, int *pfound,
+                                          uint64_t seq, const ngtcp2_cid *cid,
+                                          const uint8_t *token);
+
+/*
+ * ngtcp2_dcidtr_retire_inactive_dcid_prior_to retires inactive
+ * Destination Connection IDs (unused or bound) whose seq is less than
+ * |seq|.  For each retired ngtcp2_dcid, |on_retire|, if specified, is
+ * called with |user_data|.
+ *
+ * This function returns 0 if it succeeds, or negative error code that
+ * |on_retire| returns.
+ */
+int ngtcp2_dcidtr_retire_inactive_dcid_prior_to(ngtcp2_dcidtr *dtr,
+                                                uint64_t seq,
+                                                ngtcp2_dcidtr_cb on_retire,
+                                                void *user_data);
+
+/*
+ * ngtcp2_dcidtr_retire_active_dcid adds an active |dcid| to the
+ * retired Destination Connection ID buffer.  The buffer space of
+ * retired Destination Connection ID is limited.  If it is full, the
+ * earliest one is removed.  |on_deactivate| is called for the removed
+ * ngtcp2_dcid with |user_data|.
+ *
+ * This function returns 0 if it succeeds, or negative error code that
+ * |on_deactivate| returns.
+ */
+int ngtcp2_dcidtr_retire_active_dcid(ngtcp2_dcidtr *dtr,
+                                     const ngtcp2_dcid *dcid, ngtcp2_tstamp ts,
+                                     ngtcp2_dcidtr_cb on_deactivate,
+                                     void *user_data);
+
+/*
+ * ngtcp2_dcidtr_retire_stale_bound_dcid retires stale bound
+ * Destination Connection ID.  For each retired ngtcp2_dcid,
+ * |on_retire|, if specified, is called with |user_data|.
+ */
+int ngtcp2_dcidtr_retire_stale_bound_dcid(ngtcp2_dcidtr *dtr,
+                                          ngtcp2_duration timeout,
+                                          ngtcp2_tstamp ts,
+                                          ngtcp2_dcidtr_cb on_retire,
+                                          void *user_data);
+
+/*
+ * ngtcp2_dcidtr_remove_stale_retired_dcid removes stale retired
+ * Destination Connection ID.  For each removed ngtcp2_dcid,
+ * |on_deactivate| is called with |user_data|.
+ *
+ * This function returns 0 if it succeeds, or negative error code that
+ * |on_deactivate| returns.
+ */
+int ngtcp2_dcidtr_remove_stale_retired_dcid(ngtcp2_dcidtr *dtr,
+                                            ngtcp2_duration timeout,
+                                            ngtcp2_tstamp ts,
+                                            ngtcp2_dcidtr_cb on_deactivate,
+                                            void *user_data);
+
+/*
+ * ngtcp2_dcidtr_pop_bound_dcid removes Destination Connection ID that
+ * is bound to |path|, and copies it into the object pointed by
+ * |dest|.
+ *
+ * This function returns 0 if it succeeds, or one of the following
+ * negative error codes:
+ *
+ * NGTCP2_ERR_INVALID_ARGUMENT
+ *     No ngtcp2_dcid bound to |path| found.
+ */
+int ngtcp2_dcidtr_pop_bound_dcid(ngtcp2_dcidtr *dtr, ngtcp2_dcid *dest,
+                                 const ngtcp2_path *path);
+
+/*
+ * ngtcp2_dcidtr_earliest_bound_ts returns earliest timestamp when a
+ * Destination Connection ID is bound.  If there is no bound
+ * Destination Connection ID, this function returns UINT64_MAX.
+ */
+ngtcp2_tstamp ngtcp2_dcidtr_earliest_bound_ts(const ngtcp2_dcidtr *dtr);
+
+/*
+ * ngtcp2_dcidtr_earliest_retired_ts returns earliest timestamp when a
+ * Destination Connection ID is retired.  If there is no retired
+ * Destination Connection ID, this function returns UINT64_MAX.
+ */
+ngtcp2_tstamp ngtcp2_dcidtr_earliest_retired_ts(const ngtcp2_dcidtr *dtr);
+
+/*
+ * ngtcp2_dcidtr_push_unused adds new Destination Connection ID to the
+ * unused buffer.  |seq| is its sequence number, |cid| is its
+ * Connection ID, and |token| is its stateless reset token.  If the
+ * buffer space is full, the earliest ngtcp2_dcid is removed.
+ */
+void ngtcp2_dcidtr_push_unused(ngtcp2_dcidtr *dtr, uint64_t seq,
+                               const ngtcp2_cid *cid, const uint8_t *token);
+
+/*
+ * ngtcp2_dcidtr_pop_unused_cid_token removes an unused Destination
+ * Connection ID, and copies it into the object pointed by |dcid| with
+ * ngtcp2_dcid_copy_cid_token.  This function assumes that there is at
+ * least one unused Destination Connection ID.
+ */
+void ngtcp2_dcidtr_pop_unused_cid_token(ngtcp2_dcidtr *dtr, ngtcp2_dcid *dcid);
+
+/*
+ * ngtcp2_dcidtr_pop_unused removes an unused Destination Connection
+ * ID, and copies it into the object pointed by |dcid| with
+ * ngtcp2_dcid_copy.  This function assumes that there is at least one
+ * unused Destination Connection ID.
+ */
+void ngtcp2_dcidtr_pop_unused(ngtcp2_dcidtr *dtr, ngtcp2_dcid *dcid);
+
+/*
+ * ngtcp2_dcidtr_check_path_retired returns nonzero if |path| is
+ * included in retired Destination Connection IDs.
+ */
+int ngtcp2_dcidtr_check_path_retired(const ngtcp2_dcidtr *dtr,
+                                     const ngtcp2_path *path);
+
+/*
+ * ngtcp2_dcidtr_unused_len returns the number of unused Destination
+ * Connection ID.
+ */
+size_t ngtcp2_dcidtr_unused_len(const ngtcp2_dcidtr *dtr);
+
+/*
+ * ngtcp2_dcidtr_bound_len returns the number of bound Destination
+ * Connection ID.
+ */
+size_t ngtcp2_dcidtr_bound_len(const ngtcp2_dcidtr *dtr);
+
+/*
+ * ngtcp2_dcidtr_retired_len returns the number of retired Destination
+ * Connection ID.
+ */
+size_t ngtcp2_dcidtr_retired_len(const ngtcp2_dcidtr *dtr);
+
+/*
+ * ngtcp2_dcidtr_inactive_len returns the number of unused and bound
+ * Destination Connection ID.
+ */
+size_t ngtcp2_dcidtr_inactive_len(const ngtcp2_dcidtr *dtr);
+
+/*
+ * ngtcp2_dcidtr_unused_full returns nonzero if the buffer of unused
+ * Destination Connection ID is full.
+ */
+int ngtcp2_dcidtr_unused_full(const ngtcp2_dcidtr *dtr);
+
+/*
+ * ngtcp2_dcidtr_unused_empty returns nonzero if the buffer of unused
+ * Destination Connection ID is empty.
+ */
+int ngtcp2_dcidtr_unused_empty(const ngtcp2_dcidtr *dtr);
+
+/*
+ * ngtcp2_dcidtr_bound_full returns nonzero if the buffer of bound
+ * Destination Connection ID is full.
+ */
+int ngtcp2_dcidtr_bound_full(const ngtcp2_dcidtr *dtr);
+
+#endif /* NGTCP2_DCIDTR_H */

--- a/lib/ngtcp2_rtb.c
+++ b/lib/ngtcp2_rtb.c
@@ -672,8 +672,8 @@ static int process_acked_pkt(ngtcp2_rtb_entry *ent, ngtcp2_conn *conn,
 
       break;
     case NGTCP2_FRAME_RETIRE_CONNECTION_ID:
-      ngtcp2_conn_untrack_retired_dcid_seq(conn,
-                                           frc->fr.retire_connection_id.seq);
+      ngtcp2_dcidtr_untrack_retired_seq(&conn->dcid.dtr,
+                                        frc->fr.retire_connection_id.seq);
       break;
     case NGTCP2_FRAME_NEW_CONNECTION_ID:
       assert(conn->scid.num_in_flight);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -55,6 +55,7 @@ set(main_SOURCES
   ngtcp2_window_filter_test.c
   ngtcp2_settings_test.c
   ngtcp2_ppe_test.c
+  ngtcp2_dcidtr_test.c
   ngtcp2_test_helper.c
   munit/munit.c
 )

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -51,6 +51,7 @@ OBJECTS = \
 	ngtcp2_window_filter_test.c \
 	ngtcp2_settings_test.c \
 	ngtcp2_ppe_test.c \
+	ngtcp2_dcidtr_test.c \
 	ngtcp2_test_helper.c \
 	munit/munit.c
 
@@ -79,6 +80,7 @@ HFILES= \
 	ngtcp2_window_filter_test.h \
 	ngtcp2_settings_test.h \
 	ngtcp2_ppe_test.h \
+	ngtcp2_dcidtr_test.h \
 	ngtcp2_test_helper.h \
 	munit/munit.h
 

--- a/tests/main.c
+++ b/tests/main.c
@@ -54,34 +54,23 @@
 #include "ngtcp2_window_filter_test.h"
 #include "ngtcp2_settings_test.h"
 #include "ngtcp2_ppe_test.h"
+#include "ngtcp2_dcidtr_test.h"
 
 int main(int argc, char *argv[]) {
   const MunitSuite suites[] = {
-    pkt_suite,
-    range_suite,
-    rob_suite,
-    acktr_suite,
-    map_suite,
-    transport_params_suite,
-    rtb_suite,
-    idtr_suite,
-    conn_suite,
-    ringbuf_suite,
-    conv_suite,
-    ksl_suite,
-    gaptr_suite,
-    vec_suite,
-    strm_suite,
-    pv_suite,
-    pmtud_suite,
-    str_suite,
-    tstamp_suite,
-    cc_suite,
-    qlog_suite,
-    window_filter_suite,
-    settings_suite,
-    ppe_suite,
-    {0},
+    pkt_suite,      range_suite,
+    rob_suite,      acktr_suite,
+    map_suite,      transport_params_suite,
+    rtb_suite,      idtr_suite,
+    conn_suite,     ringbuf_suite,
+    conv_suite,     ksl_suite,
+    gaptr_suite,    vec_suite,
+    strm_suite,     pv_suite,
+    pmtud_suite,    str_suite,
+    tstamp_suite,   cc_suite,
+    qlog_suite,     window_filter_suite,
+    settings_suite, ppe_suite,
+    dcidtr_suite,   {0},
   };
   const MunitSuite suite = {
     .prefix = "",

--- a/tests/ngtcp2_conn_test.c
+++ b/tests/ngtcp2_conn_test.c
@@ -6525,10 +6525,9 @@ void test_ngtcp2_conn_recv_new_connection_id(void) {
   rv = ngtcp2_conn_read_pkt(conn, &null_path.path, &null_pi, buf, pktlen, ++t);
 
   assert_int(0, ==, rv);
-  assert_size(1, ==, ngtcp2_ringbuf_len(&conn->dcid.unused.rb));
+  assert_size(1, ==, ngtcp2_dcidtr_unused_len(&conn->dcid.dtr));
 
-  dcid = ngtcp2_ringbuf_get(&conn->dcid.unused.rb, 0);
-
+  dcid = ngtcp2_ringbuf_get(&conn->dcid.dtr.unused.rb, 0);
   assert_true(ngtcp2_cid_eq(&fr.new_connection_id.cid, &dcid->cid));
   assert_true(dcid->flags & NGTCP2_DCID_FLAG_TOKEN_PRESENT);
   assert_memory_equal(sizeof(fr.new_connection_id.stateless_reset_token),
@@ -6545,8 +6544,8 @@ void test_ngtcp2_conn_recv_new_connection_id(void) {
   rv = ngtcp2_conn_read_pkt(conn, &null_path.path, &null_pi, buf, pktlen, ++t);
 
   assert_int(0, ==, rv);
-  assert_size(0, ==, ngtcp2_ringbuf_len(&conn->dcid.bound.rb));
-  assert_size(0, ==, ngtcp2_ringbuf_len(&conn->dcid.unused.rb));
+  assert_size(0, ==, ngtcp2_dcidtr_bound_len(&conn->dcid.dtr));
+  assert_size(0, ==, ngtcp2_dcidtr_unused_len(&conn->dcid.dtr));
   assert_uint64(2, ==, conn->dcid.current.seq);
   assert_not_null(conn->pktns.tx.frq);
   assert_uint64(2, ==, conn->dcid.retire_prior_to);
@@ -6588,7 +6587,7 @@ void test_ngtcp2_conn_recv_new_connection_id(void) {
   rv = ngtcp2_conn_read_pkt(conn, &null_path.path, &null_pi, buf, pktlen, ++t);
 
   assert_int(0, ==, rv);
-  assert_size(0, ==, ngtcp2_ringbuf_len(&conn->dcid.unused.rb));
+  assert_size(0, ==, ngtcp2_dcidtr_unused_len(&conn->dcid.dtr));
   assert_uint64(2, ==, conn->dcid.current.seq);
   assert_uint64(2, ==, conn->dcid.retire_prior_to);
 
@@ -6613,7 +6612,7 @@ void test_ngtcp2_conn_recv_new_connection_id(void) {
   rv = ngtcp2_conn_read_pkt(conn, &null_path.path, &null_pi, buf, pktlen, ++t);
 
   assert_int(0, ==, rv);
-  assert_size(0, ==, ngtcp2_ringbuf_len(&conn->dcid.unused.rb));
+  assert_size(0, ==, ngtcp2_dcidtr_unused_len(&conn->dcid.dtr));
   assert_uint64(2, ==, conn->dcid.current.seq);
   assert_uint64(2, ==, conn->dcid.retire_prior_to);
 
@@ -6628,7 +6627,7 @@ void test_ngtcp2_conn_recv_new_connection_id(void) {
   rv = ngtcp2_conn_read_pkt(conn, &null_path.path, &null_pi, buf, pktlen, ++t);
 
   assert_int(0, ==, rv);
-  assert_size(0, ==, ngtcp2_ringbuf_len(&conn->dcid.unused.rb));
+  assert_size(0, ==, ngtcp2_dcidtr_unused_len(&conn->dcid.dtr));
   assert_uint64(2, ==, conn->dcid.current.seq);
   assert_uint64(2, ==, conn->dcid.retire_prior_to);
 
@@ -6679,7 +6678,7 @@ void test_ngtcp2_conn_recv_new_connection_id(void) {
   assert_true(conn->pv->flags & NGTCP2_PV_FLAG_FALLBACK_ON_FAILURE);
   assert_uint64(1, ==, conn->pv->dcid.seq);
   assert_uint64(0, ==, conn->pv->fallback_dcid.seq);
-  assert_size(2, ==, ngtcp2_ringbuf_len(&conn->dcid.unused.rb));
+  assert_size(2, ==, ngtcp2_dcidtr_unused_len(&conn->dcid.dtr));
 
   fr.type = NGTCP2_FRAME_NEW_CONNECTION_ID;
   fr.new_connection_id.seq = 3;
@@ -6692,7 +6691,7 @@ void test_ngtcp2_conn_recv_new_connection_id(void) {
   rv = ngtcp2_conn_read_pkt(conn, &new_path.path, &null_pi, buf, pktlen, ++t);
 
   assert_int(0, ==, rv);
-  assert_size(0, ==, ngtcp2_ringbuf_len(&conn->dcid.unused.rb));
+  assert_size(0, ==, ngtcp2_dcidtr_unused_len(&conn->dcid.dtr));
   assert_true(conn->pv->flags & NGTCP2_PV_FLAG_FALLBACK_ON_FAILURE);
   assert_uint64(2, ==, conn->pv->dcid.seq);
   assert_uint64(3, ==, conn->pv->fallback_dcid.seq);
@@ -6738,7 +6737,7 @@ void test_ngtcp2_conn_recv_new_connection_id(void) {
   assert_true(conn->pv->flags & NGTCP2_PV_FLAG_FALLBACK_ON_FAILURE);
   assert_uint64(1, ==, conn->pv->dcid.seq);
   assert_uint64(0, ==, conn->pv->fallback_dcid.seq);
-  assert_size(0, ==, ngtcp2_ringbuf_len(&conn->dcid.unused.rb));
+  assert_size(0, ==, ngtcp2_dcidtr_unused_len(&conn->dcid.dtr));
 
   fr.type = NGTCP2_FRAME_NEW_CONNECTION_ID;
   fr.new_connection_id.seq = 2;
@@ -6752,7 +6751,7 @@ void test_ngtcp2_conn_recv_new_connection_id(void) {
 
   assert_int(0, ==, rv);
   assert_uint64(2, ==, conn->dcid.current.seq);
-  assert_size(0, ==, ngtcp2_ringbuf_len(&conn->dcid.unused.rb));
+  assert_size(0, ==, ngtcp2_dcidtr_unused_len(&conn->dcid.dtr));
   assert_null(conn->pv);
 
   frc = conn->pktns.tx.frq;
@@ -6797,7 +6796,7 @@ void test_ngtcp2_conn_recv_new_connection_id(void) {
   assert_true(conn->pv->flags & NGTCP2_PV_FLAG_FALLBACK_ON_FAILURE);
   assert_uint64(1, ==, conn->pv->dcid.seq);
   assert_uint64(0, ==, conn->pv->fallback_dcid.seq);
-  assert_size(0, ==, ngtcp2_ringbuf_len(&conn->dcid.unused.rb));
+  assert_size(0, ==, ngtcp2_dcidtr_unused_len(&conn->dcid.dtr));
 
   /* Overwrite seq in pv->dcid so that pv->dcid cannot be renewed. */
   conn->pv->dcid.seq = 2;
@@ -6817,7 +6816,7 @@ void test_ngtcp2_conn_recv_new_connection_id(void) {
 
   assert_int(0, ==, rv);
   assert_uint64(3, ==, conn->dcid.current.seq);
-  assert_size(0, ==, ngtcp2_ringbuf_len(&conn->dcid.unused.rb));
+  assert_size(0, ==, ngtcp2_dcidtr_unused_len(&conn->dcid.dtr));
   assert_null(conn->pv);
 
   frc = conn->pktns.tx.frq;
@@ -6902,7 +6901,7 @@ void test_ngtcp2_conn_recv_new_connection_id(void) {
   rv = ngtcp2_conn_read_pkt(conn, &new_path.path, &null_pi, buf, pktlen, ++t);
 
   assert_int(0, ==, rv);
-  assert_size(0, ==, ngtcp2_ringbuf_len(&conn->dcid.unused.rb));
+  assert_size(0, ==, ngtcp2_dcidtr_unused_len(&conn->dcid.dtr));
   assert_uint64(2, ==, conn->dcid.current.seq);
   assert_not_null(conn->pv);
   assert_true(
@@ -6931,7 +6930,7 @@ void test_ngtcp2_conn_recv_new_connection_id(void) {
   rv = ngtcp2_conn_read_pkt(conn, &new_path.path, &null_pi, buf, pktlen, ++t);
 
   assert_int(0, ==, rv);
-  assert_size(0, ==, ngtcp2_ringbuf_len(&conn->dcid.unused.rb));
+  assert_size(0, ==, ngtcp2_dcidtr_unused_len(&conn->dcid.dtr));
   assert_uint64(2, ==, conn->dcid.current.seq);
 
   ngtcp2_conn_del(conn);
@@ -7507,9 +7506,9 @@ void test_ngtcp2_conn_recv_path_challenge(void) {
   assert_ptrdiff(1200, <=, spktlen);
   assert_true(ngtcp2_path_eq(&new_path.path, &ps.path));
   assert_size(0, ==, ngtcp2_ringbuf_len(&conn->rx.path_challenge.rb));
-  assert_size(1, ==, ngtcp2_ringbuf_len(&conn->dcid.bound.rb));
+  assert_size(1, ==, ngtcp2_dcidtr_bound_len(&conn->dcid.dtr));
 
-  dcid = ngtcp2_ringbuf_get(&conn->dcid.bound.rb, 0);
+  dcid = ngtcp2_ringbuf_get(&conn->dcid.dtr.bound.rb, 0);
 
   assert_uint64((uint64_t)spktlen, ==, dcid->bytes_sent);
 
@@ -7536,7 +7535,7 @@ void test_ngtcp2_conn_recv_path_challenge(void) {
   assert_ptrdiff(0, <, spktlen);
   assert_true(ngtcp2_path_eq(&new_path.path, &ps.path));
   assert_size(0, ==, ngtcp2_ringbuf_len(&conn->rx.path_challenge.rb));
-  assert_size(1, ==, ngtcp2_ringbuf_len(&conn->dcid.bound.rb));
+  assert_size(1, ==, ngtcp2_dcidtr_bound_len(&conn->dcid.dtr));
 
   shdlen = ngtcp2_pkt_decode_hd_short(&hd, buf, (size_t)spktlen, cid.datalen);
 
@@ -7580,7 +7579,7 @@ void test_ngtcp2_conn_recv_path_challenge(void) {
   assert_ptrdiff(1200, <=, spktlen);
   assert_true(ngtcp2_path_eq(&null_path.path, &ps.path));
   assert_size(0, ==, ngtcp2_ringbuf_len(&conn->rx.path_challenge.rb));
-  assert_size(0, ==, ngtcp2_ringbuf_len(&conn->dcid.bound.rb));
+  assert_size(0, ==, ngtcp2_dcidtr_bound_len(&conn->dcid.dtr));
   assert_uint64((uint64_t)spktlen, ==, conn->dcid.current.bytes_sent);
 
   ngtcp2_conn_del(conn);
@@ -10616,7 +10615,7 @@ void test_ngtcp2_conn_retire_stale_bound_dcid(void) {
 
   assert_int(0, ==, rv);
   assert_size(0, <, ngtcp2_ringbuf_len(&conn->rx.path_challenge.rb));
-  assert_size(0, <, ngtcp2_ringbuf_len(&conn->dcid.bound.rb));
+  assert_size(0, <, ngtcp2_dcidtr_bound_len(&conn->dcid.dtr));
 
   expiry = ngtcp2_conn_get_expiry(conn);
 
@@ -10627,7 +10626,7 @@ void test_ngtcp2_conn_retire_stale_bound_dcid(void) {
   rv = ngtcp2_conn_handle_expiry(conn, t);
 
   assert_int(0, ==, rv);
-  assert_size(0, ==, ngtcp2_ringbuf_len(&conn->dcid.bound.rb));
+  assert_size(0, ==, ngtcp2_dcidtr_bound_len(&conn->dcid.dtr));
 
   ngtcp2_conn_del(conn);
 }

--- a/tests/ngtcp2_dcidtr_test.c
+++ b/tests/ngtcp2_dcidtr_test.c
@@ -1,0 +1,752 @@
+/*
+ * ngtcp2
+ *
+ * Copyright (c) 2025 ngtcp2 contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+#include "ngtcp2_dcidtr_test.h"
+
+#include <stdio.h>
+
+#include "ngtcp2_dcidtr.h"
+#include "ngtcp2_test_helper.h"
+
+static const MunitTest tests[] = {
+  munit_void_test(test_ngtcp2_dcidtr_track_retired_seq),
+  munit_void_test(test_ngtcp2_dcidtr_bind_dcid),
+  munit_void_test(test_ngtcp2_dcidtr_find_bound_dcid),
+  munit_void_test(test_ngtcp2_dcidtr_bind_zerolen_dcid),
+  munit_void_test(test_ngtcp2_dcidtr_verify_stateless_reset),
+  munit_void_test(test_ngtcp2_dcidtr_verify_token_uniqueness),
+  munit_void_test(test_ngtcp2_dcidtr_retire_inactive_dcid_prior_to),
+  munit_void_test(test_ngtcp2_dcidtr_retire_active_dcid),
+  munit_void_test(test_ngtcp2_dcidtr_retire_stale_bound_dcid),
+  munit_void_test(test_ngtcp2_dcidtr_remove_stale_retired_dcid),
+  munit_void_test(test_ngtcp2_dcidtr_pop_bound_dcid),
+  munit_void_test(test_ngtcp2_dcidtr_earliest_bound_ts),
+  munit_void_test(test_ngtcp2_dcidtr_earliest_retired_ts),
+  munit_void_test(test_ngtcp2_dcidtr_pop_unused),
+  munit_void_test(test_ngtcp2_dcidtr_check_path_retired),
+  munit_void_test(test_ngtcp2_dcidtr_len),
+  munit_test_end(),
+};
+
+const MunitSuite dcidtr_suite = {
+  .prefix = "/dcidtr",
+  .tests = tests,
+};
+
+typedef struct userdata {
+  size_t cb_called;
+} userdata;
+
+static int dcidtr_cb(const ngtcp2_dcid *dcid, void *user_data) {
+  userdata *ud = user_data;
+  (void)dcid;
+
+  ++ud->cb_called;
+
+  return 0;
+}
+
+void test_ngtcp2_dcidtr_track_retired_seq(void) {
+  ngtcp2_dcidtr dtr;
+  size_t i;
+  int rv;
+
+  ngtcp2_dcidtr_init(&dtr);
+
+  assert_false(ngtcp2_dcidtr_check_retired_seq_tracked(&dtr, 0));
+
+  rv = ngtcp2_dcidtr_track_retired_seq(&dtr, 0);
+
+  assert_int(0, ==, rv);
+  assert_true(ngtcp2_dcidtr_check_retired_seq_tracked(&dtr, 0));
+  assert_size(1, ==, dtr.retire_unacked.len);
+
+  ngtcp2_dcidtr_untrack_retired_seq(&dtr, 0);
+
+  assert_false(ngtcp2_dcidtr_check_retired_seq_tracked(&dtr, 0));
+  assert_size(0, ==, dtr.retire_unacked.len);
+
+  for (i = 0; i < NGTCP2_DCIDTR_MAX_UNUSED_DCID_SIZE * 2; ++i) {
+    rv = ngtcp2_dcidtr_track_retired_seq(&dtr, i);
+
+    assert_int(0, ==, rv);
+  }
+
+  rv = ngtcp2_dcidtr_track_retired_seq(&dtr, i);
+
+  assert_int(NGTCP2_ERR_CONNECTION_ID_LIMIT, ==, rv);
+}
+
+void test_ngtcp2_dcidtr_bind_dcid(void) {
+  ngtcp2_dcidtr dtr;
+  ngtcp2_cid cid = {0};
+  const uint8_t token[NGTCP2_STATELESS_RESET_TOKENLEN] = {5};
+  ngtcp2_dcid *dcid = NULL;
+  ngtcp2_path_storage ps;
+  ngtcp2_tstamp t = 1000000007;
+  size_t i;
+  userdata ud;
+  int rv;
+
+  path_init(&ps, 0, 0, 0, 7);
+  ngtcp2_dcidtr_init(&dtr);
+
+  ngtcp2_dcidtr_push_unused(&dtr, 0, &cid, token);
+
+  rv = ngtcp2_dcidtr_bind_dcid(&dtr, &dcid, &ps.path, t, NULL, NULL);
+
+  assert_int(0, ==, rv);
+  assert_ptr_equal(ngtcp2_ringbuf_get(&dtr.bound.rb, 0), dcid);
+  assert_true(ngtcp2_path_eq(&ps.path, &dcid->ps.path));
+  assert_size(0, ==, ngtcp2_ringbuf_len(&dtr.unused.rb));
+  assert_size(1, ==, ngtcp2_ringbuf_len(&dtr.bound.rb));
+
+  /* ngtcp2_dcid is retired when binding new Destination Connection ID
+     and the bound buffer is full. */
+  ngtcp2_dcidtr_init(&dtr);
+
+  for (i = 0; i < NGTCP2_DCIDTR_MAX_BOUND_DCID_SIZE + 1; ++i) {
+    ngtcp2_dcidtr_push_unused(&dtr, i, &cid, token);
+  }
+
+  for (i = 0; i < NGTCP2_DCIDTR_MAX_BOUND_DCID_SIZE; ++i) {
+    ud.cb_called = 0;
+    rv = ngtcp2_dcidtr_bind_dcid(&dtr, &dcid, &ps.path, t, dcidtr_cb, &ud);
+
+    assert_int(0, ==, rv);
+    assert_uint64((uint64_t)i, ==, dcid->seq);
+    assert_size(0, ==, ud.cb_called);
+  }
+
+  rv = ngtcp2_dcidtr_bind_dcid(&dtr, &dcid, &ps.path, t, dcidtr_cb, &ud);
+
+  assert_int(0, ==, rv);
+  assert_uint64((uint64_t)i, ==, dcid->seq);
+  assert_size(1, ==, ud.cb_called);
+  assert_true(ngtcp2_dcidtr_check_retired_seq_tracked(&dtr, 0));
+}
+
+void test_ngtcp2_dcidtr_find_bound_dcid(void) {
+  ngtcp2_dcidtr dtr;
+  ngtcp2_cid cid = {0};
+  const uint8_t token[NGTCP2_STATELESS_RESET_TOKENLEN] = {8};
+  ngtcp2_dcid *dcid;
+  ngtcp2_path_storage ps[2];
+  ngtcp2_tstamp t = 0;
+  int rv;
+  size_t i;
+
+  for (i = 0; i < ngtcp2_arraylen(ps); ++i) {
+    path_init(&ps[i], 0, 0, 0, (uint16_t)i + 1);
+  }
+
+  ngtcp2_dcidtr_init(&dtr);
+
+  ngtcp2_dcidtr_push_unused(&dtr, 0, &cid, token);
+
+  rv = ngtcp2_dcidtr_bind_dcid(&dtr, &dcid, &ps[0].path, t, NULL, NULL);
+
+  assert_int(0, ==, rv);
+  assert_null(ngtcp2_dcidtr_find_bound_dcid(&dtr, &ps[1].path));
+
+  dcid = ngtcp2_dcidtr_find_bound_dcid(&dtr, &ps[0].path);
+
+  assert_true(ngtcp2_path_eq(&ps[0].path, &dcid->ps.path));
+}
+
+void test_ngtcp2_dcidtr_bind_zerolen_dcid(void) {
+  ngtcp2_dcidtr dtr;
+  ngtcp2_path_storage ps;
+  ngtcp2_dcid *dcid;
+
+  path_init(&ps, 0, 1, 0, 2);
+  ngtcp2_dcidtr_init(&dtr);
+
+  dcid = ngtcp2_dcidtr_bind_zerolen_dcid(&dtr, &ps.path);
+
+  assert_uint64(1, ==, dcid->seq);
+  assert_true(ngtcp2_path_eq(&ps.path, &dcid->ps.path));
+
+  dcid = ngtcp2_dcidtr_bind_zerolen_dcid(&dtr, &ps.path);
+
+  assert_uint64(2, ==, dcid->seq);
+  assert_true(ngtcp2_path_eq(&ps.path, &dcid->ps.path));
+}
+
+void test_ngtcp2_dcidtr_verify_stateless_reset(void) {
+  ngtcp2_dcidtr dtr;
+  ngtcp2_path_storage ps[3];
+  ngtcp2_cid cid[] = {
+    {
+      .data = {1},
+      .datalen = 7,
+    },
+    {
+      .data = {2},
+      .datalen = 7,
+    },
+    {
+      .data = {3},
+      .datalen = 7,
+    },
+  };
+  const uint8_t token[][NGTCP2_STATELESS_RESET_TOKENLEN] = {
+    {1},
+    {2},
+    {3},
+  };
+  ngtcp2_dcid *dcid;
+  ngtcp2_dcid active_dcid;
+  size_t i;
+  int rv;
+
+  for (i = 0; i < ngtcp2_arraylen(ps); ++i) {
+    path_init(&ps[i], 0, 0, 0, (uint16_t)i + 1);
+  }
+
+  ngtcp2_dcidtr_init(&dtr);
+
+  for (i = 0; i < ngtcp2_arraylen(cid) - 1; ++i) {
+    ngtcp2_dcidtr_push_unused(&dtr, i, &cid[i], token[i]);
+  }
+
+  rv = ngtcp2_dcidtr_bind_dcid(&dtr, &dcid, &ps[0].path, 0, NULL, NULL);
+
+  assert_int(0, ==, rv);
+
+  rv = ngtcp2_dcidtr_verify_stateless_reset(&dtr, &ps[0].path, token[0]);
+
+  assert_int(0, ==, rv);
+
+  rv = ngtcp2_dcidtr_verify_stateless_reset(&dtr, &ps[1].path, token[1]);
+
+  assert_int(NGTCP2_ERR_INVALID_ARGUMENT, ==, rv);
+
+  ngtcp2_dcid_init(&active_dcid, 2, &cid[2], token[2]);
+  ngtcp2_dcid_set_path(&active_dcid, &ps[2].path);
+
+  rv = ngtcp2_dcidtr_retire_active_dcid(&dtr, &active_dcid, 0, NULL, NULL);
+
+  assert_int(0, ==, rv);
+
+  rv = ngtcp2_dcidtr_verify_stateless_reset(&dtr, &ps[2].path, token[2]);
+
+  assert_int(0, ==, rv);
+}
+
+void test_ngtcp2_dcidtr_verify_token_uniqueness(void) {
+  ngtcp2_dcidtr dtr;
+  ngtcp2_path_storage ps[3];
+  ngtcp2_cid cid[] = {
+    {
+      .data = {1},
+      .datalen = 7,
+    },
+    {
+      .data = {2},
+      .datalen = 7,
+    },
+    {
+      .data = {3},
+      .datalen = 7,
+    },
+  };
+  const uint8_t token[][NGTCP2_STATELESS_RESET_TOKENLEN] = {
+    {1},
+    {2},
+    {3},
+  };
+  ngtcp2_dcid *dcid;
+  size_t i;
+  int rv;
+  int found;
+
+  for (i = 0; i < ngtcp2_arraylen(ps); ++i) {
+    path_init(&ps[i], 0, 0, 0, (uint16_t)i + 1);
+  }
+
+  ngtcp2_dcidtr_init(&dtr);
+
+  for (i = 0; i < ngtcp2_arraylen(cid) - 1; ++i) {
+    ngtcp2_dcidtr_push_unused(&dtr, i, &cid[i], token[i]);
+  }
+
+  rv = ngtcp2_dcidtr_bind_dcid(&dtr, &dcid, &ps[0].path, 0, NULL, NULL);
+
+  assert_int(0, ==, rv);
+
+  found = 0;
+  rv =
+    ngtcp2_dcidtr_verify_token_uniqueness(&dtr, &found, 0, &cid[0], token[0]);
+
+  assert_int(0, ==, rv);
+  assert_true(found);
+
+  found = 0;
+  rv =
+    ngtcp2_dcidtr_verify_token_uniqueness(&dtr, &found, 1, &cid[1], token[1]);
+
+  assert_int(0, ==, rv);
+  assert_true(found);
+
+  found = 0;
+  rv =
+    ngtcp2_dcidtr_verify_token_uniqueness(&dtr, &found, 2, &cid[2], token[2]);
+
+  assert_int(0, ==, rv);
+  assert_false(found);
+
+  rv =
+    ngtcp2_dcidtr_verify_token_uniqueness(&dtr, &found, 1, &cid[2], token[2]);
+
+  assert_int(NGTCP2_ERR_PROTO, ==, rv);
+
+  rv =
+    ngtcp2_dcidtr_verify_token_uniqueness(&dtr, &found, 2, &cid[0], token[0]);
+
+  assert_int(NGTCP2_ERR_PROTO, ==, rv);
+}
+
+void test_ngtcp2_dcidtr_retire_inactive_dcid_prior_to(void) {
+  ngtcp2_dcidtr dtr;
+  ngtcp2_path_storage ps[4];
+  ngtcp2_cid cid[] = {
+    {
+      .data = {1},
+      .datalen = 7,
+    },
+    {
+      .data = {2},
+      .datalen = 7,
+    },
+    {
+      .data = {3},
+      .datalen = 7,
+    },
+    {
+      .data = {4},
+      .datalen = 7,
+    },
+  };
+  const uint8_t token[][NGTCP2_STATELESS_RESET_TOKENLEN] = {
+    {1},
+    {2},
+    {3},
+    {4},
+  };
+  ngtcp2_dcid *dcid;
+  size_t i;
+  int rv;
+  userdata ud;
+
+  for (i = 0; i < ngtcp2_arraylen(ps); ++i) {
+    path_init(&ps[i], 0, 0, 0, (uint16_t)i + 1);
+  }
+
+  ngtcp2_dcidtr_init(&dtr);
+
+  for (i = 0; i < ngtcp2_arraylen(cid); ++i) {
+    ngtcp2_dcidtr_push_unused(&dtr, i, &cid[i], token[i]);
+  }
+
+  for (i = 0; i < 2; ++i) {
+    rv = ngtcp2_dcidtr_bind_dcid(&dtr, &dcid, &ps[i].path, 0, NULL, NULL);
+
+    assert_int(0, ==, rv);
+  }
+
+  ud.cb_called = 0;
+  rv = ngtcp2_dcidtr_retire_inactive_dcid_prior_to(&dtr, 3, dcidtr_cb, &ud);
+
+  assert_int(0, ==, rv);
+  assert_size(3, ==, ud.cb_called);
+  assert_size(1, ==, ngtcp2_dcidtr_unused_len(&dtr));
+  assert_size(0, ==, ngtcp2_dcidtr_bound_len(&dtr));
+
+  dcid = ngtcp2_ringbuf_get(&dtr.unused.rb, 0);
+
+  assert_uint64(3, ==, dcid->seq);
+}
+
+void test_ngtcp2_dcidtr_retire_active_dcid(void) {
+  ngtcp2_dcidtr dtr;
+  ngtcp2_path_storage ps;
+  ngtcp2_cid cid = {
+    .data = {1},
+    .datalen = 9,
+  };
+  const uint8_t token[NGTCP2_STATELESS_RESET_TOKENLEN] = {1};
+  ngtcp2_dcid dcid, *retired_dcid;
+  size_t i;
+  userdata ud;
+  int rv;
+
+  path_init(&ps, 0, 0, 0, 1);
+  ngtcp2_dcidtr_init(&dtr);
+
+  for (i = 0; i < NGTCP2_DCIDTR_MAX_RETIRED_DCID_SIZE; ++i) {
+    ngtcp2_dcid_init(&dcid, i, &cid, token);
+    ud.cb_called = 0;
+    rv = ngtcp2_dcidtr_retire_active_dcid(&dtr, &dcid, 1000000007 + i,
+                                          dcidtr_cb, &ud);
+
+    assert_int(0, ==, rv);
+    assert_size(0, ==, ud.cb_called);
+
+    retired_dcid = ngtcp2_ringbuf_get(&dtr.retired.rb,
+                                      ngtcp2_ringbuf_len(&dtr.retired.rb) - 1);
+
+    assert_uint64(i, ==, retired_dcid->seq);
+    assert_true(ngtcp2_cid_eq(&cid, &retired_dcid->cid));
+    assert_memory_equal(sizeof(token), token, retired_dcid->token);
+  }
+
+  ngtcp2_dcid_init(&dcid, i, &cid, token);
+  ud.cb_called = 0;
+  rv = ngtcp2_dcidtr_retire_active_dcid(&dtr, &dcid, 1000000007 + i, dcidtr_cb,
+                                        &ud);
+
+  assert_int(0, ==, rv);
+  assert_size(1, ==, ud.cb_called);
+
+  retired_dcid = ngtcp2_ringbuf_get(&dtr.retired.rb,
+                                    ngtcp2_ringbuf_len(&dtr.retired.rb) - 1);
+
+  assert_uint64(i, ==, retired_dcid->seq);
+  assert_true(ngtcp2_cid_eq(&cid, &retired_dcid->cid));
+  assert_memory_equal(sizeof(token), token, retired_dcid->token);
+}
+
+void test_ngtcp2_dcidtr_retire_stale_bound_dcid(void) {
+  ngtcp2_dcidtr dtr;
+  ngtcp2_path_storage ps;
+  ngtcp2_cid cid = {
+    .data = {1},
+    .datalen = 11,
+  };
+  const uint8_t token[NGTCP2_STATELESS_RESET_TOKENLEN] = {0xfe};
+  ngtcp2_dcid *dcid;
+  size_t i;
+  userdata ud;
+  int rv;
+  ngtcp2_tstamp t = 1000;
+
+  path_init(&ps, 0, 0, 0, 1);
+  ngtcp2_dcidtr_init(&dtr);
+
+  for (i = 0; i < 3; ++i) {
+    ngtcp2_dcidtr_push_unused(&dtr, i, &cid, token);
+
+    rv = ngtcp2_dcidtr_bind_dcid(&dtr, &dcid, &ps.path, t + i, NULL, NULL);
+
+    assert_int(0, ==, rv);
+  }
+
+  ud.cb_called = 0;
+  rv = ngtcp2_dcidtr_retire_stale_bound_dcid(&dtr, 100, t + 99, dcidtr_cb, &ud);
+
+  assert_int(0, ==, rv);
+  assert_size(0, ==, ud.cb_called);
+
+  ud.cb_called = 0;
+  rv =
+    ngtcp2_dcidtr_retire_stale_bound_dcid(&dtr, 100, t + 101, dcidtr_cb, &ud);
+
+  assert_int(0, ==, rv);
+  assert_size(2, ==, ud.cb_called);
+  assert_true(ngtcp2_dcidtr_check_retired_seq_tracked(&dtr, 0));
+  assert_true(ngtcp2_dcidtr_check_retired_seq_tracked(&dtr, 1));
+}
+
+void test_ngtcp2_dcidtr_remove_stale_retired_dcid(void) {
+  ngtcp2_dcidtr dtr;
+  ngtcp2_path_storage ps;
+  ngtcp2_cid cid = {
+    .data = {1},
+    .datalen = 1,
+  };
+  const uint8_t token[NGTCP2_STATELESS_RESET_TOKENLEN] = {1};
+  ngtcp2_dcid dcid, *retired_dcid;
+  size_t i;
+  userdata ud;
+  int rv;
+  ngtcp2_tstamp t = 1000000009;
+
+  path_init(&ps, 0, 0, 0, 1);
+  ngtcp2_dcidtr_init(&dtr);
+
+  for (i = 0; i < NGTCP2_DCIDTR_MAX_RETIRED_DCID_SIZE; ++i) {
+    ngtcp2_dcid_init(&dcid, i, &cid, token);
+    ud.cb_called = 0;
+    rv = ngtcp2_dcidtr_retire_active_dcid(&dtr, &dcid, t + i, dcidtr_cb, &ud);
+
+    assert_int(0, ==, rv);
+    assert_size(0, ==, ud.cb_called);
+  }
+
+  ud.cb_called = 0;
+  rv =
+    ngtcp2_dcidtr_remove_stale_retired_dcid(&dtr, 100, t + 99, dcidtr_cb, &ud);
+
+  assert_int(0, ==, rv);
+  assert_size(0, ==, ud.cb_called);
+
+  ud.cb_called = 0;
+  rv =
+    ngtcp2_dcidtr_remove_stale_retired_dcid(&dtr, 100, t + 100, dcidtr_cb, &ud);
+
+  assert_int(0, ==, rv);
+  assert_size(1, ==, ud.cb_called);
+  assert_size(1, ==, ngtcp2_ringbuf_len(&dtr.retired.rb));
+
+  retired_dcid = ngtcp2_ringbuf_get(&dtr.retired.rb, 0);
+
+  assert_uint64(1, ==, retired_dcid->seq);
+}
+
+void test_ngtcp2_dcidtr_pop_bound_dcid(void) {
+  ngtcp2_dcidtr dtr;
+  ngtcp2_path_storage ps[3];
+  ngtcp2_cid cid = {
+    .data = {1},
+    .datalen = 11,
+  };
+  const uint8_t token[NGTCP2_STATELESS_RESET_TOKENLEN] = {0xfe};
+  ngtcp2_dcid *dcid, bound_dcid;
+  size_t i;
+  int rv;
+
+  for (i = 0; i < ngtcp2_arraylen(ps); ++i) {
+    path_init(&ps[i], 0, 0, 0, (uint16_t)i + 1);
+  }
+
+  ngtcp2_dcidtr_init(&dtr);
+
+  for (i = 0; i < 2; ++i) {
+    ngtcp2_dcidtr_push_unused(&dtr, i, &cid, token);
+
+    rv = ngtcp2_dcidtr_bind_dcid(&dtr, &dcid, &ps[i].path, 0, NULL, NULL);
+
+    assert_int(0, ==, rv);
+  }
+
+  assert_int(NGTCP2_ERR_INVALID_ARGUMENT, ==,
+             ngtcp2_dcidtr_pop_bound_dcid(&dtr, &bound_dcid, &ps[2].path));
+  assert_int(0, ==,
+             ngtcp2_dcidtr_pop_bound_dcid(&dtr, &bound_dcid, &ps[1].path));
+  assert_uint64(1, ==, bound_dcid.seq);
+  assert_true(ngtcp2_path_eq(&ps[1].path, &bound_dcid.ps.path));
+}
+
+void test_ngtcp2_dcidtr_earliest_bound_ts(void) {
+  ngtcp2_dcidtr dtr;
+  ngtcp2_path_storage ps;
+  ngtcp2_cid cid = {
+    .data = {1},
+    .datalen = 11,
+  };
+  const uint8_t token[NGTCP2_STATELESS_RESET_TOKENLEN] = {0xfe};
+  ngtcp2_dcid *dcid;
+  size_t i;
+  int rv;
+  ngtcp2_tstamp t = 10000007;
+
+  path_init(&ps, 0, 0, 0, 1);
+  ngtcp2_dcidtr_init(&dtr);
+
+  assert_uint64(UINT64_MAX, ==, ngtcp2_dcidtr_earliest_bound_ts(&dtr));
+
+  for (i = 0; i < 3; ++i) {
+    ngtcp2_dcidtr_push_unused(&dtr, i, &cid, token);
+
+    rv = ngtcp2_dcidtr_bind_dcid(&dtr, &dcid, &ps.path, t + i, NULL, NULL);
+
+    assert_int(0, ==, rv);
+  }
+
+  assert_uint64(t, ==, ngtcp2_dcidtr_earliest_bound_ts(&dtr));
+}
+
+void test_ngtcp2_dcidtr_earliest_retired_ts(void) {
+  ngtcp2_dcidtr dtr;
+  ngtcp2_path_storage ps;
+  ngtcp2_cid cid = {
+    .data = {1},
+    .datalen = 1,
+  };
+  const uint8_t token[NGTCP2_STATELESS_RESET_TOKENLEN] = {1};
+  ngtcp2_dcid dcid;
+  int rv;
+  ngtcp2_tstamp t = 1000000009;
+
+  path_init(&ps, 0, 0, 0, 1);
+  ngtcp2_dcidtr_init(&dtr);
+
+  assert_uint64(UINT64_MAX, ==, ngtcp2_dcidtr_earliest_retired_ts(&dtr));
+
+  ngtcp2_dcid_init(&dcid, 0, &cid, token);
+
+  rv = ngtcp2_dcidtr_retire_active_dcid(&dtr, &dcid, t, NULL, NULL);
+
+  assert_int(0, ==, rv);
+  assert_uint64(t, ==, ngtcp2_dcidtr_earliest_retired_ts(&dtr));
+}
+
+void test_ngtcp2_dcidtr_pop_unused(void) {
+  ngtcp2_dcidtr dtr;
+  ngtcp2_path_storage ps;
+  ngtcp2_cid cid = {
+    .data = {1},
+    .datalen = 11,
+  };
+  const uint8_t token[NGTCP2_STATELESS_RESET_TOKENLEN] = {0xfe};
+  ngtcp2_dcid dcid;
+  size_t i;
+
+  ngtcp2_dcidtr_init(&dtr);
+
+  assert_uint64(UINT64_MAX, ==, ngtcp2_dcidtr_earliest_bound_ts(&dtr));
+
+  for (i = 0; i < 2; ++i) {
+    ngtcp2_dcidtr_push_unused(&dtr, 9155421 + i, &cid, token);
+  }
+
+  path_init(&dcid.ps, 0, 0, 0, 1);
+  ngtcp2_dcidtr_pop_unused(&dtr, &dcid);
+
+  assert_uint64(9155421, ==, dcid.seq);
+  assert_true(ngtcp2_cid_eq(&cid, &dcid.cid));
+  assert_size(0, ==, (size_t)dcid.ps.path.local.addrlen);
+  assert_size(0, ==, (size_t)dcid.ps.path.remote.addrlen);
+
+  path_init(&dcid.ps, 0, 0, 0, 1);
+  ngtcp2_path_storage_zero(&ps);
+  ngtcp2_path_copy(&ps.path, &dcid.ps.path);
+  ngtcp2_dcidtr_pop_unused_cid_token(&dtr, &dcid);
+
+  assert_uint64(9155422, ==, dcid.seq);
+  assert_true(ngtcp2_cid_eq(&cid, &dcid.cid));
+  assert_true(ngtcp2_path_eq(&ps.path, &dcid.ps.path));
+}
+
+void test_ngtcp2_dcidtr_check_path_retired(void) {
+  ngtcp2_dcidtr dtr;
+  ngtcp2_path_storage ps[2];
+  ngtcp2_cid cid = {
+    .data = {1},
+    .datalen = 1,
+  };
+  const uint8_t token[NGTCP2_STATELESS_RESET_TOKENLEN] = {1};
+  ngtcp2_dcid dcid;
+  size_t i;
+  int rv;
+  ngtcp2_tstamp t = 1000000009;
+
+  for (i = 0; i < ngtcp2_arraylen(ps); ++i) {
+    path_init(&ps[i], 0, 0, 0, (uint16_t)i + 1);
+  }
+
+  ngtcp2_dcidtr_init(&dtr);
+  ngtcp2_dcid_init(&dcid, 0, &cid, token);
+  ngtcp2_dcid_set_path(&dcid, &ps[1].path);
+
+  rv = ngtcp2_dcidtr_retire_active_dcid(&dtr, &dcid, t, NULL, NULL);
+
+  assert_int(0, ==, rv);
+  assert_false(ngtcp2_dcidtr_check_path_retired(&dtr, &ps[0].path));
+  assert_true(ngtcp2_dcidtr_check_path_retired(&dtr, &ps[1].path));
+}
+
+void test_ngtcp2_dcidtr_len(void) {
+  ngtcp2_dcidtr dtr;
+  ngtcp2_path_storage ps;
+  ngtcp2_cid cid = {
+    .data = {1},
+    .datalen = 1,
+  };
+  const uint8_t token[NGTCP2_STATELESS_RESET_TOKENLEN] = {1};
+  ngtcp2_dcid *dcid, retired_dcid;
+  size_t i;
+  int rv;
+
+  path_init(&ps, 0, 0, 0, 1);
+  ngtcp2_dcidtr_init(&dtr);
+
+  assert_size(0, ==, ngtcp2_dcidtr_unused_len(&dtr));
+  assert_size(0, ==, ngtcp2_dcidtr_bound_len(&dtr));
+  assert_size(0, ==, ngtcp2_dcidtr_retired_len(&dtr));
+  assert_size(0, ==, ngtcp2_dcidtr_inactive_len(&dtr));
+  assert_true(ngtcp2_dcidtr_unused_empty(&dtr));
+  assert_false(ngtcp2_dcidtr_unused_full(&dtr));
+  assert_false(ngtcp2_dcidtr_bound_full(&dtr));
+
+  for (i = 0; i < NGTCP2_DCIDTR_MAX_UNUSED_DCID_SIZE; ++i) {
+    ngtcp2_dcidtr_push_unused(&dtr, 0, &cid, token);
+  }
+
+  assert_size(NGTCP2_DCIDTR_MAX_UNUSED_DCID_SIZE, ==,
+              ngtcp2_dcidtr_unused_len(&dtr));
+  assert_size(0, ==, ngtcp2_dcidtr_bound_len(&dtr));
+  assert_size(0, ==, ngtcp2_dcidtr_retired_len(&dtr));
+  assert_size(NGTCP2_DCIDTR_MAX_UNUSED_DCID_SIZE, ==,
+              ngtcp2_dcidtr_inactive_len(&dtr));
+  assert_false(ngtcp2_dcidtr_unused_empty(&dtr));
+  assert_true(ngtcp2_dcidtr_unused_full(&dtr));
+  assert_false(ngtcp2_dcidtr_bound_full(&dtr));
+
+  for (i = 0; i < NGTCP2_DCIDTR_MAX_BOUND_DCID_SIZE; ++i) {
+    rv = ngtcp2_dcidtr_bind_dcid(&dtr, &dcid, &ps.path, 0, NULL, NULL);
+
+    assert_int(0, ==, rv);
+  }
+
+  assert_size(4, ==, ngtcp2_dcidtr_unused_len(&dtr));
+  assert_size(NGTCP2_DCIDTR_MAX_BOUND_DCID_SIZE, ==,
+              ngtcp2_dcidtr_bound_len(&dtr));
+  assert_size(0, ==, ngtcp2_dcidtr_retired_len(&dtr));
+  assert_size(4 + NGTCP2_DCIDTR_MAX_BOUND_DCID_SIZE, ==,
+              ngtcp2_dcidtr_inactive_len(&dtr));
+  assert_false(ngtcp2_dcidtr_unused_empty(&dtr));
+  assert_false(ngtcp2_dcidtr_unused_full(&dtr));
+  assert_true(ngtcp2_dcidtr_bound_full(&dtr));
+
+  for (i = 0; i < NGTCP2_DCIDTR_MAX_RETIRED_DCID_SIZE; ++i) {
+    ngtcp2_dcid_init(&retired_dcid, 0, &cid, token);
+
+    rv = ngtcp2_dcidtr_retire_active_dcid(&dtr, &retired_dcid, 0, NULL, NULL);
+
+    assert_int(0, ==, rv);
+  }
+
+  assert_size(4, ==, ngtcp2_dcidtr_unused_len(&dtr));
+  assert_size(NGTCP2_DCIDTR_MAX_BOUND_DCID_SIZE, ==,
+              ngtcp2_dcidtr_bound_len(&dtr));
+  assert_size(NGTCP2_DCIDTR_MAX_RETIRED_DCID_SIZE, ==,
+              ngtcp2_dcidtr_retired_len(&dtr));
+  assert_size(4 + NGTCP2_DCIDTR_MAX_BOUND_DCID_SIZE, ==,
+              ngtcp2_dcidtr_inactive_len(&dtr));
+  assert_false(ngtcp2_dcidtr_unused_empty(&dtr));
+  assert_false(ngtcp2_dcidtr_unused_full(&dtr));
+  assert_true(ngtcp2_dcidtr_bound_full(&dtr));
+}

--- a/tests/ngtcp2_dcidtr_test.h
+++ b/tests/ngtcp2_dcidtr_test.h
@@ -1,0 +1,55 @@
+/*
+ * ngtcp2
+ *
+ * Copyright (c) 2025 ngtcp2 contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+#ifndef NGTCP2_DCIDTR_TEST_H
+#define NGTCP2_DCIDTR_TEST_H
+
+#ifdef HAVE_CONFIG_H
+#  include <config.h>
+#endif /* defined(HAVE_CONFIG_H) */
+
+#define MUNIT_ENABLE_ASSERT_ALIASES
+
+#include "munit.h"
+
+extern const MunitSuite dcidtr_suite;
+
+munit_void_test_decl(test_ngtcp2_dcidtr_track_retired_seq)
+munit_void_test_decl(test_ngtcp2_dcidtr_bind_dcid)
+munit_void_test_decl(test_ngtcp2_dcidtr_find_bound_dcid)
+munit_void_test_decl(test_ngtcp2_dcidtr_bind_zerolen_dcid)
+munit_void_test_decl(test_ngtcp2_dcidtr_verify_stateless_reset)
+munit_void_test_decl(test_ngtcp2_dcidtr_verify_token_uniqueness)
+munit_void_test_decl(test_ngtcp2_dcidtr_retire_inactive_dcid_prior_to)
+munit_void_test_decl(test_ngtcp2_dcidtr_retire_active_dcid)
+munit_void_test_decl(test_ngtcp2_dcidtr_retire_stale_bound_dcid)
+munit_void_test_decl(test_ngtcp2_dcidtr_remove_stale_retired_dcid)
+munit_void_test_decl(test_ngtcp2_dcidtr_pop_bound_dcid)
+munit_void_test_decl(test_ngtcp2_dcidtr_earliest_bound_ts)
+munit_void_test_decl(test_ngtcp2_dcidtr_earliest_retired_ts)
+munit_void_test_decl(test_ngtcp2_dcidtr_pop_unused)
+munit_void_test_decl(test_ngtcp2_dcidtr_check_path_retired)
+munit_void_test_decl(test_ngtcp2_dcidtr_len)
+
+#endif /* !defined(NGTCP2_DCIDTR_TEST_H) */


### PR DESCRIPTION
Extract code around Destination Connection ID to ngtcp2_dcidtr so that those operations are not cluttered in ngtcp2_conn, and make it much more maintainable and testable.