### PR TITLE
Fix pc files for static  linkage

### DIFF
--- a/crypto/boringssl/libngtcp2_crypto_boringssl.pc.in
+++ b/crypto/boringssl/libngtcp2_crypto_boringssl.pc.in
@@ -31,3 +31,4 @@ URL: https://github.com/ngtcp2/ngtcp2
 Version: @VERSION@
 Libs: -L${libdir} -lngtcp2_crypto_boringssl
 Cflags: -I${includedir}
+Requires: openssl

--- a/crypto/gnutls/libngtcp2_crypto_gnutls.pc.in
+++ b/crypto/gnutls/libngtcp2_crypto_gnutls.pc.in
@@ -31,3 +31,4 @@ URL: https://github.com/ngtcp2/ngtcp2
 Version: @VERSION@
 Libs: -L${libdir} -lngtcp2_crypto_gnutls
 Cflags: -I${includedir}
+Requires: gnutls

--- a/crypto/ossl/libngtcp2_crypto_ossl.pc.in
+++ b/crypto/ossl/libngtcp2_crypto_ossl.pc.in
@@ -31,3 +31,4 @@ URL: https://github.com/ngtcp2/ngtcp2
 Version: @VERSION@
 Libs: -L${libdir} -lngtcp2_crypto_ossl
 Cflags: -I${includedir}
+Requires: openssl

--- a/crypto/quictls/libngtcp2_crypto_quictls.pc.in
+++ b/crypto/quictls/libngtcp2_crypto_quictls.pc.in
@@ -31,3 +31,4 @@ URL: https://github.com/ngtcp2/ngtcp2
 Version: @VERSION@
 Libs: -L${libdir} -lngtcp2_crypto_quictls
 Cflags: -I${includedir}
+Requires: openssl

--- a/crypto/wolfssl/libngtcp2_crypto_wolfssl.pc.in
+++ b/crypto/wolfssl/libngtcp2_crypto_wolfssl.pc.in
@@ -31,3 +31,4 @@ URL: https://github.com/ngtcp2/ngtcp2
 Version: @VERSION@
 Libs: -L${libdir} -lngtcp2_crypto_wolfssl
 Cflags: -I${includedir}
+Requires: wolfssl


### PR DESCRIPTION
Fix pc files for static  linkage.
I try this with ngtcp2 + openssl + nghttp3 + curl to compile curl with http3. on linux static compilation (with vcpkg).
I verify that in vcpkg:
openssl, libressl, boringssl create pc file name: openssl.pc
wolfssl -> wolfssl.pc
libgnutls -> gnutls.pc 

Without this fix I get error compilation.
ngtcp2 + openssl + nghttp3 + curl to compile curl with http3.
I get these errors:

```
/usr/bin/ld: /home/tal/vcpkg/installed/x64-linux/debug/lib/libngtcp2_crypto_ossl.a(ossl.c.o): in function `ngtcp2_crypto_set_local_transport_params':
/home/tal/vcpkg/buildtrees/ngtcp2/src/v1.13.0-ba2cdf4128.clean/crypto/ossl/ossl.c:943: undefined reference to `SSL_set_quic_tls_transport_params'
/usr/bin/ld: /home/tal/vcpkg/installed/x64-linux/debug/lib/libngtcp2_crypto_ossl.a(ossl.c.o): in function `crypto_ossl_configure_session':
/home/tal/vcpkg/buildtrees/ngtcp2/src/v1.13.0-ba2cdf4128.clean/crypto/ossl/ossl.c:1178: undefined reference to `SSL_set_quic_tls_cbs'
```
