### PR TITLE
GHA: Exclude macos-15 cmake due to the include path issue

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -302,6 +302,8 @@ jobs:
           tls: group-c
         - os: macos-15
           tls: group-a
+        - os: macos-15
+          buildtool: cmake
         - os: macos-14
           tls: group-d
 


### PR DESCRIPTION
Exclude macos-15 cmake due to the include path issue for nghttp3.