### PR TITLE
ngtcp2_conn_write_aggregate_pkt: Remove max_num_pkts parameter

### DIFF
--- a/examples/client.cc
+++ b/examples/client.cc
@@ -1161,9 +1161,9 @@ int Client::write_streams() {
 
   ngtcp2_path_storage_zero(&ps);
 
-  auto nwrite = ngtcp2_conn_write_aggregate_pkt(
-    conn_, &ps.path, &pi, txbuf.data(), txbuf.size(), &gso_size,
-    /* max_num_pkt = */ 0, ::write_pkt, ts);
+  auto nwrite =
+    ngtcp2_conn_write_aggregate_pkt(conn_, &ps.path, &pi, txbuf.data(),
+                                    txbuf.size(), &gso_size, ::write_pkt, ts);
   if (nwrite < 0) {
     disconnect();
     return -1;

--- a/examples/h09client.cc
+++ b/examples/h09client.cc
@@ -1061,9 +1061,9 @@ int Client::write_streams() {
 
   ngtcp2_path_storage_zero(&ps);
 
-  auto nwrite = ngtcp2_conn_write_aggregate_pkt(
-    conn_, &ps.path, &pi, txbuf.data(), txbuf.size(), &gso_size,
-    /* max_num_pkt = */ 0, ::write_pkt, ts);
+  auto nwrite =
+    ngtcp2_conn_write_aggregate_pkt(conn_, &ps.path, &pi, txbuf.data(),
+                                    txbuf.size(), &gso_size, ::write_pkt, ts);
   if (nwrite < 0) {
     disconnect();
     return -1;

--- a/examples/h09server.cc
+++ b/examples/h09server.cc
@@ -1034,9 +1034,9 @@ int Handler::write_streams() {
 
   ngtcp2_path_storage_zero(&ps);
 
-  auto nwrite = ngtcp2_conn_write_aggregate_pkt(
-    conn_, &ps.path, &pi, txbuf.data(), txbuf.size(), &gso_size,
-    /* max_num_pkt = */ 0, ::write_pkt, ts);
+  auto nwrite =
+    ngtcp2_conn_write_aggregate_pkt(conn_, &ps.path, &pi, txbuf.data(),
+                                    txbuf.size(), &gso_size, ::write_pkt, ts);
   if (nwrite < 0) {
     return handle_error();
   }

--- a/examples/server.cc
+++ b/examples/server.cc
@@ -1801,9 +1801,9 @@ int Handler::write_streams() {
 
   ngtcp2_path_storage_zero(&ps);
 
-  auto nwrite = ngtcp2_conn_write_aggregate_pkt(
-    conn_, &ps.path, &pi, txbuf.data(), txbuf.size(), &gso_size,
-    /* max_num_pkt = */ 0, ::write_pkt, ts);
+  auto nwrite =
+    ngtcp2_conn_write_aggregate_pkt(conn_, &ps.path, &pi, txbuf.data(),
+                                    txbuf.size(), &gso_size, ::write_pkt, ts);
   if (nwrite < 0) {
     return handle_error();
   }

--- a/lib/includes/ngtcp2/ngtcp2.h
+++ b/lib/includes/ngtcp2/ngtcp2.h
@@ -5641,18 +5641,22 @@ typedef ngtcp2_ssize (*ngtcp2_write_pkt)(ngtcp2_conn *conn, ngtcp2_path *path,
  * written to the buffer pointed by |buf| of length |buflen|.
  * |buflen| must be at least
  * `ngtcp2_conn_get_path_max_tx_udp_payload_size(conn)
- * <ngtcp2_conn_get_path_max_tx_udp_payload_size>` bytes long.
- * Because this function is intended to build packets for GSO, an
- * application typically provides the buffer of length 65536 bytes.
- * If this function returns positive integer, all packets share the
- * same :type:`ngtcp2_path` and :type:`ngtcp2_pkt_info` values, and
- * they are assigned to the objects pointed by |path| and |pi|
- * respectively.  The length of all packets other than the last packet
- * is assigned to |*pgsolen|.  The length of last packet is equal to
- * or less than |*pgsolen|.  This function produces at most
- * |max_num_pkts| packets if |max_num_pkts| is nonzero.  |write_pkt|
- * must write a single packet.  After all packets are written, this
- * function calls `ngtcp2_conn_update_pkt_tx_time`.
+ * <ngtcp2_conn_get_path_max_tx_udp_payload_size>` bytes long.  It is
+ * recommended to pass the buffer at least
+ * `ngtcp2_conn_get_max_tx_udp_payload_size(conn)
+ * <ngtcp2_conn_get_max_tx_udp_payload_size>` bytes in order to send a
+ * PMTUD packet.  This function only writes multiple packets if the
+ * first packet is `ngtcp2_conn_get_path_max_tx_udp_payload_size(conn)
+ * <ngtcp2_conn_get_path_max_tx_udp_payload_size>` bytes long.  The
+ * application can adjust the length of the buffer to limit the number
+ * of packets to aggregate.  If this function returns positive
+ * integer, all packets share the same :type:`ngtcp2_path` and
+ * :type:`ngtcp2_pkt_info` values, and they are assigned to the
+ * objects pointed by |path| and |pi| respectively.  The length of all
+ * packets other than the last packet is assigned to |*pgsolen|.  The
+ * length of last packet is equal to or less than |*pgsolen|.
+ * |write_pkt| must write a single packet.  After all packets are
+ * written, this function calls `ngtcp2_conn_update_pkt_tx_time`.
  *
  * This function returns the number of bytes written to the buffer, or
  * a negative error code returned by |write_pkt|.
@@ -5662,7 +5666,7 @@ typedef ngtcp2_ssize (*ngtcp2_write_pkt)(ngtcp2_conn *conn, ngtcp2_path *path,
 NGTCP2_EXTERN ngtcp2_ssize ngtcp2_conn_write_aggregate_pkt_versioned(
   ngtcp2_conn *conn, ngtcp2_path *path, int pkt_info_version,
   ngtcp2_pkt_info *pi, uint8_t *buf, size_t buflen, size_t *pgsolen,
-  size_t max_num_pkts, ngtcp2_write_pkt write_pkt, ngtcp2_tstamp ts);
+  ngtcp2_write_pkt write_pkt, ngtcp2_tstamp ts);
 
 /**
  * @function
@@ -6052,10 +6056,10 @@ NGTCP2_EXTERN uint32_t ngtcp2_select_version(const uint32_t *preferred_versions,
  * struct version.
  */
 #define ngtcp2_conn_write_aggregate_pkt(CONN, PATH, PI, BUF, BUFLEN, PGSOLEN,  \
-                                        MAX_NUM_PKTS, WRITE_PKT, TS)           \
+                                        WRITE_PKT, TS)                         \
   ngtcp2_conn_write_aggregate_pkt_versioned(                                   \
     (CONN), (PATH), NGTCP2_PKT_INFO_VERSION, (PI), (BUF), (BUFLEN), (PGSOLEN), \
-    (MAX_NUM_PKTS), (WRITE_PKT), (TS))
+    (WRITE_PKT), (TS))
 
 /*
  * `ngtcp2_settings_default` is a wrapper around

--- a/lib/ngtcp2_conn.c
+++ b/lib/ngtcp2_conn.c
@@ -13751,7 +13751,7 @@ void ngtcp2_conn_add_path_history(ngtcp2_conn *conn, const ngtcp2_dcid *dcid,
 ngtcp2_ssize ngtcp2_conn_write_aggregate_pkt_versioned(
   ngtcp2_conn *conn, ngtcp2_path *path, int pkt_info_version,
   ngtcp2_pkt_info *pi, uint8_t *buf, size_t buflen, size_t *pgsolen,
-  size_t max_num_pkts, ngtcp2_write_pkt write_pkt, ngtcp2_tstamp ts) {
+  ngtcp2_write_pkt write_pkt, ngtcp2_tstamp ts) {
   size_t max_udp_payloadlen = ngtcp2_conn_get_max_tx_udp_payload_size(conn);
   size_t path_max_udp_payloadlen =
     ngtcp2_conn_get_path_max_tx_udp_payload_size(conn);
@@ -13790,15 +13790,13 @@ ngtcp2_ssize ngtcp2_conn_write_aggregate_pkt_versioned(
     wbuf += nwrite;
     buflen -= (size_t)nwrite;
 
-    --max_num_pkts;
-
     if (first_pkt) {
       assert(!(conn->flags & NGTCP2_CONN_FLAG_AGGREGATE_PKTS));
 
       *pgsolen = (size_t)nwrite;
 
       if ((size_t)nwrite != path_max_udp_payloadlen ||
-          ecn_state != conn->tx.ecn.state || max_num_pkts == 0) {
+          ecn_state != conn->tx.ecn.state) {
         nwrite = wbuf - buf;
         break;
       }
@@ -13822,7 +13820,7 @@ ngtcp2_ssize ngtcp2_conn_write_aggregate_pkt_versioned(
     }
 
     if (buflen < path_max_udp_payloadlen || (size_t)nwrite < *pgsolen ||
-        ecn_state != conn->tx.ecn.state || max_num_pkts == 0) {
+        ecn_state != conn->tx.ecn.state) {
       nwrite = wbuf - buf;
       break;
     }

--- a/tests/ngtcp2_conn_test.c
+++ b/tests/ngtcp2_conn_test.c
@@ -16443,9 +16443,8 @@ void test_ngtcp2_conn_write_aggregate_pkt(void) {
   ud.write_pkt.stream_id = stream_id;
   ud.write_pkt.num_write_left = 10;
 
-  spktlen = ngtcp2_conn_write_aggregate_pkt(
-    conn, &ps.path, &pi, buf, sizeof(buf), &gsolen,
-    /* max_num_pkts = */ 0, write_pkt, t);
+  spktlen = ngtcp2_conn_write_aggregate_pkt(conn, &ps.path, &pi, buf,
+                                            sizeof(buf), &gsolen, write_pkt, t);
 
   /* Due to CWND, only 8 packets are written. */
   assert_ptrdiff(
@@ -16497,8 +16496,7 @@ void test_ngtcp2_conn_write_aggregate_pkt(void) {
   ud.write_pkt.num_write_left = 2;
 
   spktlen = ngtcp2_conn_write_aggregate_pkt(
-    conn, &ps.path, &pi, buf, sizeof(buf), &gsolen,
-    /* max_num_pkts = */ 0, write_pkt, ++t);
+    conn, &ps.path, &pi, buf, sizeof(buf), &gsolen, write_pkt, ++t);
 
   /* We have not validated new path, and server is subject to
      anti-amplification limit. */
@@ -16517,9 +16515,8 @@ void test_ngtcp2_conn_write_aggregate_pkt(void) {
   ud.write_pkt.stream_id = 0;
   ud.write_pkt.num_write_left = 2;
 
-  spktlen = ngtcp2_conn_write_aggregate_pkt(
-    conn, &ps.path, &pi, buf, sizeof(buf), &gsolen,
-    /* max_num_pkts = */ 0, write_pkt, t);
+  spktlen = ngtcp2_conn_write_aggregate_pkt(conn, &ps.path, &pi, buf,
+                                            sizeof(buf), &gsolen, write_pkt, t);
 
   assert_ptrdiff(
     (ngtcp2_ssize)ngtcp2_conn_get_path_max_tx_udp_payload_size(conn) * 2, ==,


### PR DESCRIPTION
Remove max_num_pkts parameter from ngtcp2_conn_write_aggregate_pkt. Application can limit the number of packets to aggregate by adjusting the length of the buffer.