### PR TITLE
Add Wave congestion control algorithm

### DIFF
--- a/examples/client.cc
+++ b/examples/client.cc
@@ -2645,7 +2645,7 @@ Options:
               specified.
   --disable-early-data
               Disable early data.
-  --cc=(cubic|reno|bbr)
+  --cc=(cubic|reno|bbr|wave)
               The name of congestion controller algorithm.
               Default: )"
             << util::strccalgo(config.cc_algo) << R"(
@@ -3039,7 +3039,11 @@ int main(int argc, char **argv) {
           config.cc_algo = NGTCP2_CC_ALGO_BBR;
           break;
         }
-        std::cerr << "cc: specify cubic, reno, or bbr" << std::endl;
+        if (strcmp("wave", optarg) == 0) {
+          config.cc_algo = NGTCP2_CC_ALGO_WAVE;
+          break;
+        }
+        std::cerr << "cc: specify cubic, reno, bbr or wave" << std::endl;
         exit(EXIT_FAILURE);
       case 28:
         // --exit-on-all-streams-close

--- a/examples/h09client.cc
+++ b/examples/h09client.cc
@@ -2159,7 +2159,7 @@ Options:
               specified.
   --disable-early-data
               Disable early data.
-  --cc=(cubic|reno|bbr)
+  --cc=(cubic|reno|bbr|wave)
               The name of congestion controller algorithm.
               Default: )"
             << util::strccalgo(config.cc_algo) << R"(
@@ -2552,7 +2552,11 @@ int main(int argc, char **argv) {
           config.cc_algo = NGTCP2_CC_ALGO_BBR;
           break;
         }
-        std::cerr << "cc: specify cubic, reno, or bbr" << std::endl;
+        if (strcmp("wave", optarg) == 0) {
+          config.cc_algo = NGTCP2_CC_ALGO_WAVE;
+          break;
+        }
+        std::cerr << "cc: specify cubic, reno, bbr or wave" << std::endl;
         exit(EXIT_FAILURE);
       case 28:
         // --exit-on-all-streams-close

--- a/examples/h09server.cc
+++ b/examples/h09server.cc
@@ -2738,7 +2738,7 @@ Options:
               The maximum length of a dynamically generated content.
               Default: )"
             << util::format_uint_iec(config.max_dyn_length) << R"(
-  --cc=(cubic|reno|bbr)
+  --cc=(cubic|reno|bbr|wave)
               The name of congestion controller algorithm.
               Default: )"
             << util::strccalgo(config.cc_algo) << R"(
@@ -3067,7 +3067,11 @@ int main(int argc, char **argv) {
           config.cc_algo = NGTCP2_CC_ALGO_BBR;
           break;
         }
-        std::cerr << "cc: specify cubic, reno, or bbr" << std::endl;
+        if (strcmp("wave", optarg) == 0) {
+          config.cc_algo = NGTCP2_CC_ALGO_WAVE;
+          break;
+        }
+        std::cerr << "cc: specify cubic, reno, bbr or wave" << std::endl;
         exit(EXIT_FAILURE);
       case 20:
         // --initial-rtt

--- a/examples/server.cc
+++ b/examples/server.cc
@@ -3468,7 +3468,7 @@ Options:
               The maximum length of a dynamically generated content.
               Default: )"
             << util::format_uint_iec(config.max_dyn_length) << R"(
-  --cc=(cubic|reno|bbr)
+  --cc=(cubic|reno|bbr|wave)
               The name of congestion controller algorithm.
               Default: )"
             << util::strccalgo(config.cc_algo) << R"(
@@ -3801,7 +3801,11 @@ int main(int argc, char **argv) {
           config.cc_algo = NGTCP2_CC_ALGO_BBR;
           break;
         }
-        std::cerr << "cc: specify cubic, reno, or bbr" << std::endl;
+        if (strcmp("wave", optarg) == 0) {
+          config.cc_algo = NGTCP2_CC_ALGO_WAVE;
+          break;
+        }
+        std::cerr << "cc: specify cubic, reno, bbr or wave" << std::endl;
         exit(EXIT_FAILURE);
       case 20:
         // --initial-rtt

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -54,6 +54,7 @@ set(ngtcp2_SOURCES
   ngtcp2_ksl.c
   ngtcp2_cc.c
   ngtcp2_bbr.c
+  ngtcp2_wave.c
   ngtcp2_addr.c
   ngtcp2_path.c
   ngtcp2_pv.c

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -62,6 +62,7 @@ OBJECTS = \
 	ngtcp2_ksl.c \
 	ngtcp2_cc.c \
 	ngtcp2_bbr.c \
+	ngtcp2_wave.c \
 	ngtcp2_addr.c \
 	ngtcp2_path.c \
 	ngtcp2_pv.c \
@@ -106,6 +107,7 @@ HFILES = \
 	ngtcp2_ksl.h \
 	ngtcp2_cc.h \
 	ngtcp2_bbr.h \
+	ngtcp2_wave.h \
 	ngtcp2_addr.h \
 	ngtcp2_path.h \
 	ngtcp2_pv.h \

--- a/lib/includes/ngtcp2/ngtcp2.h
+++ b/lib/includes/ngtcp2/ngtcp2.h
@@ -1619,7 +1619,11 @@ typedef enum ngtcp2_cc_algo {
   /**
    * :enum:`NGTCP2_CC_ALGO_BBR` represents BBR v2.
    */
-  NGTCP2_CC_ALGO_BBR = 0x02
+  NGTCP2_CC_ALGO_BBR = 0x02,
+  /**
+   * :enum:`NGTCP2_CC_ALGO_WAVE` represents Wave.
+   */
+  NGTCP2_CC_ALGO_WAVE = 0x03
 } ngtcp2_cc_algo;
 
 /**

--- a/lib/ngtcp2_conn.c
+++ b/lib/ngtcp2_conn.c
@@ -1327,6 +1327,10 @@ static int conn_new(ngtcp2_conn **pconn, const ngtcp2_cid *dcid,
                        &settings->rand_ctx);
 
     break;
+  case NGTCP2_CC_ALGO_WAVE:
+    ngtcp2_cc_wave_init(&(*pconn)->wave, &(*pconn)->log, &(*pconn)->cstat);
+
+    break;
   default:
     ngtcp2_unreachable();
   }

--- a/lib/ngtcp2_conn.h
+++ b/lib/ngtcp2_conn.h
@@ -43,6 +43,7 @@
 #include "ngtcp2_pq.h"
 #include "ngtcp2_cc.h"
 #include "ngtcp2_bbr.h"
+#include "ngtcp2_wave.h"
 #include "ngtcp2_pv.h"
 #include "ngtcp2_pmtud.h"
 #include "ngtcp2_cid.h"
@@ -636,6 +637,7 @@ struct ngtcp2_conn {
     ngtcp2_cc_reno reno;
     ngtcp2_cc_cubic cubic;
     ngtcp2_cc_bbr bbr;
+    ngtcp2_cc_wave wave;
   };
   /* path_history remembers the paths that have been validated
      successfully.  The path is added to this history when a local

--- a/lib/ngtcp2_wave.c
+++ b/lib/ngtcp2_wave.c
@@ -1,0 +1,331 @@
+/*
+ * ngtcp2
+ *
+ * Copyright (c) 2025 ngtcp2 contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+#include "ngtcp2_wave.h"
+
+#include <string.h>
+
+#include "ngtcp2_log.h"
+#include "ngtcp2_macro.h"
+#include "ngtcp2_conn_stat.h"
+
+#define NGTCP2_WAVE_MAX_QUIC_PACKET_SIZE 1444
+
+static void wave_reset(ngtcp2_cc_wave *wave, ngtcp2_conn_stat *cstat);
+
+static void wave_reset(ngtcp2_cc_wave *wave, ngtcp2_conn_stat *cstat) {
+    // Restore Wave state variables to default
+    wave->default_burst_size = 10 * NGTCP2_WAVE_MAX_QUIC_PACKET_SIZE;
+    wave->tx_time = 200 * NGTCP2_MILLISECONDS;
+    wave->beta = 150 * NGTCP2_MILLISECONDS;
+    wave->min_rtt = UINT64_MAX;
+    wave->avg_rtt = cstat->smoothed_rtt;
+    wave->alpha = 0;
+    wave->ack_count = 0;
+    wave->ack_data = 0;
+    wave->bursts = (burst_stats *) NULL;
+
+    // Update CC pacing data
+    cstat->pacing_interval_m = (wave->tx_time / wave->default_burst_size) << 10;
+    cstat->send_quantum = wave->default_burst_size;
+    cstat->cwnd = UINT64_MAX;
+    cstat->ssthresh = UINT64_MAX;
+
+    ngtcp2_log_info(wave->cc.log, NGTCP2_LOG_EVENT_CCA,
+                    "Wave state set to default values. Tx time=",
+                    wave->tx_time);
+}
+
+void wave_cc_on_pkt_acked(ngtcp2_cc *cc,
+                                    ngtcp2_conn_stat *cstat,
+                                    const ngtcp2_cc_pkt *pkt,
+                                    ngtcp2_tstamp ts) {
+    // When a packet is acknowledged update the related burst_stat structure
+    ngtcp2_cc_wave *wave = ngtcp2_struct_of(cc, ngtcp2_cc_wave, cc);
+    burst_stats * current_burst = wave->bursts;
+
+    if (current_burst == NULL) {
+        // Error: How can be null if I received an ack for that burst?
+        // In practice this happens only for Handshake packets. Ignoring
+        // Edit: this can happen if Wave returned from Adjustment mode,
+        // deleting all data about burst sent previously
+        return;
+    }
+
+    while (current_burst != NULL) {
+        if (current_burst->send_time == pkt->sent_ts) {
+            // Find the corresponding burst for that packet
+            break;
+        }
+        if (current_burst->next != NULL) {
+            // Iterate over the burst list
+            current_burst = current_burst->next;
+        } else {
+            // Error: Burst not found in the list. Why?
+            // Because of the same fact of previous: Handshake packets or
+            // Adjustment mode. Ignoring both case
+            return;
+        }
+    }
+
+    // Once the corresponding burst is found, update the stats
+    if (ts < current_burst->first_ack_time) {
+        // Update the pilot RTT and ACK timestamp
+        current_burst->first_ack_time = ts;
+        current_burst->pilot_rtt = ts - pkt->sent_ts;
+    }
+    if (ts > current_burst->last_ack_time) {
+        current_burst->last_ack_time = ts;
+        current_burst->ack_num++;
+        current_burst->cumulative_ack_rtt += ts - pkt->sent_ts;
+    }
+    current_burst->acked_bytes += pkt->pktlen;
+
+    // If all ACKs for that burst were received, update the Wave CC state
+    if (current_burst->acked_bytes != current_burst->send_burst_size) {
+        return;
+    }
+
+    // Wave ack-dispersion works well with at least 3 acks per burst
+    if (current_burst->ack_num < 3) {
+        goto FREE_MEMORY;
+    }
+
+    // Compute ack train dispersion
+    double ack_train_disp = 1.0 * (current_burst->last_ack_time -
+                                   current_burst->first_ack_time) *
+                            (1.0 * current_burst->ack_num /
+                            (1.0 * current_burst->ack_num - 1));
+
+    // Compute the EWMA filter parameter
+    double alpha = 1.0 * (current_burst->pilot_rtt - wave->min_rtt) /
+                   (1.0 * current_burst->pilot_rtt);
+    wave->alpha = alpha;
+
+    // Computing the average RTT
+    double avg_rtt = alpha * wave->avg_rtt +
+                     (1.0 - alpha) * current_burst->pilot_rtt;
+    wave->avg_rtt = avg_rtt;
+
+    // Compute delta RTT to check if Adjustment mode should be triggered
+    double delta_rtt = wave->avg_rtt - wave->min_rtt;
+
+    if (delta_rtt > wave->beta) {
+        // Reset Wave State
+        wave->tx_time = 200 * NGTCP2_MILLISECONDS;
+        wave->min_rtt = UINT64_MAX;
+        wave->avg_rtt = cstat->smoothed_rtt;
+        wave->alpha = 0;
+        wave->ack_count = 0;
+        wave->ack_data = 0;
+
+        // Update CC pacing data
+        cstat->pacing_interval_m = (wave->tx_time / wave->default_burst_size) << 10;;
+
+        // Discard all previous burst info and free memory
+        current_burst = wave->bursts;
+        while (current_burst != NULL) {
+            // Iterate over the burst list and delete elements
+            if (current_burst->next == NULL) {
+                free(current_burst);
+                break;
+            } else {
+                current_burst = current_burst->next;
+                free(current_burst->previous);
+            }
+        }
+        wave->bursts = (burst_stats *) NULL;
+        return;
+    }
+
+    // Compute new transmission timer
+    uint64_t tx_timer = (uint64_t) ((ack_train_disp + 0.5 * delta_rtt));
+    if (tx_timer < 1 * NGTCP2_MILLISECONDS) {
+        wave->tx_time = 1 * NGTCP2_MILLISECONDS;
+    } else {
+        wave->tx_time = (tx_timer / 1000000) * 1000000;
+    }
+    cstat->pacing_interval_m = (wave->tx_time / wave->default_burst_size) << 10;
+    ngtcp2_log_info(wave->cc.log, NGTCP2_LOG_EVENT_CCA,
+                    "New Wave Tx time=", wave->tx_time);
+
+FREE_MEMORY: ;
+    // Update the burst list and free memory
+    burst_stats * next = current_burst->next;
+    burst_stats * prev = current_burst->previous;
+    if (prev == NULL && next == NULL) {
+        // Current is the only node
+        wave->bursts = NULL;
+    } else if (prev == NULL && next != NULL) {
+        // Current is the head
+        wave->bursts = next;
+        next->previous = NULL;
+    } else if (prev != NULL && next != NULL) {
+        // Current is in the middle
+        prev->next = current_burst->next;
+        next->previous = current_burst->previous;
+    } else if (prev != NULL && next == NULL) {
+        // Current is at the end
+        prev->next = NULL;
+    }
+    free(current_burst);
+}
+
+void wave_cc_on_pkt_sent(ngtcp2_cc *cc,
+                                   ngtcp2_conn_stat *cstat,
+                                   const ngtcp2_cc_pkt *pkt) {
+    // When a packet is sent, record the send time of the burst which belongs to
+    ngtcp2_cc_wave *wave = ngtcp2_struct_of(cc, ngtcp2_cc_wave, cc);
+    burst_stats * current_burst = wave->bursts;
+    if (current_burst == NULL) {
+        // Init the stats if this is the first bust that was sent
+        current_burst = malloc(sizeof(burst_stats));
+        current_burst->send_time = pkt->sent_ts;
+        current_burst->send_burst_size = pkt->pktlen;
+        current_burst->first_ack_time = UINT64_MAX;
+        current_burst->last_ack_time = 0;
+        current_burst->ack_num = 0;
+        current_burst->acked_bytes = 0;
+        current_burst->cumulative_ack_rtt = 0;
+        current_burst->pilot_rtt = UINT64_MAX;
+        current_burst->previous = (burst_stats *) NULL; // Head of the List
+        current_burst->next = (burst_stats *) NULL;
+
+        wave->bursts = current_burst;
+        return;
+    }
+
+    while (current_burst != NULL) {
+        if (current_burst->send_time == pkt->sent_ts) {
+            // If the packet sent is not the first, update related burst stats
+            current_burst->send_burst_size += pkt->pktlen;
+            break;
+        }
+
+        if (current_burst->next != NULL) {
+          // Iterate over the burst list
+            current_burst = current_burst->next;
+        } else {
+            // Append a new burst to the list
+            current_burst->next = malloc(sizeof(burst_stats));
+            current_burst->next->send_time = pkt->sent_ts;
+            current_burst->next->send_burst_size = pkt->pktlen;
+            current_burst->next->first_ack_time = UINT64_MAX;
+            current_burst->next->last_ack_time = 0;
+            current_burst->next->ack_num = 0;
+            current_burst->next->acked_bytes = 0;
+            current_burst->next->cumulative_ack_rtt = 0;
+            current_burst->next->pilot_rtt = UINT64_MAX;
+            current_burst->next->previous = current_burst;
+            current_burst->next->next = (burst_stats *) NULL;
+
+            break;
+        }
+    }
+}
+
+
+void wave_cc_on_ack_recv(ngtcp2_cc *cc,
+                                   ngtcp2_conn_stat *cstat,
+                                   const ngtcp2_cc_ack *ack,
+                                   ngtcp2_tstamp ts) {
+    // When an ack or a burst of ack is received, update the minimum RTT
+    // and trigger the recovery mode
+    ngtcp2_cc_wave *wave = ngtcp2_struct_of(cc, ngtcp2_cc_wave, cc);
+    uint64_t tx_timer;
+
+    if (ack->bytes_delivered <= 0 || ack->rtt > 10 * wave->min_rtt) {
+        // Why an ACK should deliver 0 (or lower) bytes? Ignoring.
+        // Discard also unreliable (too old) samples
+        return;
+    }
+
+    // Update min rtt
+    if (ack->rtt < wave->min_rtt) {
+        wave->min_rtt = ack->rtt;
+    }
+
+    // Trigger the Recovery Mode when acks come in burst
+    if (ack->bytes_delivered >= wave->default_burst_size) {
+        // Update average rtt
+        //wave->avg_rtt = (uint64_t) ((1.0 - 0.2) * wave->avg_rtt + 0.2 * ack->rtt);
+
+        // Compute the EWMA filter parameter
+        double alpha = 1.0 * (ack->rtt - wave->min_rtt) /
+                       (1.0 * ack->rtt);
+        wave->alpha = alpha;
+
+        // Computing the average RTT
+        double avg_rtt = alpha * wave->avg_rtt +
+                         (1.0 - alpha) * ack->rtt;
+        wave->avg_rtt = avg_rtt;
+
+        double d_rtt = (uint64_t) (ack->rtt - wave->min_rtt);
+        double delta_rtt = (uint64_t) (wave->avg_rtt - wave->min_rtt);
+
+        if (delta_rtt > wave->beta) {
+            // Reset Wave State
+            wave->tx_time = 200 * NGTCP2_MILLISECONDS;
+            wave->min_rtt = UINT64_MAX;
+            wave->avg_rtt = cstat->smoothed_rtt;
+            wave->alpha = 0;
+            wave->ack_count = 0;
+            wave->ack_data = 0;
+
+            // Update CC pacing data
+            cstat->pacing_interval_m = (wave->tx_time / wave->default_burst_size) << 10;;
+            return;
+        }
+        // Recovery Mode Transmission Timer
+        tx_timer = (uint64_t) (0.4 * wave->tx_time + 0.2 * d_rtt);
+        if (tx_timer < 1 * NGTCP2_MILLISECONDS) {
+            wave->tx_time = 1 * NGTCP2_MILLISECONDS;
+        } else {
+            wave->tx_time = (tx_timer / 1000000) * 1000000;
+        }
+        cstat->pacing_interval_m = (wave->tx_time / wave->default_burst_size) << 10;
+
+        ngtcp2_log_info(wave->cc.log, NGTCP2_LOG_EVENT_CCA,
+                        "New Wave Tx time=", wave->tx_time);
+    }
+}
+
+void wave_cc_reset(ngtcp2_cc *cc, ngtcp2_conn_stat *cstat,
+                             ngtcp2_tstamp ts) {
+    ngtcp2_cc_wave *wave = ngtcp2_struct_of(cc, ngtcp2_cc_wave, cc);
+    wave_reset(wave, cstat);
+}
+
+void ngtcp2_cc_wave_init(ngtcp2_cc_wave *wave, ngtcp2_log *log,
+                         ngtcp2_conn_stat *cstat) {
+    memset(wave, 0, sizeof(*wave));
+
+    wave->cc.log = log;
+    wave->cc.on_pkt_acked = wave_cc_on_pkt_acked;
+    wave->cc.on_pkt_sent = wave_cc_on_pkt_sent;
+    wave->cc.on_ack_recv = wave_cc_on_ack_recv;
+    wave->cc.reset = wave_cc_reset;
+
+    wave_reset(wave, cstat);
+}

--- a/lib/ngtcp2_wave.h
+++ b/lib/ngtcp2_wave.h
@@ -1,0 +1,71 @@
+/*
+ * ngtcp2
+ *
+ * Copyright (c) 2025 ngtcp2 contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+#ifndef NGTCP2_WAVE_H
+#define NGTCP2_WAVE_H
+
+#ifdef HAVE_CONFIG_H
+#  include <config.h>
+#endif /* defined(HAVE_CONFIG_H) */
+
+#include <ngtcp2/ngtcp2.h>
+
+#include "ngtcp2_cc.h"
+
+typedef struct burst_stats {
+    uint64_t send_time;             // Timestamp of when this burst is sent [ns]
+    uint64_t send_burst_size;       // Size of the burst sent [bytes]
+    uint64_t first_ack_time;        // Timestamp of the first ACK of a Burst [ns]
+    uint64_t last_ack_time;         // Timestamp of the last ACK of a Burst [ns]
+    uint64_t ack_num;               // Number of ACKs received
+    uint64_t acked_bytes;           // Number of ACKed bytes for a Burst [bytes]
+    uint64_t cumulative_ack_rtt;    // Sum of RTTs of packets of a Burst [ns]
+    uint64_t pilot_rtt;             // RTT of the first packet sent [ns]
+    struct burst_stats * previous;  // Pointer to the previous burst sent
+    struct burst_stats * next;      // Pointer to the next burst sent
+} burst_stats;
+
+/*
+ * ngtcp2_cc_wave is Wave congestion controller, described in:
+ * [1] https://doi.org/10.1016/j.comnet.2016.11.002
+ * [2] https://doi.org/10.1016/j.comnet.2020.107633
+ */
+typedef struct ngtcp2_cc_wave {
+    ngtcp2_cc cc;
+    uint64_t default_burst_size;           // Default burst size [bytes]
+    uint64_t tx_time;                      // Transmission timer [ns]
+    uint64_t beta;                         // Threshold for Adj. Mode [ns]
+    uint64_t min_rtt;                      // Min RTT since last Adj. Mode [ns]
+    uint64_t avg_rtt;                      // Avg RTT since last Adj. Mode [ns]
+    uint64_t alpha;                        // EWMA filter parameter
+    uint64_t ack_count;                    // Number of ACK Received
+    uint64_t ack_data;                     // Size of ACK-ed Data [bytes]
+    burst_stats * bursts;                  // List of bursts sent
+} ngtcp2_cc_wave;
+
+void ngtcp2_cc_wave_init(ngtcp2_cc_wave *cc,
+                         ngtcp2_log *log,
+                         ngtcp2_conn_stat *cstat);
+
+#endif /* !defined(NGTCP2_WAVE_H) */


### PR DESCRIPTION
### Summary
This pull request updates the `ngtcp2` source code to include the Wave congestion control algorithm.

### Description 
Wave (https://doi.org/10.1016/j.comnet.2016.11.002) is an innovative Congestion Control Algorithm (CCA) developed by RomARS as part of the QUICoS research project (https://connectivity.esa.int/projects/quicos), funded by the European Space Agency (ESA).

Traditional CCAs (such as Cubic and New Reno) rely on packet losses as a symptom of congestion. Instead, Wave adopts a proactive rate control strategy based on ACK train dispersion, which reflects the spreading of ACKs over time, thereby preventing congestion and reducing buffer utilization.

This Wave CCA implementation is primarily tailored for QUIC-based web applications optimization over high-latency links. Recent tests involving QUIC-Wave have shown improvements in the user experience compared to TCP, including cases with Performance Enhancing Proxies (PEPs) as well.

Its main benefits also include fairness with respect to other flows simultaneously sharing the same bottleneck link, fast responsiveness to link changes, and minimization of the bufferbloat effect.

### Testing
To select Wave as a congestion control algorithm, use the `--cc=wave` command-line option when starting the `ngtcp2` client or server.

### Logs / Screenshots / Test Results
- Example QLOG file generated by ngtcp2 using Wave as CCA, visualized through [qvis](https://qvis.quictools.info) (Note the small "waves" in the chart):
![immagine](https://github.com/user-attachments/assets/d7c61a9c-7847-4d7a-8f1f-7b40ecdd4055)

- Download of a 2GB file with QUIC-Wave on a link with 50Mbit/s of bandwidth:
![immagine](https://github.com/user-attachments/assets/e1d560a2-2232-4b24-b7d4-d4c2dcab0134)


- Two QUIC-Wave flows downloading a 1GB file sharing the same bottleneck link with 50Mbit/s of bandwidth (closer red and blue lines indicate better fairness between flows):
![immagine](https://github.com/user-attachments/assets/3bcc76d0-dbcb-4d3c-8438-e03b4296a437)


- Throughput measured during subsequent download of 5 small files via QUIC-Wave, and TCP-BBR (with and without PEP):
![immagine](https://github.com/user-attachments/assets/c73e99f6-02d1-4110-b54b-133c1b2da65e)


- Round-Trip Time (RTT) statistics measured during file transfer using different `ngtcp2` CCAs over a link with 40 ms physical RTT (lower values indicate less bufferbloat): 
<div align="center">

|                   | Wave        | BBRv2       | Cubic         | New Reno |
| :-------------:| :-------------: | :------------: | :-------------: |:-------------: |
|  **RTT (Avg. ± Std. Dev.)** | 48.0 ± 7.6 ms | 83.8 ± 14.3 ms | 240.4 ± 41.9 ms | 205.1 ± 40.7 ms |

</div>



### Notes
The software developed in this PR is part of a journal manuscript currently under review.