### PR TITLE
putting important libdir and incdir first

### DIFF
--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -138,11 +138,12 @@ endif # ENABLE_EXAMPLE_GNUTLS
 if ENABLE_EXAMPLE_BORINGSSL
 noinst_PROGRAMS += bsslclient bsslserver
 
-bsslclient_CPPFLAGS = ${AM_CPPFLAGS} @BORINGSSL_CFLAGS@ -DWITH_EXAMPLE_BORINGSSL
-bsslclient_LDADD = ${LDADD} \
+bsslclient_CPPFLAGS = @BORINGSSL_CFLAGS@ -DWITH_EXAMPLE_BORINGSSL ${AM_CPPFLAGS}
+bsslclient_LDADD = \
 	$(top_builddir)/crypto/boringssl/libngtcp2_crypto_boringssl.a \
 	@BORINGSSL_LIBS@ \
-	@JEMALLOC_LIBS@
+	@JEMALLOC_LIBS@ \
+        ${LDADD}
 bsslclient_SOURCES = client.cc client.h ${CLIENT_SRCS} \
 	tls_client_context_boringssl.cc tls_client_context_boringssl.h \
 	tls_client_session_boringssl.cc tls_client_session_boringssl.h \


### PR DESCRIPTION
This should fix #1246.

This patch enabels to build "client"/"server" under examples with BoringSSL on macOS where "libev" is installed via macports.