### PR TITLE
Rename persistent_congestion_started_ts to handshake_confirmed_ts

### DIFF
--- a/fuzz/read_write_pkt.cc
+++ b/fuzz/read_write_pkt.cc
@@ -708,7 +708,7 @@ ngtcp2_conn *setup_conn(FuzzedDataProvider &fuzzed_data_provider,
   }
 
   conn->negotiated_version = conn->client_chosen_version;
-  conn->pktns.rtb.persistent_congestion_start_ts = 0;
+  conn->handshake_confirmed_ts = 0;
 
   auto chunk_len = fuzzed_data_provider.ConsumeIntegral<size_t>();
   auto chunk = fuzzed_data_provider.ConsumeBytes<uint8_t>(chunk_len);

--- a/lib/ngtcp2_conn.c
+++ b/lib/ngtcp2_conn.c
@@ -1377,6 +1377,7 @@ static int conn_new(ngtcp2_conn **pconn, const ngtcp2_cid *dcid,
   (*pconn)->mem = mem;
   (*pconn)->user_data = user_data;
   (*pconn)->idle_ts = settings->initial_ts;
+  (*pconn)->handshake_confirmed_ts = UINT64_MAX;
   (*pconn)->crypto.key_update.confirmed_ts = UINT64_MAX;
   (*pconn)->tx.last_max_data_ts = UINT64_MAX;
   (*pconn)->tx.pacing.next_ts = UINT64_MAX;
@@ -8109,7 +8110,7 @@ static int conn_recv_handshake_done(ngtcp2_conn *conn, ngtcp2_tstamp ts) {
   conn->flags |= NGTCP2_CONN_FLAG_HANDSHAKE_CONFIRMED |
                  NGTCP2_CONN_FLAG_SERVER_ADDR_VERIFIED;
 
-  conn->pktns.rtb.persistent_congestion_start_ts = ts;
+  conn->handshake_confirmed_ts = ts;
 
   ngtcp2_conn_discard_handshake_state(conn, ts);
 
@@ -9775,7 +9776,7 @@ static ngtcp2_ssize conn_read_handshake(ngtcp2_conn *conn,
       }
     }
 
-    conn->pktns.rtb.persistent_congestion_start_ts = ts;
+    conn->handshake_confirmed_ts = ts;
 
     /* Re-arm loss detection timer here after handshake has been
        confirmed. */

--- a/lib/ngtcp2_conn.h
+++ b/lib/ngtcp2_conn.h
@@ -636,6 +636,9 @@ struct ngtcp2_conn {
   const ngtcp2_mem *mem;
   /* idle_ts is the time instant when idle timer started. */
   ngtcp2_tstamp idle_ts;
+  /* handshake_confirmed_ts is the time instant when handshake is
+     confirmed.  For server, it is confirmed when completed. */
+  ngtcp2_tstamp handshake_confirmed_ts;
   void *user_data;
   uint32_t client_chosen_version;
   uint32_t negotiated_version;

--- a/lib/ngtcp2_rtb.c
+++ b/lib/ngtcp2_rtb.c
@@ -101,7 +101,6 @@ void ngtcp2_rtb_init(ngtcp2_rtb *rtb, ngtcp2_rst *rst, ngtcp2_cc *cc,
   rtb->probe_pkt_left = 0;
   rtb->cc_pkt_num = cc_pkt_num;
   rtb->cc_bytes_in_flight = 0;
-  rtb->persistent_congestion_start_ts = UINT64_MAX;
   rtb->num_lost_pkts = 0;
   rtb->num_lost_pmtud_pkts = 0;
 }
@@ -1052,7 +1051,7 @@ static int rtb_detect_lost_pkt(ngtcp2_rtb *rtb, uint64_t *ppkt_lost,
          max_ack_delay) *
         NGTCP2_PERSISTENT_CONGESTION_THRESHOLD;
 
-      start_ts = ngtcp2_max_uint64(rtb->persistent_congestion_start_ts,
+      start_ts = ngtcp2_max_uint64(conn->handshake_confirmed_ts,
                                    cstat->first_rtt_sample_ts);
 
       for (; !ngtcp2_ksl_it_end(&it); ngtcp2_ksl_it_next(&it)) {

--- a/lib/ngtcp2_rtb.h
+++ b/lib/ngtcp2_rtb.h
@@ -184,10 +184,6 @@ typedef struct ngtcp2_rtb {
      count a packet whose packet number is greater than or equals to
      cc_pkt_num. */
   uint64_t cc_bytes_in_flight;
-  /* persistent_congestion_start_ts is the time when persistent
-     congestion evaluation is started.  It happens roughly after
-     handshake is confirmed. */
-  ngtcp2_tstamp persistent_congestion_start_ts;
   /* num_lost_pkts is the number entries in ents which has
      NGTCP2_RTB_ENTRY_FLAG_LOST_RETRANSMITTED flag set. */
   size_t num_lost_pkts;

--- a/tests/ngtcp2_conn_test.c
+++ b/tests/ngtcp2_conn_test.c
@@ -905,7 +905,7 @@ static void setup_default_server_cid_settings(
   (*pconn)->local.uni.max_streams = remote_params.initial_max_streams_uni;
   (*pconn)->tx.max_offset = remote_params.initial_max_data;
   (*pconn)->negotiated_version = (*pconn)->client_chosen_version;
-  (*pconn)->pktns.rtb.persistent_congestion_start_ts = 0;
+  (*pconn)->handshake_confirmed_ts = 0;
 }
 
 static void
@@ -985,7 +985,7 @@ setup_default_client_settings(ngtcp2_conn **pconn, const ngtcp2_path *path,
 
   (*pconn)->dcid.current.flags |= NGTCP2_DCID_FLAG_TOKEN_PRESENT;
   memset((*pconn)->dcid.current.token, 0xf1, NGTCP2_STATELESS_RESET_TOKENLEN);
-  (*pconn)->pktns.rtb.persistent_congestion_start_ts = 0;
+  (*pconn)->handshake_confirmed_ts = 0;
 }
 
 static void setup_default_client(ngtcp2_conn **pconn) {


### PR DESCRIPTION
Rename persistent_congestion_started_ts to handshake_confirmed_ts, and move it to ngtcp2_conn.