### PR TITLE
Fix few warnings generated by gcc in tests

### DIFF
--- a/tests/ngtcp2_ringbuf_test.c
+++ b/tests/ngtcp2_ringbuf_test.c
@@ -49,8 +49,10 @@ void test_ngtcp2_ringbuf_push_front(void) {
   ngtcp2_ringbuf rb;
   const ngtcp2_mem *mem = ngtcp2_mem_default();
   size_t i;
+  int rv;
 
-  ngtcp2_ringbuf_init(&rb, 64, sizeof(ints), mem);
+  rv = ngtcp2_ringbuf_init(&rb, 64, sizeof(ints), mem);
+  assert_int(0, ==, rv);
 
   for (i = 0; i < 64; ++i) {
     ints *p = ngtcp2_ringbuf_push_front(&rb);
@@ -78,8 +80,10 @@ void test_ngtcp2_ringbuf_pop_front(void) {
   ngtcp2_ringbuf rb;
   const ngtcp2_mem *mem = ngtcp2_mem_default();
   size_t i;
+  int rv;
 
-  ngtcp2_ringbuf_init(&rb, 4, sizeof(ints), mem);
+  rv = ngtcp2_ringbuf_init(&rb, 4, sizeof(ints), mem);
+  assert_int(0, ==, rv);
 
   for (i = 0; i < 5; ++i) {
     ints *p = ngtcp2_ringbuf_push_front(&rb);

--- a/tests/ngtcp2_vec_test.c
+++ b/tests/ngtcp2_vec_test.c
@@ -600,7 +600,7 @@ void test_ngtcp2_vec_copy_at_most(void) {
   /* 0 length vectors */
   {
     ngtcp2_vec dst[1];
-    const ngtcp2_vec src[1];
+    const ngtcp2_vec src[1] = {0};
 
     n = ngtcp2_vec_copy_at_most(dst, 0, src, 0, 100);
 


### PR DESCRIPTION
Ensure memory allocation is checked by the test. In vector this change should not be required, but gcc emits warning about access to uniinitialized src. That should never be accessed with srccnt == 0, but add source initialization to keep compiler quiet.