### PR TITLE
Use WITH_EXAMPLE_BORINGSSL

### DIFF
--- a/examples/tls_session_base_quictls.cc
+++ b/examples/tls_session_base_quictls.cc
@@ -47,7 +47,7 @@ std::string TLSSessionBase::get_cipher_name() const {
 }
 
 std::string_view TLSSessionBase::get_negotiated_group() const {
-#if defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
+#ifdef WITH_EXAMPLE_BORINGSSL
   return SSL_get_group_name(SSL_get_group_id(ssl_));
 #elif OPENSSL_VERSION_NUMBER >= 0x30000000L
   auto name = SSL_group_to_name(ssl_, SSL_get_negotiated_group(ssl_));
@@ -58,7 +58,7 @@ std::string_view TLSSessionBase::get_negotiated_group() const {
   return name;
 #elif defined(LIBRESSL_VERSION_NUMBER)
   return ""sv;
-#else  // !(defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC) ||
+#else  // !(defined(WITH_EXAMPLE_BORINGSSL) ||
        // OPENSSL_VERSION_NUMBER >= 0x30000000L ||
        // defined(LIBRESSL_VERSION_NUMBER))
   EVP_PKEY *key;
@@ -86,7 +86,7 @@ std::string_view TLSSessionBase::get_negotiated_group() const {
   }
 
   return name;
-#endif // !(defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC) ||
+#endif // !(defined(WITH_EXAMPLE_BORINGSSL) ||
        // OPENSSL_VERSION_NUMBER >= 0x30000000L ||
        // defined(LIBRESSL_VERSION_NUMBER))
 }

--- a/examples/util_openssl.cc
+++ b/examples/util_openssl.cc
@@ -140,9 +140,9 @@ const char *crypto_default_ciphers() {
 
 const char *crypto_default_groups() {
   return "X25519:P-256:P-384:P-521"
-#if defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
+#ifdef WITH_EXAMPLE_BORINGSSL
          ":X25519MLKEM768"
-#endif // defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
+#endif // defined(WITH_EXAMPLE_BORINGSSL)
     ;
 }
 


### PR DESCRIPTION
Use WITH_EXAMPLE_BORINGSSL instead of OPENSSL_IS_BORINGSSL and OPENSSL_IS_AWSLC.