### PR TITLE
Fix ngtcp2_conn_get_active_dcid for zero-length DCID

### DIFF
--- a/lib/ngtcp2_conn.c
+++ b/lib/ngtcp2_conn.c
@@ -13010,6 +13010,10 @@ static size_t conn_get_num_active_dcid(ngtcp2_conn *conn) {
   size_t n = 1; /* for conn->dcid.current */
   ngtcp2_pv *pv = conn->pv;
 
+  if (conn->dcid.current.cid.datalen == 0) {
+    return n;
+  }
+
   if (pv) {
     if (pv->dcid.seq != conn->dcid.current.seq) {
       ++n;
@@ -13053,6 +13057,10 @@ size_t ngtcp2_conn_get_active_dcid(ngtcp2_conn *conn, ngtcp2_cid_token *dest) {
 
   copy_dcid_to_cid_token(dest, &conn->dcid.current);
   ++dest;
+
+  if (conn->dcid.current.cid.datalen == 0) {
+    return 1;
+  }
 
   if (pv) {
     if (pv->dcid.seq != conn->dcid.current.seq) {

--- a/lib/ngtcp2_dcidtr.c
+++ b/lib/ngtcp2_dcidtr.c
@@ -34,7 +34,6 @@ void ngtcp2_dcidtr_init(ngtcp2_dcidtr *dtr) {
   ngtcp2_static_ringbuf_dcid_bound_init(&dtr->bound);
   ngtcp2_static_ringbuf_dcid_retired_init(&dtr->retired);
 
-  dtr->zerolen_seq = 0;
   dtr->retire_unacked.len = 0;
 }
 
@@ -123,7 +122,7 @@ ngtcp2_dcid *ngtcp2_dcidtr_bind_zerolen_dcid(ngtcp2_dcidtr *dtr,
   ngtcp2_cid cid;
 
   ngtcp2_cid_zero(&cid);
-  ngtcp2_dcid_init(dcid, ++dtr->zerolen_seq, &cid, NULL);
+  ngtcp2_dcid_init(dcid, 0, &cid, NULL);
   ngtcp2_dcid_set_path(dcid, path);
 
   return dcid;

--- a/lib/ngtcp2_dcidtr.h
+++ b/lib/ngtcp2_dcidtr.h
@@ -71,10 +71,6 @@ typedef struct ngtcp2_dcidtr {
      endpoint.  Keep them in 3*PTO to catch packets in flight along
      the old path.  They are considered active. */
   ngtcp2_static_ringbuf_dcid_retired retired;
-  /* zerolen_seq is a pseudo sequence number of zero-length
-     Destination Connection ID in order to distinguish between
-     them. */
-  uint64_t zerolen_seq;
   struct {
     /* seqs contains sequence number of Destination Connection ID
        whose retirement is not acknowledged by the remote endpoint

--- a/tests/ngtcp2_dcidtr_test.c
+++ b/tests/ngtcp2_dcidtr_test.c
@@ -185,12 +185,12 @@ void test_ngtcp2_dcidtr_bind_zerolen_dcid(void) {
 
   dcid = ngtcp2_dcidtr_bind_zerolen_dcid(&dtr, &ps.path);
 
-  assert_uint64(1, ==, dcid->seq);
+  assert_uint64(0, ==, dcid->seq);
   assert_true(ngtcp2_path_eq(&ps.path, &dcid->ps.path));
 
   dcid = ngtcp2_dcidtr_bind_zerolen_dcid(&dtr, &ps.path);
 
-  assert_uint64(2, ==, dcid->seq);
+  assert_uint64(0, ==, dcid->seq);
   assert_true(ngtcp2_path_eq(&ps.path, &dcid->ps.path));
 }
 


### PR DESCRIPTION
ngtcp2_conn_get_active_dcid now always returns 1 if Destination Connection ID is zero length after handshake completion.  Its sequence number is 0.