### PR TITLE
fuzz: Set negotiated version before setting remote transport params

### DIFF
--- a/fuzz/read_write_pkt.cc
+++ b/fuzz/read_write_pkt.cc
@@ -707,6 +707,9 @@ ngtcp2_conn *setup_conn(FuzzedDataProvider &fuzzed_data_provider,
     }
   }
 
+  conn->negotiated_version = conn->client_chosen_version;
+  conn->pktns.rtb.persistent_congestion_start_ts = 0;
+
   auto chunk_len = fuzzed_data_provider.ConsumeIntegral<size_t>();
   auto chunk = fuzzed_data_provider.ConsumeBytes<uint8_t>(chunk_len);
 
@@ -716,9 +719,6 @@ ngtcp2_conn *setup_conn(FuzzedDataProvider &fuzzed_data_provider,
     ngtcp2_conn_del(conn);
     return nullptr;
   }
-
-  conn->negotiated_version = conn->client_chosen_version;
-  conn->pktns.rtb.persistent_congestion_start_ts = 0;
 
   return conn;
 }


### PR DESCRIPTION
conn_client_validate_transport_params() validates params.version_info.chosen_version by comparing it to conn.negotiated_version. To ensure this validation works correctly, conn.negotiated_version should be set before calling ngtcp2_conn_decode_and_set_remote_transport_params().