### PR TITLE
Avoid limiting CWND during path validation

### DIFF
--- a/lib/ngtcp2_conn.c
+++ b/lib/ngtcp2_conn.c
@@ -1892,21 +1892,12 @@ static size_t pktns_select_pkt_numlen(ngtcp2_pktns *pktns) {
 }
 
 /*
- * conn_get_cwnd returns cwnd for the current path.
- */
-static uint64_t conn_get_cwnd(ngtcp2_conn *conn) {
-  return conn->pv && (conn->pv->flags & NGTCP2_PV_FLAG_FALLBACK_ON_FAILURE)
-           ? ngtcp2_cc_compute_initcwnd(conn->cstat.max_tx_udp_payload_size)
-           : conn->cstat.cwnd;
-}
-
-/*
  * conn_cwnd_is_zero returns nonzero if the number of bytes the local
  * endpoint can sent at this time is zero.
  */
 static int conn_cwnd_is_zero(ngtcp2_conn *conn) {
   uint64_t bytes_in_flight = conn->cstat.bytes_in_flight;
-  uint64_t cwnd = conn_get_cwnd(conn);
+  uint64_t cwnd = conn->cstat.cwnd;
 
   if (bytes_in_flight >= cwnd) {
     ngtcp2_log_info(&conn->log, NGTCP2_LOG_EVENT_LDC,
@@ -13258,7 +13249,7 @@ uint64_t ngtcp2_conn_get_streams_uni_left(ngtcp2_conn *conn) {
 
 uint64_t ngtcp2_conn_get_cwnd_left(ngtcp2_conn *conn) {
   uint64_t bytes_in_flight = conn->cstat.bytes_in_flight;
-  uint64_t cwnd = conn_get_cwnd(conn);
+  uint64_t cwnd = conn->cstat.cwnd;
 
   if (cwnd > bytes_in_flight) {
     return cwnd - bytes_in_flight;


### PR DESCRIPTION
We already limit the amount of data to send under 3x amplification limit, so no need to further punish CWND in this period.