### PR TITLE
examples: Fix Connection ID validation

### DIFF
--- a/examples/client.cc
+++ b/examples/client.cc
@@ -2564,9 +2564,9 @@ Options:
               send 0-RTT data, the  transport parameters received from
               the previous session must be supplied with this option.
   --dcid=<DCID>
-              Specify  initial  DCID.   <DCID> is  hex  string.   When
+              Specify  initial DCID.   <DCID>  is  hex string.   After
               decoded as binary, it should be  at least 8 bytes and at
-              most 18 bytes long.
+              most 20 bytes long.
   --scid=<SCID>
               Specify source connection ID.  <SCID> is hex string.  If
               an empty string  is given, zero length  connection ID is
@@ -2896,12 +2896,19 @@ int main(int argc, char **argv) {
         break;
       case 6: {
         // --dcid
-        auto dcidlen2 = strlen(optarg);
-        if (dcidlen2 % 2 || dcidlen2 / 2 < 8 || dcidlen2 / 2 > 18) {
+        auto hexcid = std::string_view{optarg};
+        if (hexcid.size() < NGTCP2_MIN_INITIAL_DCIDLEN * 2 ||
+            hexcid.size() > NGTCP2_MAX_CIDLEN * 2) {
           std::cerr << "dcid: wrong length" << std::endl;
           exit(EXIT_FAILURE);
         }
-        auto dcid = util::decode_hex(optarg);
+
+        if (!util::is_hex_string(hexcid)) {
+          std::cerr << "dcid: not hex string" << std::endl;
+          exit(EXIT_FAILURE);
+        }
+
+        auto dcid = util::decode_hex(hexcid);
         ngtcp2_cid_init(&config.dcid,
                         reinterpret_cast<const uint8_t *>(dcid.c_str()),
                         dcid.size());
@@ -3091,7 +3098,18 @@ int main(int argc, char **argv) {
         break;
       case 34: {
         // --scid
-        auto scid = util::decode_hex(optarg);
+        auto hexcid = std::string_view{optarg};
+        if (hexcid.size() > NGTCP2_MAX_CIDLEN * 2) {
+          std::cerr << "scid: wrong length" << std::endl;
+          exit(EXIT_FAILURE);
+        }
+
+        if (!util::is_hex_string(hexcid)) {
+          std::cerr << "scid: not hex string" << std::endl;
+          exit(EXIT_FAILURE);
+        }
+
+        auto scid = util::decode_hex(hexcid);
         ngtcp2_cid_init(&config.scid,
                         reinterpret_cast<const uint8_t *>(scid.c_str()),
                         scid.size());

--- a/examples/h09client.cc
+++ b/examples/h09client.cc
@@ -2075,9 +2075,9 @@ Options:
               send 0-RTT data, the  transport parameters received from
               the previous session must be supplied with this option.
   --dcid=<DCID>
-              Specify  initial  DCID.   <DCID> is  hex  string.   When
+              Specify  initial DCID.   <DCID>  is  hex string.   After
               decoded as binary, it should be  at least 8 bytes and at
-              most 18 bytes long.
+              most 20 bytes long.
   --change-local-addr=<DURATION>
               Client  changes  local  address when  <DURATION>  elapse
               after handshake completes.
@@ -2402,12 +2402,19 @@ int main(int argc, char **argv) {
         break;
       case 6: {
         // --dcid
-        auto dcidlen2 = strlen(optarg);
-        if (dcidlen2 % 2 || dcidlen2 / 2 < 8 || dcidlen2 / 2 > 18) {
+        auto hexcid = std::string_view{optarg};
+        if (hexcid.size() < NGTCP2_MIN_INITIAL_DCIDLEN * 2 ||
+            hexcid.size() > NGTCP2_MAX_CIDLEN * 2) {
           std::cerr << "dcid: wrong length" << std::endl;
           exit(EXIT_FAILURE);
         }
-        auto dcid = util::decode_hex(optarg);
+
+        if (!util::is_hex_string(hexcid)) {
+          std::cerr << "dcid: not hex string" << std::endl;
+          exit(EXIT_FAILURE);
+        }
+
+        auto dcid = util::decode_hex(hexcid);
         ngtcp2_cid_init(&config.dcid,
                         reinterpret_cast<const uint8_t *>(dcid.c_str()),
                         dcid.size());

--- a/examples/util.h
+++ b/examples/util.h
@@ -469,6 +469,15 @@ constexpr bool is_hex_digit(char c) noexcept {
   return is_hex_digit_tbl[static_cast<uint8_t>(c)];
 }
 
+// is_hex_string returns true if the length of |s| is even, and |s|
+// does not contain a character other than [0-9A-Fa-f].  It returns
+// false otherwise.
+template <std::ranges::input_range R>
+requires(!std::is_array_v<std::remove_cvref_t<R>>)
+constexpr bool is_hex_string(R &&r) {
+  return !(std::ranges::size(r) & 1) && std::ranges::all_of(r, is_hex_digit);
+}
+
 constinit const auto hex_to_uint_tbl = []() {
   std::array<uint32_t, 256> tbl;
 

--- a/examples/util_test.cc
+++ b/examples/util_test.cc
@@ -45,6 +45,8 @@ const MunitTest tests[]{
   munit_void_test(test_util_normalize_path),
   munit_void_test(test_util_hexdump),
   munit_void_test(test_util_format_hex),
+  munit_void_test(test_util_decode_hex),
+  munit_void_test(test_util_is_hex_string),
   munit_test_end(),
 };
 } // namespace
@@ -417,6 +419,24 @@ void test_util_format_hex() {
   assert_stdstring_equal("deadbeef"s, util::format_hex(a));
   assert_stdstring_equal("deadbeef"s, util::format_hex(0xdeadbeef));
   assert_stdstring_equal("beef"s, util::format_hex(a.data() + 2, 2));
+}
+
+void test_util_decode_hex() {
+  assert_stdstring_equal("\xde\xad\xbe\xef"s, util::decode_hex("deadbeef"sv));
+  assert_stdstring_equal(""s, util::decode_hex(""sv));
+}
+
+void test_util_is_hex_string() {
+  assert_true(util::is_hex_string(""sv));
+  assert_true(util::is_hex_string("0123456789abcdef"sv));
+  assert_true(util::is_hex_string("0123456789ABCDEF"sv));
+  assert_false(util::is_hex_string("0123456789ABCDEF9"sv));
+  assert_false(util::is_hex_string("aaa"sv));
+  assert_true(util::is_hex_string("aa"sv));
+  assert_false(util::is_hex_string("a"sv));
+  assert_false(util::is_hex_string("zzz"sv));
+  assert_false(util::is_hex_string("zz"sv));
+  assert_false(util::is_hex_string("z"sv));
 }
 
 } // namespace ngtcp2

--- a/examples/util_test.h
+++ b/examples/util_test.h
@@ -47,6 +47,8 @@ munit_void_test_decl(test_util_parse_duration)
 munit_void_test_decl(test_util_normalize_path)
 munit_void_test_decl(test_util_hexdump)
 munit_void_test_decl(test_util_format_hex)
+munit_void_test_decl(test_util_decode_hex)
+munit_void_test_decl(test_util_is_hex_string)
 
 } // namespace ngtcp2
 


### PR DESCRIPTION
Fix Connection ID validation for --dcid and --scid options.  The maximum length of Connection ID should be 20 bytes rather than 18 bytes.