### PR TITLE
ngtcp2_idtr: Add stream ID upper bound check

### DIFF
--- a/lib/ngtcp2_idtr.c
+++ b/lib/ngtcp2_idtr.c
@@ -50,6 +50,10 @@ int ngtcp2_idtr_open(ngtcp2_idtr *idtr, int64_t stream_id) {
 
   q = id_from_stream_id(stream_id);
 
+  if (stream_id < 0 || stream_id >= (1ULL << 62)) {
+    return NGTCP2_ERR_INVALID_ARGUMENT;
+  }
+  
   if (ngtcp2_gaptr_is_pushed(&idtr->gap, q, 1)) {
     return NGTCP2_ERR_STREAM_IN_USE;
   }


### PR DESCRIPTION
According to the QUIC specification, stream IDs are 62-bit unsigned integers (i.e., valid range is [0, 2^62 - 1]).