### PR TITLE
Use Requires.private because it is needed for static linking

### DIFF
--- a/crypto/boringssl/libngtcp2_crypto_boringssl.pc.in
+++ b/crypto/boringssl/libngtcp2_crypto_boringssl.pc.in
@@ -31,4 +31,4 @@ URL: https://github.com/ngtcp2/ngtcp2
 Version: @VERSION@
 Libs: -L${libdir} -lngtcp2_crypto_boringssl
 Cflags: -I${includedir}
-Requires: openssl
+Requires.private: openssl

--- a/crypto/gnutls/libngtcp2_crypto_gnutls.pc.in
+++ b/crypto/gnutls/libngtcp2_crypto_gnutls.pc.in
@@ -31,4 +31,4 @@ URL: https://github.com/ngtcp2/ngtcp2
 Version: @VERSION@
 Libs: -L${libdir} -lngtcp2_crypto_gnutls
 Cflags: -I${includedir}
-Requires: gnutls
+Requires.private: gnutls

--- a/crypto/ossl/libngtcp2_crypto_ossl.pc.in
+++ b/crypto/ossl/libngtcp2_crypto_ossl.pc.in
@@ -31,4 +31,4 @@ URL: https://github.com/ngtcp2/ngtcp2
 Version: @VERSION@
 Libs: -L${libdir} -lngtcp2_crypto_ossl
 Cflags: -I${includedir}
-Requires: openssl
+Requires.private: openssl

--- a/crypto/quictls/libngtcp2_crypto_quictls.pc.in
+++ b/crypto/quictls/libngtcp2_crypto_quictls.pc.in
@@ -31,4 +31,4 @@ URL: https://github.com/ngtcp2/ngtcp2
 Version: @VERSION@
 Libs: -L${libdir} -lngtcp2_crypto_quictls
 Cflags: -I${includedir}
-Requires: openssl
+Requires.private: openssl

--- a/crypto/wolfssl/libngtcp2_crypto_wolfssl.pc.in
+++ b/crypto/wolfssl/libngtcp2_crypto_wolfssl.pc.in
@@ -31,4 +31,4 @@ URL: https://github.com/ngtcp2/ngtcp2
 Version: @VERSION@
 Libs: -L${libdir} -lngtcp2_crypto_wolfssl
 Cflags: -I${includedir}
-Requires: wolfssl
+Requires.private: wolfssl


### PR DESCRIPTION
https://github.com/ngtcp2/ngtcp2/pull/1689#issuecomment-3121481153