### PR TITLE
ngtcp2_log: Do not format string

### DIFF
--- a/lib/ngtcp2_bbr.c
+++ b/lib/ngtcp2_bbr.c
@@ -384,8 +384,9 @@ static void bbr_check_full_bw_reached(ngtcp2_cc_bbr *bbr,
 
   bbr->full_bw_reached = 1;
 
-  ngtcp2_log_info(bbr->cc.log, NGTCP2_LOG_EVENT_CCA,
-                  "bbr reached full bandwidth, full_bw=%" PRIu64, bbr->full_bw);
+  ngtcp2_log_infof(bbr->cc.log, NGTCP2_LOG_EVENT_CCA,
+                   "bbr reached full bandwidth, full_bw=%" PRIu64,
+                   bbr->full_bw);
 }
 
 static void bbr_check_startup_high_loss(ngtcp2_cc_bbr *bbr) {
@@ -1025,8 +1026,8 @@ static void bbr_update_min_rtt(ngtcp2_cc_bbr *bbr, const ngtcp2_cc_ack *ack,
     bbr->min_rtt = bbr->probe_rtt_min_delay;
     bbr->min_rtt_stamp = bbr->probe_rtt_min_stamp;
 
-    ngtcp2_log_info(bbr->cc.log, NGTCP2_LOG_EVENT_CCA,
-                    "bbr update min_rtt=%" PRIu64, bbr->min_rtt);
+    ngtcp2_log_infof(bbr->cc.log, NGTCP2_LOG_EVENT_CCA,
+                     "bbr update min_rtt=%" PRIu64, bbr->min_rtt);
   }
 }
 

--- a/lib/ngtcp2_cc.c
+++ b/lib/ngtcp2_cc.c
@@ -92,9 +92,9 @@ void ngtcp2_cc_reno_cc_on_pkt_acked(ngtcp2_cc *cc, ngtcp2_conn_stat *cstat,
 
   if (cstat->cwnd < cstat->ssthresh) {
     cstat->cwnd += pkt->pktlen;
-    ngtcp2_log_info(reno->cc.log, NGTCP2_LOG_EVENT_CCA,
-                    "pkn=%" PRId64 " acked, slow start cwnd=%" PRIu64,
-                    pkt->pkt_num, cstat->cwnd);
+    ngtcp2_log_infof(reno->cc.log, NGTCP2_LOG_EVENT_CCA,
+                     "pkn=%" PRId64 " acked, slow start cwnd=%" PRIu64,
+                     pkt->pkt_num, cstat->cwnd);
     return;
   }
 
@@ -123,9 +123,9 @@ void ngtcp2_cc_reno_cc_congestion_event(ngtcp2_cc *cc, ngtcp2_conn_stat *cstat,
 
   reno->pending_add = 0;
 
-  ngtcp2_log_info(reno->cc.log, NGTCP2_LOG_EVENT_CCA,
-                  "reduce cwnd because of packet loss cwnd=%" PRIu64,
-                  cstat->cwnd);
+  ngtcp2_log_infof(reno->cc.log, NGTCP2_LOG_EVENT_CCA,
+                   "reduce cwnd because of packet loss cwnd=%" PRIu64,
+                   cstat->cwnd);
 }
 
 void ngtcp2_cc_reno_cc_on_persistent_congestion(ngtcp2_cc *cc,
@@ -291,9 +291,9 @@ void ngtcp2_cc_cubic_cc_on_ack_recv(ngtcp2_cc *cc, ngtcp2_conn_stat *cstat,
         cstat->cwnd += ack->bytes_delivered;
       }
 
-      ngtcp2_log_info(cubic->cc.log, NGTCP2_LOG_EVENT_CCA,
-                      "%" PRIu64 " bytes acked, slow start cwnd=%" PRIu64,
-                      ack->bytes_delivered, cstat->cwnd);
+      ngtcp2_log_infof(cubic->cc.log, NGTCP2_LOG_EVENT_CCA,
+                       "%" PRIu64 " bytes acked, slow start cwnd=%" PRIu64,
+                       ack->bytes_delivered, cstat->cwnd);
     }
 
     if (round_start) {
@@ -398,11 +398,11 @@ void ngtcp2_cc_cubic_cc_on_ack_recv(ngtcp2_cc *cc, ngtcp2_conn_stat *cstat,
     cstat->cwnd += m / cstat->cwnd;
   }
 
-  ngtcp2_log_info(cubic->cc.log, NGTCP2_LOG_EVENT_CCA,
-                  "%" PRIu64 " bytes acked, cubic-ca cwnd=%" PRIu64
-                  " k_m=%" PRIu64 " target=%" PRIu64 " w_est=%" PRIu64,
-                  ack->bytes_delivered, cstat->cwnd, cubic->current.k_m, target,
-                  cubic->current.w_est);
+  ngtcp2_log_infof(cubic->cc.log, NGTCP2_LOG_EVENT_CCA,
+                   "%" PRIu64 " bytes acked, cubic-ca cwnd=%" PRIu64
+                   " k_m=%" PRIu64 " target=%" PRIu64 " w_est=%" PRIu64,
+                   ack->bytes_delivered, cstat->cwnd, cubic->current.k_m,
+                   target, cubic->current.w_est);
 }
 
 void ngtcp2_cc_cubic_cc_congestion_event(ngtcp2_cc *cc, ngtcp2_conn_stat *cstat,
@@ -464,9 +464,9 @@ void ngtcp2_cc_cubic_cc_congestion_event(ngtcp2_cc *cc, ngtcp2_conn_stat *cstat,
   cubic->current.k_m =
     ngtcp2_cbrt((cwnd_delta << 30) * 10 / 4 / cstat->max_tx_udp_payload_size);
 
-  ngtcp2_log_info(cubic->cc.log, NGTCP2_LOG_EVENT_CCA,
-                  "reduce cwnd because of packet loss cwnd=%" PRIu64,
-                  cstat->cwnd);
+  ngtcp2_log_infof(cubic->cc.log, NGTCP2_LOG_EVENT_CCA,
+                   "reduce cwnd because of packet loss cwnd=%" PRIu64,
+                   cstat->cwnd);
 }
 
 void ngtcp2_cc_cubic_cc_on_spurious_congestion(ngtcp2_cc *cc,
@@ -482,10 +482,10 @@ void ngtcp2_cc_cubic_cc_on_spurious_congestion(ngtcp2_cc *cc,
     cstat->cwnd = cubic->undo.cwnd;
     cstat->ssthresh = cubic->undo.ssthresh;
 
-    ngtcp2_log_info(cubic->cc.log, NGTCP2_LOG_EVENT_CCA,
-                    "spurious congestion is detected and congestion state is "
-                    "restored cwnd=%" PRIu64,
-                    cstat->cwnd);
+    ngtcp2_log_infof(cubic->cc.log, NGTCP2_LOG_EVENT_CCA,
+                     "spurious congestion is detected and congestion state is "
+                     "restored cwnd=%" PRIu64,
+                     cstat->cwnd);
   }
 
   cubic_vars_reset(&cubic->undo.v);

--- a/lib/ngtcp2_conn.c
+++ b/lib/ngtcp2_conn.c
@@ -1085,8 +1085,8 @@ static void conn_update_skip_pkt(ngtcp2_conn *conn, ngtcp2_pktns *pktns) {
 
   pktns->tx.skip_pkt.next_pkt_num = pktns->tx.last_pkt_num + gap;
 
-  ngtcp2_log_info(&conn->log, NGTCP2_LOG_EVENT_CON, "next skip pkn=%" PRId64,
-                  pktns->tx.skip_pkt.next_pkt_num);
+  ngtcp2_log_infof(&conn->log, NGTCP2_LOG_EVENT_CON, "next skip pkn=%" PRId64,
+                   pktns->tx.skip_pkt.next_pkt_num);
 }
 
 static int conn_handle_skip_pkt(ngtcp2_conn *conn, ngtcp2_pktns *pktns,
@@ -1863,9 +1863,9 @@ static int conn_cwnd_is_zero(ngtcp2_conn *conn) {
   uint64_t cwnd = conn->cstat.cwnd;
 
   if (bytes_in_flight >= cwnd) {
-    ngtcp2_log_info(&conn->log, NGTCP2_LOG_EVENT_LDC,
-                    "cwnd limited bytes_in_flight=%lu cwnd=%lu",
-                    bytes_in_flight, cwnd);
+    ngtcp2_log_infof(&conn->log, NGTCP2_LOG_EVENT_LDC,
+                     "cwnd limited bytes_in_flight=%lu cwnd=%lu",
+                     bytes_in_flight, cwnd);
   }
 
   return bytes_in_flight >= cwnd;
@@ -4480,8 +4480,8 @@ static ngtcp2_ssize conn_write_pkt(ngtcp2_conn *conn, ngtcp2_pkt_info *pi,
       (rtb_entry_flags & NGTCP2_RTB_ENTRY_FLAG_ACK_ELICITING)) {
     --pktns->rtb.probe_pkt_left;
 
-    ngtcp2_log_info(&conn->log, NGTCP2_LOG_EVENT_CON, "probe pkt size=%td",
-                    nwrite);
+    ngtcp2_log_infof(&conn->log, NGTCP2_LOG_EVENT_CON, "probe pkt size=%td",
+                     nwrite);
   }
 
   conn_update_keep_alive_last_ts(conn, ts);
@@ -4676,8 +4676,8 @@ ngtcp2_ssize ngtcp2_conn_write_single_frame_pkt(
           ngtcp2_path_eq(&conn->dcid.current.ps.path, path)) {
         --pktns->rtb.probe_pkt_left;
 
-        ngtcp2_log_info(&conn->log, NGTCP2_LOG_EVENT_CON, "probe pkt size=%td",
-                        nwrite);
+        ngtcp2_log_infof(&conn->log, NGTCP2_LOG_EVENT_CON, "probe pkt size=%td",
+                         nwrite);
       }
     }
   } else if (pi && conn->tx.ecn.state == NGTCP2_ECN_STATE_CAPABLE) {
@@ -4909,8 +4909,8 @@ static ngtcp2_ssize conn_write_pmtud_probe(ngtcp2_conn *conn,
     return 0;
   }
 
-  ngtcp2_log_info(&conn->log, NGTCP2_LOG_EVENT_CON,
-                  "sending PMTUD probe packet len=%zu", probelen);
+  ngtcp2_log_infof(&conn->log, NGTCP2_LOG_EVENT_CON,
+                   "sending PMTUD probe packet len=%zu", probelen);
 
   lfr.type = NGTCP2_FRAME_PING;
 
@@ -5431,9 +5431,9 @@ static int conn_on_retry(ngtcp2_conn *conn, const ngtcp2_pkt_hd *hd,
     return rv;
   }
 
-  ngtcp2_log_info(&conn->log, NGTCP2_LOG_EVENT_PKT, "odcid=0x%s",
-                  (const char *)ngtcp2_encode_hex(cidbuf, retry.odcid.data,
-                                                  retry.odcid.datalen));
+  ngtcp2_log_infof(&conn->log, NGTCP2_LOG_EVENT_PKT, "odcid=0x%s",
+                   (const char *)ngtcp2_encode_hex(cidbuf, retry.odcid.data,
+                                                   retry.odcid.datalen));
 
   if (retry.tokenlen == 0) {
     return NGTCP2_ERR_PROTO;
@@ -6393,8 +6393,8 @@ conn_recv_handshake_pkt(ngtcp2_conn *conn, const ngtcp2_path *path,
       return 0;
     }
 
-    ngtcp2_log_info(&conn->log, NGTCP2_LOG_EVENT_CON,
-                    "buffering 1RTT packet len=%zu", pktlen);
+    ngtcp2_log_infof(&conn->log, NGTCP2_LOG_EVENT_CON,
+                     "buffering 1RTT packet len=%zu", pktlen);
 
     rv =
       conn_buffer_pkt(conn, &conn->pktns, path, pi, pkt, pktlen, dgramlen, ts);
@@ -6541,8 +6541,8 @@ conn_recv_handshake_pkt(ngtcp2_conn *conn, const ngtcp2_path *path,
     }
 
     /* Buffer re-ordered 0-RTT packet. */
-    ngtcp2_log_info(&conn->log, NGTCP2_LOG_EVENT_CON,
-                    "buffering 0-RTT packet len=%zu", pktlen);
+    ngtcp2_log_infof(&conn->log, NGTCP2_LOG_EVENT_CON,
+                     "buffering 0-RTT packet len=%zu", pktlen);
 
     rv = conn_buffer_pkt(conn, conn->in_pktns, path, pi, pkt, pktlen, dgramlen,
                          ts);
@@ -6564,7 +6564,7 @@ conn_recv_handshake_pkt(ngtcp2_conn *conn, const ngtcp2_path *path,
 
     if (conn->server) {
       if (dgramlen < NGTCP2_MAX_UDP_PAYLOAD_SIZE) {
-        ngtcp2_log_info(
+        ngtcp2_log_infof(
           &conn->log, NGTCP2_LOG_EVENT_PKT,
           "Initial packet was ignored because it is included in UDP datagram "
           "less than %zu bytes: %zu bytes",
@@ -6647,8 +6647,8 @@ conn_recv_handshake_pkt(ngtcp2_conn *conn, const ngtcp2_path *path,
           "Handshake packet at this point is unexpected and discarded");
         return (ngtcp2_ssize)pktlen;
       }
-      ngtcp2_log_info(&conn->log, NGTCP2_LOG_EVENT_CON,
-                      "buffering Handshake packet len=%zu", pktlen);
+      ngtcp2_log_infof(&conn->log, NGTCP2_LOG_EVENT_CON,
+                       "buffering Handshake packet len=%zu", pktlen);
 
       rv = conn_buffer_pkt(conn, conn->hs_pktns, path, pi, pkt, pktlen,
                            dgramlen, ts);
@@ -6702,8 +6702,8 @@ conn_recv_handshake_pkt(ngtcp2_conn *conn, const ngtcp2_path *path,
   hd.pkt_num = ngtcp2_pkt_adjust_pkt_num(pktns->acktr.max_pkt_num, hd.pkt_num,
                                          hd.pkt_numlen);
   if (hd.pkt_num > NGTCP2_MAX_PKT_NUM) {
-    ngtcp2_log_info(&conn->log, NGTCP2_LOG_EVENT_PKT,
-                    "pkn=%" PRId64 " is greater than maximum pkn", hd.pkt_num);
+    ngtcp2_log_infof(&conn->log, NGTCP2_LOG_EVENT_PKT,
+                     "pkn=%" PRId64 " is greater than maximum pkn", hd.pkt_num);
     return NGTCP2_ERR_DISCARD_PKT;
   }
 
@@ -6750,9 +6750,9 @@ conn_recv_handshake_pkt(ngtcp2_conn *conn, const ngtcp2_path *path,
       !conn->negotiated_version) {
     conn->negotiated_version = hd.version;
 
-    ngtcp2_log_info(&conn->log, NGTCP2_LOG_EVENT_CON,
-                    "the negotiated version is 0x%08x",
-                    conn->negotiated_version);
+    ngtcp2_log_infof(&conn->log, NGTCP2_LOG_EVENT_CON,
+                     "the negotiated version is 0x%08x",
+                     conn->negotiated_version);
   }
 
   payload = conn->crypto.decrypt_buf.base;
@@ -6855,9 +6855,9 @@ conn_recv_handshake_pkt(ngtcp2_conn *conn, const ngtcp2_path *path,
           ngtcp2_vec_len(fr->stream.data, fr->stream.datacnt)) {
         conn->negotiated_version = hd.version;
 
-        ngtcp2_log_info(&conn->log, NGTCP2_LOG_EVENT_CON,
-                        "the negotiated version is 0x%08x",
-                        conn->negotiated_version);
+        ngtcp2_log_infof(&conn->log, NGTCP2_LOG_EVENT_CON,
+                         "the negotiated version is 0x%08x",
+                         conn->negotiated_version);
       }
 
       rv = conn_recv_crypto(conn, encryption_level, crypto, &fr->stream, ts);
@@ -7006,8 +7006,8 @@ static ngtcp2_ssize conn_recv_handshake_cpkt(ngtcp2_conn *conn,
     ++conn->cstat.pkt_recv;
     conn->cstat.bytes_recv += (uint64_t)nread;
 
-    ngtcp2_log_info(&conn->log, NGTCP2_LOG_EVENT_PKT,
-                    "read packet %td left %zu", nread, pktlen);
+    ngtcp2_log_infof(&conn->log, NGTCP2_LOG_EVENT_PKT,
+                     "read packet %td left %zu", nread, pktlen);
   }
 
   return (ngtcp2_ssize)dgramlen;
@@ -9206,8 +9206,8 @@ static ngtcp2_ssize conn_recv_pkt(ngtcp2_conn *conn, const ngtcp2_path *path,
       break;
     default:
       ngtcp2_log_rx_pkt_hd(&conn->log, &hd);
-      ngtcp2_log_info(&conn->log, NGTCP2_LOG_EVENT_PKT,
-                      "packet type 0x%02x was ignored", hd.type);
+      ngtcp2_log_infof(&conn->log, NGTCP2_LOG_EVENT_PKT,
+                       "packet type 0x%02x was ignored", hd.type);
       return (ngtcp2_ssize)pktlen;
     }
   } else {
@@ -9254,8 +9254,8 @@ static ngtcp2_ssize conn_recv_pkt(ngtcp2_conn *conn, const ngtcp2_path *path,
   hd.pkt_num = ngtcp2_pkt_adjust_pkt_num(pktns->acktr.max_pkt_num, hd.pkt_num,
                                          hd.pkt_numlen);
   if (hd.pkt_num > NGTCP2_MAX_PKT_NUM) {
-    ngtcp2_log_info(&conn->log, NGTCP2_LOG_EVENT_PKT,
-                    "pkn=%" PRId64 " is greater than maximum pkn", hd.pkt_num);
+    ngtcp2_log_infof(&conn->log, NGTCP2_LOG_EVENT_PKT,
+                     "pkn=%" PRId64 " is greater than maximum pkn", hd.pkt_num);
     return NGTCP2_ERR_DISCARD_PKT;
   }
 
@@ -9266,7 +9266,7 @@ static ngtcp2_ssize conn_recv_pkt(ngtcp2_conn *conn, const ngtcp2_path *path,
         conn->rx.preferred_addr.pkt_num < hd.pkt_num &&
         ngtcp2_sockaddr_eq((const ngtcp2_sockaddr *)&conn->hs_local_addr,
                            path->local.addr)) {
-      ngtcp2_log_info(
+      ngtcp2_log_infof(
         &conn->log, NGTCP2_LOG_EVENT_PKT,
         "pkt=%" PRId64
         " is discarded because it was received on handshake local "
@@ -9947,8 +9947,8 @@ static int conn_recv_cpkt(ngtcp2_conn *conn, const ngtcp2_path *path,
     ++conn->cstat.pkt_recv;
     conn->cstat.bytes_recv += (uint64_t)nread;
 
-    ngtcp2_log_info(&conn->log, NGTCP2_LOG_EVENT_PKT,
-                    "read packet %td left %zu", nread, pktlen);
+    ngtcp2_log_infof(&conn->log, NGTCP2_LOG_EVENT_PKT,
+                     "read packet %td left %zu", nread, pktlen);
   }
 
   return 0;
@@ -10120,9 +10120,9 @@ static ngtcp2_ssize conn_read_handshake(ngtcp2_conn *conn,
       if ((size_t)nread < pktlen) {
         /* We have 1RTT packet and application rx key, but the
            handshake has not completed yet. */
-        ngtcp2_log_info(&conn->log, NGTCP2_LOG_EVENT_CON,
-                        "buffering 1RTT packet len=%zu",
-                        pktlen - (size_t)nread);
+        ngtcp2_log_infof(&conn->log, NGTCP2_LOG_EVENT_CON,
+                         "buffering 1RTT packet len=%zu",
+                         pktlen - (size_t)nread);
 
         rv = conn_buffer_pkt(conn, &conn->pktns, path, pi, pkt + nread,
                              pktlen - (size_t)nread, pktlen, ts);
@@ -10201,8 +10201,8 @@ int ngtcp2_conn_read_pkt_versioned(ngtcp2_conn *conn, const ngtcp2_path *path,
 
   conn_update_timestamp(conn, ts);
 
-  ngtcp2_log_info(&conn->log, NGTCP2_LOG_EVENT_CON, "recv packet len=%zu",
-                  pktlen);
+  ngtcp2_log_infof(&conn->log, NGTCP2_LOG_EVENT_CON, "recv packet len=%zu",
+                   pktlen);
 
   if (pktlen == 0) {
     return 0;
@@ -11532,9 +11532,9 @@ int ngtcp2_conn_set_remote_transport_params(
     conn->local.transport_params.version_info.chosen_version =
       conn->negotiated_version;
 
-    ngtcp2_log_info(&conn->log, NGTCP2_LOG_EVENT_CON,
-                    "the negotiated version is 0x%08x",
-                    conn->negotiated_version);
+    ngtcp2_log_infof(&conn->log, NGTCP2_LOG_EVENT_CON,
+                     "the negotiated version is 0x%08x",
+                     conn->negotiated_version);
   } else {
     rv = conn_client_validate_transport_params(conn, params);
     if (rv != 0) {
@@ -12322,9 +12322,9 @@ ngtcp2_ssize ngtcp2_conn_write_vmsg(ngtcp2_conn *conn, ngtcp2_path *path,
   }
 
   if (conn->pktns.rtb.probe_pkt_left) {
-    ngtcp2_log_info(&conn->log, NGTCP2_LOG_EVENT_CON,
-                    "transmit probe pkt left=%zu",
-                    conn->pktns.rtb.probe_pkt_left);
+    ngtcp2_log_infof(&conn->log, NGTCP2_LOG_EVENT_CON,
+                     "transmit probe pkt left=%zu",
+                     conn->pktns.rtb.probe_pkt_left);
 
     nwrite = conn_write_pkt(conn, pi, dest, destlen, (size_t)res, vmsg,
                             NGTCP2_PKT_1RTT, wflags, ts);
@@ -13027,7 +13027,7 @@ int ngtcp2_conn_update_rtt(ngtcp2_conn *conn, ngtcp2_duration rtt,
                rtt < cstat->min_rtt + ack_delay) {
       /* Ignore RTT sample if adjusting ack_delay causes the sample
          less than min_rtt before handshake confirmation. */
-      ngtcp2_log_info(
+      ngtcp2_log_infof(
         &conn->log, NGTCP2_LOG_EVENT_LDC,
         "ignore rtt sample because ack_delay is too large latest_rtt=%" PRIu64
         " min_rtt=%" PRIu64 " ack_delay=%" PRIu64,
@@ -13050,7 +13050,7 @@ int ngtcp2_conn_update_rtt(ngtcp2_conn *conn, ngtcp2_duration rtt,
     cstat->smoothed_rtt = (cstat->smoothed_rtt * 7 + rtt) / 8;
   }
 
-  ngtcp2_log_info(
+  ngtcp2_log_infof(
     &conn->log, NGTCP2_LOG_EVENT_LDC,
     "latest_rtt=%" PRIu64 " min_rtt=%" PRIu64 " smoothed_rtt=%" PRIu64
     " rttvar=%" PRIu64 " ack_delay=%" PRIu64,
@@ -13147,9 +13147,10 @@ void ngtcp2_conn_set_loss_detection_timer(ngtcp2_conn *conn, ngtcp2_tstamp ts) {
   if (earliest_loss_time != UINT64_MAX) {
     cstat->loss_detection_timer = earliest_loss_time;
 
-    ngtcp2_log_info(&conn->log, NGTCP2_LOG_EVENT_LDC,
-                    "loss_detection_timer=%" PRIu64 " nonzero crypto loss time",
-                    cstat->loss_detection_timer);
+    ngtcp2_log_infof(&conn->log, NGTCP2_LOG_EVENT_LDC,
+                     "loss_detection_timer=%" PRIu64
+                     " nonzero crypto loss time",
+                     cstat->loss_detection_timer);
     return;
   }
 
@@ -13173,9 +13174,9 @@ void ngtcp2_conn_set_loss_detection_timer(ngtcp2_conn *conn, ngtcp2_tstamp ts) {
   timeout =
     cstat->loss_detection_timer > ts ? cstat->loss_detection_timer - ts : 0;
 
-  ngtcp2_log_info(&conn->log, NGTCP2_LOG_EVENT_LDC,
-                  "loss_detection_timer=%" PRIu64 " timeout=%" PRIu64,
-                  cstat->loss_detection_timer, timeout / NGTCP2_MILLISECONDS);
+  ngtcp2_log_infof(&conn->log, NGTCP2_LOG_EVENT_LDC,
+                   "loss_detection_timer=%" PRIu64 " timeout=%" PRIu64,
+                   cstat->loss_detection_timer, timeout / NGTCP2_MILLISECONDS);
 }
 
 void ngtcp2_conn_cancel_loss_detection_timer(ngtcp2_conn *conn) {
@@ -13247,8 +13248,8 @@ int ngtcp2_conn_on_loss_detection_timer(ngtcp2_conn *conn, ngtcp2_tstamp ts) {
 
   ++cstat->pto_count;
 
-  ngtcp2_log_info(&conn->log, NGTCP2_LOG_EVENT_LDC, "pto_count=%zu",
-                  cstat->pto_count);
+  ngtcp2_log_infof(&conn->log, NGTCP2_LOG_EVENT_LDC, "pto_count=%zu",
+                   cstat->pto_count);
 
   ngtcp2_conn_set_loss_detection_timer(conn, ts);
 

--- a/lib/ngtcp2_log.c
+++ b/lib/ngtcp2_log.c
@@ -90,23 +90,10 @@ void ngtcp2_log_init(ngtcp2_log *log, const ngtcp2_cid *scid,
  *   Frame type in hex string.
  */
 
-#define NGTCP2_LOG_BUFLEN 4096
+#define NGTCP2_LOG_PKT " %s %" PRId64 " %s"
+#define NGTCP2_LOG_TP " remote transport_parameters"
 
-/* TODO Split second and remaining fraction with comma */
-#define NGTCP2_LOG_HD "I%08" PRIu64 " 0x%s %s"
-#define NGTCP2_LOG_PKT NGTCP2_LOG_HD " %s %" PRId64 " %s"
-#define NGTCP2_LOG_TP NGTCP2_LOG_HD " remote transport_parameters"
-
-#define NGTCP2_LOG_FRM_HD_FIELDS(DIR)                                          \
-  timestamp_cast(log->last_ts - log->ts), (const char *)log->scid, "frm",      \
-    (DIR), hd->pkt_num, strpkttype(hd)
-
-#define NGTCP2_LOG_PKT_HD_FIELDS(DIR)                                          \
-  timestamp_cast(log->last_ts - log->ts), (const char *)log->scid, "pkt",      \
-    (DIR), hd->pkt_num, strpkttype(hd)
-
-#define NGTCP2_LOG_TP_HD_FIELDS                                                \
-  timestamp_cast(log->last_ts - log->ts), (const char *)log->scid, "cry"
+#define NGTCP2_LOG_PKT_HD_FIELDS(DIR) (DIR), hd->pkt_num, strpkttype(hd)
 
 static const char *strerrorcode(uint64_t error_code) {
   switch (error_code) {
@@ -196,37 +183,13 @@ static const char *strpkttype_type_flags(uint8_t type, uint8_t flags) {
   return strpkttype(&hd);
 }
 
-static const char *strevent(ngtcp2_log_event ev) {
-  switch (ev) {
-  case NGTCP2_LOG_EVENT_CON:
-    return "con";
-  case NGTCP2_LOG_EVENT_PKT:
-    return "pkt";
-  case NGTCP2_LOG_EVENT_FRM:
-    return "frm";
-  case NGTCP2_LOG_EVENT_LDC:
-    return "ldc";
-  case NGTCP2_LOG_EVENT_CRY:
-    return "cry";
-  case NGTCP2_LOG_EVENT_PTV:
-    return "ptv";
-  case NGTCP2_LOG_EVENT_CCA:
-    return "cca";
-  case NGTCP2_LOG_EVENT_NONE:
-  default:
-    return "non";
-  }
-}
-
-static uint64_t timestamp_cast(uint64_t ns) { return ns / NGTCP2_MILLISECONDS; }
-
 static void log_fr_stream(ngtcp2_log *log, const ngtcp2_pkt_hd *hd,
                           const ngtcp2_stream *fr, const char *dir) {
-  log->log_printf(
-    log->user_data,
-    (NGTCP2_LOG_PKT " STREAM(0x%02" PRIx64 ") id=0x%" PRIx64
-                    " fin=%d offset=%" PRIu64 " len=%" PRIu64 " uni=%d"),
-    NGTCP2_LOG_FRM_HD_FIELDS(dir), fr->type | fr->flags, fr->stream_id, fr->fin,
+  ngtcp2_log_infof_raw(
+    log, NGTCP2_LOG_EVENT_FRM,
+    NGTCP2_LOG_PKT " STREAM(0x%02" PRIx64 ") id=0x%" PRIx64
+                   " fin=%d offset=%" PRIu64 " len=%" PRIu64 " uni=%d",
+    NGTCP2_LOG_PKT_HD_FIELDS(dir), fr->type | fr->flags, fr->stream_id, fr->fin,
     fr->offset, ngtcp2_vec_len(fr->data, fr->datacnt),
     (fr->stream_id & 0x2) != 0);
 }
@@ -236,58 +199,58 @@ static void log_fr_ack(ngtcp2_log *log, const ngtcp2_pkt_hd *hd,
   int64_t largest_ack, min_ack;
   size_t i;
 
-  log->log_printf(
-    log->user_data,
-    (NGTCP2_LOG_PKT " ACK(0x%02" PRIx64 ") largest_ack=%" PRId64
-                    " ack_delay=%" PRIu64 "(%" PRIu64 ") ack_range_count=%zu"),
-    NGTCP2_LOG_FRM_HD_FIELDS(dir), fr->type, fr->largest_ack,
+  ngtcp2_log_infof_raw(
+    log, NGTCP2_LOG_EVENT_FRM,
+    NGTCP2_LOG_PKT " ACK(0x%02" PRIx64 ") largest_ack=%" PRId64
+                   " ack_delay=%" PRIu64 "(%" PRIu64 ") ack_range_count=%zu",
+    NGTCP2_LOG_PKT_HD_FIELDS(dir), fr->type, fr->largest_ack,
     fr->ack_delay_unscaled / NGTCP2_MILLISECONDS, fr->ack_delay, fr->rangecnt);
 
   largest_ack = fr->largest_ack;
   min_ack = fr->largest_ack - (int64_t)fr->first_ack_range;
 
-  log->log_printf(log->user_data,
-                  (NGTCP2_LOG_PKT " ACK(0x%02" PRIx64 ") range=[%" PRId64
-                                  "..%" PRId64 "] len=%" PRIu64),
-                  NGTCP2_LOG_FRM_HD_FIELDS(dir), fr->type, largest_ack, min_ack,
-                  fr->first_ack_range);
+  ngtcp2_log_infof_raw(log, NGTCP2_LOG_EVENT_FRM,
+                       NGTCP2_LOG_PKT " ACK(0x%02" PRIx64 ") range=[%" PRId64
+                                      "..%" PRId64 "] len=%" PRIu64,
+                       NGTCP2_LOG_PKT_HD_FIELDS(dir), fr->type, largest_ack,
+                       min_ack, fr->first_ack_range);
 
   for (i = 0; i < fr->rangecnt; ++i) {
     const ngtcp2_ack_range *range = &fr->ranges[i];
     largest_ack = min_ack - (int64_t)range->gap - 2;
     min_ack = largest_ack - (int64_t)range->len;
-    log->log_printf(log->user_data,
-                    (NGTCP2_LOG_PKT " ACK(0x%02" PRIx64 ") range=[%" PRId64
-                                    "..%" PRId64 "] gap=%" PRIu64
-                                    " len=%" PRIu64),
-                    NGTCP2_LOG_FRM_HD_FIELDS(dir), fr->type, largest_ack,
-                    min_ack, range->gap, range->len);
+    ngtcp2_log_infof_raw(log, NGTCP2_LOG_EVENT_FRM,
+                         NGTCP2_LOG_PKT " ACK(0x%02" PRIx64 ") range=[%" PRId64
+                                        "..%" PRId64 "] gap=%" PRIu64
+                                        " len=%" PRIu64,
+                         NGTCP2_LOG_PKT_HD_FIELDS(dir), fr->type, largest_ack,
+                         min_ack, range->gap, range->len);
   }
 
   if (fr->type == NGTCP2_FRAME_ACK_ECN) {
-    log->log_printf(log->user_data,
-                    (NGTCP2_LOG_PKT " ACK(0x%02" PRIx64 ") ect0=%" PRIu64
-                                    " ect1=%" PRIu64 " ce=%" PRIu64),
-                    NGTCP2_LOG_FRM_HD_FIELDS(dir), fr->type, fr->ecn.ect0,
-                    fr->ecn.ect1, fr->ecn.ce);
+    ngtcp2_log_infof_raw(log, NGTCP2_LOG_EVENT_FRM,
+                         NGTCP2_LOG_PKT " ACK(0x%02" PRIx64 ") ect0=%" PRIu64
+                                        " ect1=%" PRIu64 " ce=%" PRIu64,
+                         NGTCP2_LOG_PKT_HD_FIELDS(dir), fr->type, fr->ecn.ect0,
+                         fr->ecn.ect1, fr->ecn.ce);
   }
 }
 
 static void log_fr_padding(ngtcp2_log *log, const ngtcp2_pkt_hd *hd,
                            const ngtcp2_padding *fr, const char *dir) {
-  log->log_printf(log->user_data,
-                  (NGTCP2_LOG_PKT " PADDING(0x%02" PRIx64 ") len=%zu"),
-                  NGTCP2_LOG_FRM_HD_FIELDS(dir), fr->type, fr->len);
+  ngtcp2_log_infof_raw(log, NGTCP2_LOG_EVENT_FRM,
+                       NGTCP2_LOG_PKT " PADDING(0x%02" PRIx64 ") len=%zu",
+                       NGTCP2_LOG_PKT_HD_FIELDS(dir), fr->type, fr->len);
 }
 
 static void log_fr_reset_stream(ngtcp2_log *log, const ngtcp2_pkt_hd *hd,
                                 const ngtcp2_reset_stream *fr,
                                 const char *dir) {
-  log->log_printf(
-    log->user_data,
-    (NGTCP2_LOG_PKT " RESET_STREAM(0x%02" PRIx64 ") id=0x%" PRIx64
-                    " app_error_code=%s(0x%" PRIx64 ") final_size=%" PRIu64),
-    NGTCP2_LOG_FRM_HD_FIELDS(dir), fr->type, fr->stream_id,
+  ngtcp2_log_infof_raw(
+    log, NGTCP2_LOG_EVENT_FRM,
+    NGTCP2_LOG_PKT " RESET_STREAM(0x%02" PRIx64 ") id=0x%" PRIx64
+                   " app_error_code=%s(0x%" PRIx64 ") final_size=%" PRIu64,
+    NGTCP2_LOG_PKT_HD_FIELDS(dir), fr->type, fr->stream_id,
     strapperrorcode(fr->app_error_code), fr->app_error_code, fr->final_size);
 }
 
@@ -297,12 +260,12 @@ static void log_fr_connection_close(ngtcp2_log *log, const ngtcp2_pkt_hd *hd,
   char reason[256];
   size_t reasonlen = ngtcp2_min_size(sizeof(reason) - 1, fr->reasonlen);
 
-  log->log_printf(
-    log->user_data,
-    (NGTCP2_LOG_PKT " CONNECTION_CLOSE(0x%02" PRIx64
-                    ") error_code=%s(0x%" PRIx64 ") "
-                    "frame_type=%" PRIx64 " reason_len=%zu reason=[%s]"),
-    NGTCP2_LOG_FRM_HD_FIELDS(dir), fr->type,
+  ngtcp2_log_infof_raw(
+    log, NGTCP2_LOG_EVENT_FRM,
+    NGTCP2_LOG_PKT " CONNECTION_CLOSE(0x%02" PRIx64 ") error_code=%s(0x%" PRIx64
+                   ") "
+                   "frame_type=%" PRIx64 " reason_len=%zu reason=[%s]",
+    NGTCP2_LOG_PKT_HD_FIELDS(dir), fr->type,
     fr->type == NGTCP2_FRAME_CONNECTION_CLOSE ? strerrorcode(fr->error_code)
                                               : strapperrorcode(fr->error_code),
     fr->error_code, fr->frame_type, fr->reasonlen,
@@ -311,63 +274,64 @@ static void log_fr_connection_close(ngtcp2_log *log, const ngtcp2_pkt_hd *hd,
 
 static void log_fr_max_data(ngtcp2_log *log, const ngtcp2_pkt_hd *hd,
                             const ngtcp2_max_data *fr, const char *dir) {
-  log->log_printf(
-    log->user_data,
-    (NGTCP2_LOG_PKT " MAX_DATA(0x%02" PRIx64 ") max_data=%" PRIu64),
-    NGTCP2_LOG_FRM_HD_FIELDS(dir), fr->type, fr->max_data);
+  ngtcp2_log_infof_raw(log, NGTCP2_LOG_EVENT_FRM,
+                       NGTCP2_LOG_PKT " MAX_DATA(0x%02" PRIx64
+                                      ") max_data=%" PRIu64,
+                       NGTCP2_LOG_PKT_HD_FIELDS(dir), fr->type, fr->max_data);
 }
 
 static void log_fr_max_stream_data(ngtcp2_log *log, const ngtcp2_pkt_hd *hd,
                                    const ngtcp2_max_stream_data *fr,
                                    const char *dir) {
-  log->log_printf(log->user_data,
-                  (NGTCP2_LOG_PKT " MAX_STREAM_DATA(0x%02" PRIx64
-                                  ") id=0x%" PRIx64
-                                  " max_stream_data=%" PRIu64),
-                  NGTCP2_LOG_FRM_HD_FIELDS(dir), fr->type, fr->stream_id,
-                  fr->max_stream_data);
+  ngtcp2_log_infof_raw(log, NGTCP2_LOG_EVENT_FRM,
+                       NGTCP2_LOG_PKT " MAX_STREAM_DATA(0x%02" PRIx64
+                                      ") id=0x%" PRIx64
+                                      " max_stream_data=%" PRIu64,
+                       NGTCP2_LOG_PKT_HD_FIELDS(dir), fr->type, fr->stream_id,
+                       fr->max_stream_data);
 }
 
 static void log_fr_max_streams(ngtcp2_log *log, const ngtcp2_pkt_hd *hd,
                                const ngtcp2_max_streams *fr, const char *dir) {
-  log->log_printf(
-    log->user_data,
-    (NGTCP2_LOG_PKT " MAX_STREAMS(0x%02" PRIx64 ") max_streams=%" PRIu64),
-    NGTCP2_LOG_FRM_HD_FIELDS(dir), fr->type, fr->max_streams);
+  ngtcp2_log_infof_raw(
+    log, NGTCP2_LOG_EVENT_FRM,
+    NGTCP2_LOG_PKT " MAX_STREAMS(0x%02" PRIx64 ") max_streams=%" PRIu64,
+    NGTCP2_LOG_PKT_HD_FIELDS(dir), fr->type, fr->max_streams);
 }
 
 static void log_fr_ping(ngtcp2_log *log, const ngtcp2_pkt_hd *hd,
                         const ngtcp2_ping *fr, const char *dir) {
-  log->log_printf(log->user_data, (NGTCP2_LOG_PKT " PING(0x%02" PRIx64 ")"),
-                  NGTCP2_LOG_FRM_HD_FIELDS(dir), fr->type);
+  ngtcp2_log_infof_raw(log, NGTCP2_LOG_EVENT_FRM,
+                       NGTCP2_LOG_PKT " PING(0x%02" PRIx64 ")",
+                       NGTCP2_LOG_PKT_HD_FIELDS(dir), fr->type);
 }
 
 static void log_fr_data_blocked(ngtcp2_log *log, const ngtcp2_pkt_hd *hd,
                                 const ngtcp2_data_blocked *fr,
                                 const char *dir) {
-  log->log_printf(
-    log->user_data,
-    (NGTCP2_LOG_PKT " DATA_BLOCKED(0x%02" PRIx64 ") offset=%" PRIu64),
-    NGTCP2_LOG_FRM_HD_FIELDS(dir), fr->type, fr->offset);
+  ngtcp2_log_infof_raw(log, NGTCP2_LOG_EVENT_FRM,
+                       NGTCP2_LOG_PKT " DATA_BLOCKED(0x%02" PRIx64
+                                      ") offset=%" PRIu64,
+                       NGTCP2_LOG_PKT_HD_FIELDS(dir), fr->type, fr->offset);
 }
 
 static void log_fr_stream_data_blocked(ngtcp2_log *log, const ngtcp2_pkt_hd *hd,
                                        const ngtcp2_stream_data_blocked *fr,
                                        const char *dir) {
-  log->log_printf(log->user_data,
-                  (NGTCP2_LOG_PKT " STREAM_DATA_BLOCKED(0x%02" PRIx64
-                                  ") id=0x%" PRIx64 " offset=%" PRIu64),
-                  NGTCP2_LOG_FRM_HD_FIELDS(dir), fr->type, fr->stream_id,
-                  fr->offset);
+  ngtcp2_log_infof_raw(log, NGTCP2_LOG_EVENT_FRM,
+                       NGTCP2_LOG_PKT " STREAM_DATA_BLOCKED(0x%02" PRIx64
+                                      ") id=0x%" PRIx64 " offset=%" PRIu64,
+                       NGTCP2_LOG_PKT_HD_FIELDS(dir), fr->type, fr->stream_id,
+                       fr->offset);
 }
 
 static void log_fr_streams_blocked(ngtcp2_log *log, const ngtcp2_pkt_hd *hd,
                                    const ngtcp2_streams_blocked *fr,
                                    const char *dir) {
-  log->log_printf(
-    log->user_data,
-    (NGTCP2_LOG_PKT " STREAMS_BLOCKED(0x%02" PRIx64 ") max_streams=%" PRIu64),
-    NGTCP2_LOG_FRM_HD_FIELDS(dir), fr->type, fr->max_streams);
+  ngtcp2_log_infof_raw(
+    log, NGTCP2_LOG_EVENT_FRM,
+    NGTCP2_LOG_PKT " STREAMS_BLOCKED(0x%02" PRIx64 ") max_streams=%" PRIu64,
+    NGTCP2_LOG_PKT_HD_FIELDS(dir), fr->type, fr->max_streams);
 }
 
 static void log_fr_new_connection_id(ngtcp2_log *log, const ngtcp2_pkt_hd *hd,
@@ -376,12 +340,12 @@ static void log_fr_new_connection_id(ngtcp2_log *log, const ngtcp2_pkt_hd *hd,
   uint8_t buf[sizeof(fr->stateless_reset_token) * 2 + 1];
   uint8_t cid[sizeof(fr->cid.data) * 2 + 1];
 
-  log->log_printf(
-    log->user_data,
-    (NGTCP2_LOG_PKT " NEW_CONNECTION_ID(0x%02" PRIx64 ") seq=%" PRIu64
-                    " cid=0x%s retire_prior_to=%" PRIu64
-                    " stateless_reset_token=0x%s"),
-    NGTCP2_LOG_FRM_HD_FIELDS(dir), fr->type, fr->seq,
+  ngtcp2_log_infof_raw(
+    log, NGTCP2_LOG_EVENT_FRM,
+    NGTCP2_LOG_PKT " NEW_CONNECTION_ID(0x%02" PRIx64 ") seq=%" PRIu64
+                   " cid=0x%s retire_prior_to=%" PRIu64
+                   " stateless_reset_token=0x%s",
+    NGTCP2_LOG_PKT_HD_FIELDS(dir), fr->type, fr->seq,
     (const char *)ngtcp2_encode_hex(cid, fr->cid.data, fr->cid.datalen),
     fr->retire_prior_to,
     (const char *)ngtcp2_encode_hex(buf, fr->stateless_reset_token,
@@ -391,11 +355,12 @@ static void log_fr_new_connection_id(ngtcp2_log *log, const ngtcp2_pkt_hd *hd,
 static void log_fr_stop_sending(ngtcp2_log *log, const ngtcp2_pkt_hd *hd,
                                 const ngtcp2_stop_sending *fr,
                                 const char *dir) {
-  log->log_printf(log->user_data,
-                  (NGTCP2_LOG_PKT " STOP_SENDING(0x%02" PRIx64 ") id=0x%" PRIx64
-                                  " app_error_code=%s(0x%" PRIx64 ")"),
-                  NGTCP2_LOG_FRM_HD_FIELDS(dir), fr->type, fr->stream_id,
-                  strapperrorcode(fr->app_error_code), fr->app_error_code);
+  ngtcp2_log_infof_raw(log, NGTCP2_LOG_EVENT_FRM,
+                       NGTCP2_LOG_PKT " STOP_SENDING(0x%02" PRIx64
+                                      ") id=0x%" PRIx64
+                                      " app_error_code=%s(0x%" PRIx64 ")",
+                       NGTCP2_LOG_PKT_HD_FIELDS(dir), fr->type, fr->stream_id,
+                       strapperrorcode(fr->app_error_code), fr->app_error_code);
 }
 
 static void log_fr_path_challenge(ngtcp2_log *log, const ngtcp2_pkt_hd *hd,
@@ -403,10 +368,10 @@ static void log_fr_path_challenge(ngtcp2_log *log, const ngtcp2_pkt_hd *hd,
                                   const char *dir) {
   uint8_t buf[sizeof(fr->data) * 2 + 1];
 
-  log->log_printf(
-    log->user_data,
-    (NGTCP2_LOG_PKT " PATH_CHALLENGE(0x%02" PRIx64 ") data=0x%s"),
-    NGTCP2_LOG_FRM_HD_FIELDS(dir), fr->type,
+  ngtcp2_log_infof_raw(
+    log, NGTCP2_LOG_EVENT_FRM,
+    NGTCP2_LOG_PKT " PATH_CHALLENGE(0x%02" PRIx64 ") data=0x%s",
+    NGTCP2_LOG_PKT_HD_FIELDS(dir), fr->type,
     (const char *)ngtcp2_encode_hex(buf, fr->data, sizeof(fr->data)));
 }
 
@@ -415,20 +380,20 @@ static void log_fr_path_response(ngtcp2_log *log, const ngtcp2_pkt_hd *hd,
                                  const char *dir) {
   uint8_t buf[sizeof(fr->data) * 2 + 1];
 
-  log->log_printf(
-    log->user_data,
-    (NGTCP2_LOG_PKT " PATH_RESPONSE(0x%02" PRIx64 ") data=0x%s"),
-    NGTCP2_LOG_FRM_HD_FIELDS(dir), fr->type,
+  ngtcp2_log_infof_raw(
+    log, NGTCP2_LOG_EVENT_FRM,
+    NGTCP2_LOG_PKT " PATH_RESPONSE(0x%02" PRIx64 ") data=0x%s",
+    NGTCP2_LOG_PKT_HD_FIELDS(dir), fr->type,
     (const char *)ngtcp2_encode_hex(buf, fr->data, sizeof(fr->data)));
 }
 
 static void log_fr_crypto(ngtcp2_log *log, const ngtcp2_pkt_hd *hd,
                           const ngtcp2_stream *fr, const char *dir) {
-  log->log_printf(
-    log->user_data,
-    (NGTCP2_LOG_PKT " CRYPTO(0x%02" PRIx64 ") offset=%" PRIu64 " len=%" PRIu64),
-    NGTCP2_LOG_FRM_HD_FIELDS(dir), fr->type, fr->offset,
-    ngtcp2_vec_len(fr->data, fr->datacnt));
+  ngtcp2_log_infof_raw(log, NGTCP2_LOG_EVENT_FRM,
+                       NGTCP2_LOG_PKT " CRYPTO(0x%02" PRIx64 ") offset=%" PRIu64
+                                      " len=%" PRIu64,
+                       NGTCP2_LOG_PKT_HD_FIELDS(dir), fr->type, fr->offset,
+                       ngtcp2_vec_len(fr->data, fr->datacnt));
 }
 
 static void log_fr_new_token(ngtcp2_log *log, const ngtcp2_pkt_hd *hd,
@@ -445,36 +410,37 @@ static void log_fr_new_token(ngtcp2_log *log, const ngtcp2_pkt_hd *hd,
   } else {
     p = ngtcp2_encode_hex(buf, fr->token, fr->tokenlen);
   }
-  log->log_printf(
-    log->user_data,
-    (NGTCP2_LOG_PKT " NEW_TOKEN(0x%02" PRIx64 ") token=0x%s len=%zu"),
-    NGTCP2_LOG_FRM_HD_FIELDS(dir), fr->type, (const char *)p, fr->tokenlen);
+
+  ngtcp2_log_infof_raw(
+    log, NGTCP2_LOG_EVENT_FRM,
+    NGTCP2_LOG_PKT " NEW_TOKEN(0x%02" PRIx64 ") token=0x%s len=%zu",
+    NGTCP2_LOG_PKT_HD_FIELDS(dir), fr->type, (const char *)p, fr->tokenlen);
 }
 
 static void log_fr_retire_connection_id(ngtcp2_log *log,
                                         const ngtcp2_pkt_hd *hd,
                                         const ngtcp2_retire_connection_id *fr,
                                         const char *dir) {
-  log->log_printf(
-    log->user_data,
-    (NGTCP2_LOG_PKT " RETIRE_CONNECTION_ID(0x%02" PRIx64 ") seq=%" PRIu64),
-    NGTCP2_LOG_FRM_HD_FIELDS(dir), fr->type, fr->seq);
+  ngtcp2_log_infof_raw(log, NGTCP2_LOG_EVENT_FRM,
+                       NGTCP2_LOG_PKT " RETIRE_CONNECTION_ID(0x%02" PRIx64
+                                      ") seq=%" PRIu64,
+                       NGTCP2_LOG_PKT_HD_FIELDS(dir), fr->type, fr->seq);
 }
 
 static void log_fr_handshake_done(ngtcp2_log *log, const ngtcp2_pkt_hd *hd,
                                   const ngtcp2_handshake_done *fr,
                                   const char *dir) {
-  log->log_printf(log->user_data,
-                  (NGTCP2_LOG_PKT " HANDSHAKE_DONE(0x%02" PRIx64 ")"),
-                  NGTCP2_LOG_FRM_HD_FIELDS(dir), fr->type);
+  ngtcp2_log_infof_raw(log, NGTCP2_LOG_EVENT_FRM,
+                       NGTCP2_LOG_PKT " HANDSHAKE_DONE(0x%02" PRIx64 ")",
+                       NGTCP2_LOG_PKT_HD_FIELDS(dir), fr->type);
 }
 
 static void log_fr_datagram(ngtcp2_log *log, const ngtcp2_pkt_hd *hd,
                             const ngtcp2_datagram *fr, const char *dir) {
-  log->log_printf(log->user_data,
-                  (NGTCP2_LOG_PKT " DATAGRAM(0x%02" PRIx64 ") len=%" PRIu64),
-                  NGTCP2_LOG_FRM_HD_FIELDS(dir), fr->type,
-                  ngtcp2_vec_len(fr->data, fr->datacnt));
+  ngtcp2_log_infof_raw(log, NGTCP2_LOG_EVENT_FRM,
+                       NGTCP2_LOG_PKT " DATAGRAM(0x%02" PRIx64 ") len=%" PRIu64,
+                       NGTCP2_LOG_PKT_HD_FIELDS(dir), fr->type,
+                       ngtcp2_vec_len(fr->data, fr->datacnt));
 }
 
 static void log_fr(ngtcp2_log *log, const ngtcp2_pkt_hd *hd,
@@ -580,8 +546,8 @@ void ngtcp2_log_rx_vn(ngtcp2_log *log, const ngtcp2_pkt_hd *hd,
   }
 
   for (i = 0; i < nsv; ++i) {
-    log->log_printf(log->user_data, (NGTCP2_LOG_PKT " v=0x%08x"),
-                    NGTCP2_LOG_PKT_HD_FIELDS("rx"), sv[i]);
+    ngtcp2_log_infof_raw(log, NGTCP2_LOG_EVENT_PKT, NGTCP2_LOG_PKT " v=0x%08x",
+                         NGTCP2_LOG_PKT_HD_FIELDS("rx"), sv[i]);
   }
 }
 
@@ -598,8 +564,8 @@ void ngtcp2_log_rx_sr(ngtcp2_log *log, const ngtcp2_pkt_stateless_reset *sr) {
     .type = NGTCP2_PKT_STATELESS_RESET,
   };
 
-  log->log_printf(
-    log->user_data, (NGTCP2_LOG_PKT " token=0x%s randlen=%zu"),
+  ngtcp2_log_infof_raw(
+    log, NGTCP2_LOG_EVENT_PKT, NGTCP2_LOG_PKT " token=0x%s randlen=%zu",
     NGTCP2_LOG_PKT_HD_FIELDS("rx"),
     (const char *)ngtcp2_encode_hex(buf, sr->stateless_reset_token,
                                     sizeof(sr->stateless_reset_token)),
@@ -622,9 +588,8 @@ void ngtcp2_log_remote_tp(ngtcp2_log *log,
   }
 
   if (params->stateless_reset_token_present) {
-    log->log_printf(
-      log->user_data, (NGTCP2_LOG_TP " stateless_reset_token=0x%s"),
-      NGTCP2_LOG_TP_HD_FIELDS,
+    ngtcp2_log_infof_raw(
+      log, NGTCP2_LOG_EVENT_CRY, NGTCP2_LOG_TP " stateless_reset_token=0x%s",
       (const char *)ngtcp2_encode_hex(token, params->stateless_reset_token,
                                       sizeof(params->stateless_reset_token)));
   }
@@ -633,116 +598,113 @@ void ngtcp2_log_remote_tp(ngtcp2_log *log,
     if (params->preferred_addr.ipv4_present) {
       sa_in = &params->preferred_addr.ipv4;
 
-      log->log_printf(log->user_data,
-                      (NGTCP2_LOG_TP " preferred_address.ipv4_addr=%s"),
-                      NGTCP2_LOG_TP_HD_FIELDS,
-                      (const char *)ngtcp2_encode_ipv4(
-                        addr, (const uint8_t *)&sa_in->sin_addr));
-      log->log_printf(log->user_data,
-                      (NGTCP2_LOG_TP " preferred_address.ipv4_port=%u"),
-                      NGTCP2_LOG_TP_HD_FIELDS, ngtcp2_ntohs(sa_in->sin_port));
+      ngtcp2_log_infof_raw(log, NGTCP2_LOG_EVENT_CRY,
+                           NGTCP2_LOG_TP " preferred_address.ipv4_addr=%s",
+                           (const char *)ngtcp2_encode_ipv4(
+                             addr, (const uint8_t *)&sa_in->sin_addr));
+      ngtcp2_log_infof_raw(log, NGTCP2_LOG_EVENT_CRY,
+                           NGTCP2_LOG_TP " preferred_address.ipv4_port=%u",
+                           ngtcp2_ntohs(sa_in->sin_port));
     }
 
     if (params->preferred_addr.ipv6_present) {
       sa_in6 = &params->preferred_addr.ipv6;
 
-      log->log_printf(log->user_data,
-                      (NGTCP2_LOG_TP " preferred_address.ipv6_addr=%s"),
-                      NGTCP2_LOG_TP_HD_FIELDS,
-                      (const char *)ngtcp2_encode_ipv6(
-                        addr, (const uint8_t *)&sa_in6->sin6_addr));
-      log->log_printf(log->user_data,
-                      (NGTCP2_LOG_TP " preferred_address.ipv6_port=%u"),
-                      NGTCP2_LOG_TP_HD_FIELDS, ngtcp2_ntohs(sa_in6->sin6_port));
+      ngtcp2_log_infof_raw(log, NGTCP2_LOG_EVENT_CRY,
+                           NGTCP2_LOG_TP " preferred_address.ipv6_addr=%s",
+                           (const char *)ngtcp2_encode_ipv6(
+                             addr, (const uint8_t *)&sa_in6->sin6_addr));
+      ngtcp2_log_infof_raw(log, NGTCP2_LOG_EVENT_CRY,
+                           NGTCP2_LOG_TP " preferred_address.ipv6_port=%u",
+                           ngtcp2_ntohs(sa_in6->sin6_port));
     }
 
-    log->log_printf(
-      log->user_data, (NGTCP2_LOG_TP " preferred_address.cid=0x%s"),
-      NGTCP2_LOG_TP_HD_FIELDS,
+    ngtcp2_log_infof_raw(
+      log, NGTCP2_LOG_EVENT_CRY, NGTCP2_LOG_TP " preferred_address.cid=0x%s",
       (const char *)ngtcp2_encode_hex(cid, params->preferred_addr.cid.data,
                                       params->preferred_addr.cid.datalen));
-    log->log_printf(
-      log->user_data,
-      (NGTCP2_LOG_TP " preferred_address.stateless_reset_token=0x%s"),
-      NGTCP2_LOG_TP_HD_FIELDS,
+    ngtcp2_log_infof_raw(
+      log, NGTCP2_LOG_EVENT_CRY,
+      NGTCP2_LOG_TP " preferred_address.stateless_reset_token=0x%s",
       (const char *)ngtcp2_encode_hex(
         token, params->preferred_addr.stateless_reset_token,
         sizeof(params->preferred_addr.stateless_reset_token)));
   }
 
   if (params->original_dcid_present) {
-    log->log_printf(
-      log->user_data,
-      (NGTCP2_LOG_TP " original_destination_connection_id=0x%s"),
-      NGTCP2_LOG_TP_HD_FIELDS,
+    ngtcp2_log_infof_raw(
+      log, NGTCP2_LOG_EVENT_CRY,
+      NGTCP2_LOG_TP " original_destination_connection_id=0x%s",
       (const char *)ngtcp2_encode_hex(cid, params->original_dcid.data,
                                       params->original_dcid.datalen));
   }
 
   if (params->retry_scid_present) {
-    log->log_printf(
-      log->user_data, (NGTCP2_LOG_TP " retry_source_connection_id=0x%s"),
-      NGTCP2_LOG_TP_HD_FIELDS,
+    ngtcp2_log_infof_raw(
+      log, NGTCP2_LOG_EVENT_CRY,
+      NGTCP2_LOG_TP " retry_source_connection_id=0x%s",
       (const char *)ngtcp2_encode_hex(cid, params->retry_scid.data,
                                       params->retry_scid.datalen));
   }
 
   if (params->initial_scid_present) {
-    log->log_printf(
-      log->user_data, (NGTCP2_LOG_TP " initial_source_connection_id=0x%s"),
-      NGTCP2_LOG_TP_HD_FIELDS,
+    ngtcp2_log_infof_raw(
+      log, NGTCP2_LOG_EVENT_CRY,
+      NGTCP2_LOG_TP " initial_source_connection_id=0x%s",
       (const char *)ngtcp2_encode_hex(cid, params->initial_scid.data,
                                       params->initial_scid.datalen));
   }
 
-  log->log_printf(
-    log->user_data,
-    (NGTCP2_LOG_TP " initial_max_stream_data_bidi_local=%" PRIu64),
-    NGTCP2_LOG_TP_HD_FIELDS, params->initial_max_stream_data_bidi_local);
-  log->log_printf(
-    log->user_data,
-    (NGTCP2_LOG_TP " initial_max_stream_data_bidi_remote=%" PRIu64),
-    NGTCP2_LOG_TP_HD_FIELDS, params->initial_max_stream_data_bidi_remote);
-  log->log_printf(log->user_data,
-                  (NGTCP2_LOG_TP " initial_max_stream_data_uni=%" PRIu64),
-                  NGTCP2_LOG_TP_HD_FIELDS, params->initial_max_stream_data_uni);
-  log->log_printf(log->user_data, (NGTCP2_LOG_TP " initial_max_data=%" PRIu64),
-                  NGTCP2_LOG_TP_HD_FIELDS, params->initial_max_data);
-  log->log_printf(log->user_data,
-                  (NGTCP2_LOG_TP " initial_max_streams_bidi=%" PRIu64),
-                  NGTCP2_LOG_TP_HD_FIELDS, params->initial_max_streams_bidi);
-  log->log_printf(log->user_data,
-                  (NGTCP2_LOG_TP " initial_max_streams_uni=%" PRIu64),
-                  NGTCP2_LOG_TP_HD_FIELDS, params->initial_max_streams_uni);
-  log->log_printf(log->user_data, (NGTCP2_LOG_TP " max_idle_timeout=%" PRIu64),
-                  NGTCP2_LOG_TP_HD_FIELDS,
-                  params->max_idle_timeout / NGTCP2_MILLISECONDS);
-  log->log_printf(log->user_data,
-                  (NGTCP2_LOG_TP " max_udp_payload_size=%" PRIu64),
-                  NGTCP2_LOG_TP_HD_FIELDS, params->max_udp_payload_size);
-  log->log_printf(log->user_data,
-                  (NGTCP2_LOG_TP " ack_delay_exponent=%" PRIu64),
-                  NGTCP2_LOG_TP_HD_FIELDS, params->ack_delay_exponent);
-  log->log_printf(log->user_data, (NGTCP2_LOG_TP " max_ack_delay=%" PRIu64),
-                  NGTCP2_LOG_TP_HD_FIELDS,
-                  params->max_ack_delay / NGTCP2_MILLISECONDS);
-  log->log_printf(log->user_data,
-                  (NGTCP2_LOG_TP " active_connection_id_limit=%" PRIu64),
-                  NGTCP2_LOG_TP_HD_FIELDS, params->active_connection_id_limit);
-  log->log_printf(log->user_data,
-                  (NGTCP2_LOG_TP " disable_active_migration=%d"),
-                  NGTCP2_LOG_TP_HD_FIELDS, params->disable_active_migration);
-  log->log_printf(log->user_data,
-                  (NGTCP2_LOG_TP " max_datagram_frame_size=%" PRIu64),
-                  NGTCP2_LOG_TP_HD_FIELDS, params->max_datagram_frame_size);
-  log->log_printf(log->user_data, (NGTCP2_LOG_TP " grease_quic_bit=%d"),
-                  NGTCP2_LOG_TP_HD_FIELDS, params->grease_quic_bit);
+  ngtcp2_log_infof_raw(log, NGTCP2_LOG_EVENT_CRY,
+                       NGTCP2_LOG_TP
+                       " initial_max_stream_data_bidi_local=%" PRIu64,
+                       params->initial_max_stream_data_bidi_local);
+  ngtcp2_log_infof_raw(log, NGTCP2_LOG_EVENT_CRY,
+                       NGTCP2_LOG_TP
+                       " initial_max_stream_data_bidi_remote=%" PRIu64,
+                       params->initial_max_stream_data_bidi_remote);
+  ngtcp2_log_infof_raw(log, NGTCP2_LOG_EVENT_CRY,
+                       NGTCP2_LOG_TP " initial_max_stream_data_uni=%" PRIu64,
+                       params->initial_max_stream_data_uni);
+  ngtcp2_log_infof_raw(log, NGTCP2_LOG_EVENT_CRY,
+                       NGTCP2_LOG_TP " initial_max_data=%" PRIu64,
+                       params->initial_max_data);
+  ngtcp2_log_infof_raw(log, NGTCP2_LOG_EVENT_CRY,
+                       NGTCP2_LOG_TP " initial_max_streams_bidi=%" PRIu64,
+                       params->initial_max_streams_bidi);
+  ngtcp2_log_infof_raw(log, NGTCP2_LOG_EVENT_CRY,
+                       NGTCP2_LOG_TP " initial_max_streams_uni=%" PRIu64,
+                       params->initial_max_streams_uni);
+  ngtcp2_log_infof_raw(log, NGTCP2_LOG_EVENT_CRY,
+                       NGTCP2_LOG_TP " max_idle_timeout=%" PRIu64,
+                       params->max_idle_timeout / NGTCP2_MILLISECONDS);
+  ngtcp2_log_infof_raw(log, NGTCP2_LOG_EVENT_CRY,
+                       NGTCP2_LOG_TP " max_udp_payload_size=%" PRIu64,
+                       params->max_udp_payload_size);
+  ngtcp2_log_infof_raw(log, NGTCP2_LOG_EVENT_CRY,
+                       NGTCP2_LOG_TP " ack_delay_exponent=%" PRIu64,
+                       params->ack_delay_exponent);
+  ngtcp2_log_infof_raw(log, NGTCP2_LOG_EVENT_CRY,
+                       NGTCP2_LOG_TP " max_ack_delay=%" PRIu64,
+                       params->max_ack_delay / NGTCP2_MILLISECONDS);
+  ngtcp2_log_infof_raw(log, NGTCP2_LOG_EVENT_CRY,
+                       NGTCP2_LOG_TP " active_connection_id_limit=%" PRIu64,
+                       params->active_connection_id_limit);
+  ngtcp2_log_infof_raw(log, NGTCP2_LOG_EVENT_CRY,
+                       NGTCP2_LOG_TP " disable_active_migration=%d",
+                       params->disable_active_migration);
+  ngtcp2_log_infof_raw(log, NGTCP2_LOG_EVENT_CRY,
+                       NGTCP2_LOG_TP " max_datagram_frame_size=%" PRIu64,
+                       params->max_datagram_frame_size);
+  ngtcp2_log_infof_raw(log, NGTCP2_LOG_EVENT_CRY,
+                       NGTCP2_LOG_TP " grease_quic_bit=%d",
+                       params->grease_quic_bit);
 
   if (params->version_info_present) {
-    log->log_printf(
-      log->user_data,
-      (NGTCP2_LOG_TP " version_information.chosen_version=0x%08x"),
-      NGTCP2_LOG_TP_HD_FIELDS, params->version_info.chosen_version);
+    ngtcp2_log_infof_raw(log, NGTCP2_LOG_EVENT_CRY,
+                         NGTCP2_LOG_TP
+                         " version_information.chosen_version=0x%08x",
+                         params->version_info.chosen_version);
 
     assert(!(params->version_info.available_versionslen & 0x3));
 
@@ -751,10 +713,10 @@ void ngtcp2_log_remote_tp(ngtcp2_log *log,
          i += sizeof(uint32_t)) {
       p = ngtcp2_get_uint32be(&version, p);
 
-      log->log_printf(
-        log->user_data,
-        (NGTCP2_LOG_TP " version_information.available_versions[%zu]=0x%08x"),
-        NGTCP2_LOG_TP_HD_FIELDS, i >> 2, version);
+      ngtcp2_log_infof_raw(
+        log, NGTCP2_LOG_EVENT_CRY,
+        NGTCP2_LOG_TP " version_information.available_versions[%zu]=0x%08x",
+        i >> 2, version);
     }
   }
 }
@@ -765,9 +727,9 @@ void ngtcp2_log_pkt_lost(ngtcp2_log *log, int64_t pkt_num, uint8_t type,
     return;
   }
 
-  ngtcp2_log_info(log, NGTCP2_LOG_EVENT_LDC,
-                  "pkn=%" PRId64 " lost type=%s sent_ts=%" PRIu64, pkt_num,
-                  strpkttype_type_flags(type, flags), sent_ts);
+  ngtcp2_log_infof(log, NGTCP2_LOG_EVENT_LDC,
+                   "pkn=%" PRId64 " lost type=%s sent_ts=%" PRIu64, pkt_num,
+                   strpkttype_type_flags(type, flags), sent_ts);
 }
 
 static void log_pkt_hd(ngtcp2_log *log, const ngtcp2_pkt_hd *hd,
@@ -780,13 +742,13 @@ static void log_pkt_hd(ngtcp2_log *log, const ngtcp2_pkt_hd *hd,
   }
 
   if (hd->type == NGTCP2_PKT_1RTT) {
-    ngtcp2_log_info(
+    ngtcp2_log_infof(
       log, NGTCP2_LOG_EVENT_PKT, "%s pkn=%" PRId64 " dcid=0x%s type=%s k=%d",
       dir, hd->pkt_num,
       (const char *)ngtcp2_encode_hex(dcid, hd->dcid.data, hd->dcid.datalen),
       strpkttype(hd), (hd->flags & NGTCP2_PKT_FLAG_KEY_PHASE) != 0);
   } else {
-    ngtcp2_log_info(
+    ngtcp2_log_infof(
       log, NGTCP2_LOG_EVENT_PKT,
       "%s pkn=%" PRId64 " dcid=0x%s scid=0x%s version=0x%08x type=%s len=%zu",
       dir, hd->pkt_num,
@@ -804,31 +766,12 @@ void ngtcp2_log_tx_pkt_hd(ngtcp2_log *log, const ngtcp2_pkt_hd *hd) {
   log_pkt_hd(log, hd, "tx");
 }
 
-void ngtcp2_log_info(ngtcp2_log *log, ngtcp2_log_event ev, const char *fmt,
-                     ...) {
-  va_list ap;
-  int n;
-  char buf[NGTCP2_LOG_BUFLEN];
-
-  if (!log->log_printf || !(log->events & ev)) {
-    return;
-  }
-
-  va_start(ap, fmt);
-  n = vsnprintf(buf, sizeof(buf), fmt, ap);
-  va_end(ap);
-
-  if (n < 0 || (size_t)n >= sizeof(buf)) {
-    return;
-  }
-
-  log->log_printf(log->user_data, (NGTCP2_LOG_HD " %s"),
-                  timestamp_cast(log->last_ts - log->ts), log->scid,
-                  strevent(ev), buf);
+void ngtcp2_log_tx_cancel(ngtcp2_log *log, const ngtcp2_pkt_hd *hd) {
+  ngtcp2_log_infof(log, NGTCP2_LOG_EVENT_PKT,
+                   "cancel tx pkn=%" PRId64 " type=%s", hd->pkt_num,
+                   strpkttype(hd));
 }
 
-void ngtcp2_log_tx_cancel(ngtcp2_log *log, const ngtcp2_pkt_hd *hd) {
-  ngtcp2_log_info(log, NGTCP2_LOG_EVENT_PKT,
-                  "cancel tx pkn=%" PRId64 " type=%s", hd->pkt_num,
-                  strpkttype(hd));
+uint64_t ngtcp2_log_timestamp(const ngtcp2_log *log) {
+  return (log->last_ts - log->ts) / NGTCP2_MILLISECONDS;
 }

--- a/lib/ngtcp2_log.h
+++ b/lib/ngtcp2_log.h
@@ -121,12 +121,71 @@ void ngtcp2_log_tx_pkt_hd(ngtcp2_log *log, const ngtcp2_pkt_hd *hd);
 
 void ngtcp2_log_tx_cancel(ngtcp2_log *log, const ngtcp2_pkt_hd *hd);
 
+#define NGTCP2_LOG_HD "I%08" PRIu64 " 0x%s %s"
+
+uint64_t ngtcp2_log_timestamp(const ngtcp2_log *log);
+
+static inline const char *ngtcp2_log_event_str(ngtcp2_log_event ev) {
+  switch (ev) {
+  case NGTCP2_LOG_EVENT_CON:
+    return "con";
+  case NGTCP2_LOG_EVENT_PKT:
+    return "pkt";
+  case NGTCP2_LOG_EVENT_FRM:
+    return "frm";
+  case NGTCP2_LOG_EVENT_LDC:
+    return "ldc";
+  case NGTCP2_LOG_EVENT_CRY:
+    return "cry";
+  case NGTCP2_LOG_EVENT_PTV:
+    return "ptv";
+  case NGTCP2_LOG_EVENT_CCA:
+    return "cca";
+  case NGTCP2_LOG_EVENT_NONE:
+  default:
+    return "non";
+  }
+}
+
+#define ngtcp2_log_infof_raw(LOG, EV, FMT, ...)                                \
+  (LOG)->log_printf((LOG)->user_data, NGTCP2_LOG_HD " " FMT,                   \
+                    ngtcp2_log_timestamp(LOG), (LOG)->scid,                    \
+                    ngtcp2_log_event_str(EV), __VA_ARGS__);
+
 /**
  * @function
  *
- * `ngtcp2_log_info` writes info level log.
+ * `ngtcp2_log_infof` writes info level log with printf like
+ * formatting.
  */
-void ngtcp2_log_info(ngtcp2_log *log, ngtcp2_log_event ev, const char *fmt,
-                     ...);
+#define ngtcp2_log_infof(LOG, EV, FMT, ...)                                    \
+  do {                                                                         \
+    if (!(LOG)->log_printf || !((LOG)->events & (EV))) {                       \
+      break;                                                                   \
+    }                                                                          \
+                                                                               \
+    ngtcp2_log_infof_raw((LOG), (EV), FMT, __VA_ARGS__);                       \
+  } while (0)
+
+#define ngtcp2_log_info_raw(LOG, EV, FMT)                                      \
+  (LOG)->log_printf((LOG)->user_data, NGTCP2_LOG_HD " " FMT,                   \
+                    ngtcp2_log_timestamp(LOG), (LOG)->scid,                    \
+                    ngtcp2_log_event_str(EV))
+
+/**
+ * @function
+ *
+ * `ngtcp2_log_info` writes info level log.  FMT should not contain
+ * formatting directive.  This function exists to workaround the issue
+ * that __VA_ARGS__ cannot be empty.
+ */
+#define ngtcp2_log_info(LOG, EV, FMT)                                          \
+  do {                                                                         \
+    if (!(LOG)->log_printf || !((LOG)->events & (EV))) {                       \
+      break;                                                                   \
+    }                                                                          \
+                                                                               \
+    ngtcp2_log_info_raw((LOG), (EV), FMT);                                     \
+  } while (0)
 
 #endif /* !defined(NGTCP2_LOG_H) */

--- a/lib/ngtcp2_rtb.c
+++ b/lib/ngtcp2_rtb.c
@@ -473,9 +473,9 @@ static int rtb_on_pkt_lost(ngtcp2_rtb *rtb, ngtcp2_rtb_entry *ent,
   }
 
   if (ent->flags & NGTCP2_RTB_ENTRY_FLAG_PTO_RECLAIMED) {
-    ngtcp2_log_info(rtb->log, NGTCP2_LOG_EVENT_LDC,
-                    "pkn=%" PRId64 " has already been reclaimed on PTO",
-                    ent->hd.pkt_num);
+    ngtcp2_log_infof(rtb->log, NGTCP2_LOG_EVENT_LDC,
+                     "pkn=%" PRId64 " has already been reclaimed on PTO",
+                     ent->hd.pkt_num);
     assert(!(ent->flags & NGTCP2_RTB_ENTRY_FLAG_LOST_RETRANSMITTED));
     assert(UINT64_MAX == ent->lost_ts);
   } else {
@@ -1158,10 +1158,10 @@ static int rtb_detect_lost_pkt(ngtcp2_rtb *rtb, uint64_t *ppkt_lost,
        */
       if (pktns->id == NGTCP2_PKTNS_ID_APPLICATION && loss_window &&
           loss_window >= congestion_period) {
-        ngtcp2_log_info(rtb->log, NGTCP2_LOG_EVENT_LDC,
-                        "persistent congestion loss_window=%" PRIu64
-                        " congestion_period=%" PRIu64,
-                        loss_window, congestion_period);
+        ngtcp2_log_infof(rtb->log, NGTCP2_LOG_EVENT_LDC,
+                         "persistent congestion loss_window=%" PRIu64
+                         " congestion_period=%" PRIu64,
+                         loss_window, congestion_period);
 
         /* Reset min_rtt, srtt, and rttvar here.  Next new RTT
            sample will be used to recalculate these values. */
@@ -1208,8 +1208,8 @@ void ngtcp2_rtb_remove_excessive_lost_pkt(ngtcp2_rtb *rtb, size_t n) {
 
     assert(ent->flags & NGTCP2_RTB_ENTRY_FLAG_LOST_RETRANSMITTED);
 
-    ngtcp2_log_info(rtb->log, NGTCP2_LOG_EVENT_LDC,
-                    "removing stale lost pkn=%" PRId64, ent->hd.pkt_num);
+    ngtcp2_log_infof(rtb->log, NGTCP2_LOG_EVENT_LDC,
+                     "removing stale lost pkn=%" PRId64, ent->hd.pkt_num);
 
     --rtb->num_lost_pkts;
 
@@ -1250,8 +1250,8 @@ void ngtcp2_rtb_remove_expired_lost_pkt(ngtcp2_rtb *rtb,
       return;
     }
 
-    ngtcp2_log_info(rtb->log, NGTCP2_LOG_EVENT_LDC,
-                    "removing stale lost pkn=%" PRId64, ent->hd.pkt_num);
+    ngtcp2_log_infof(rtb->log, NGTCP2_LOG_EVENT_LDC,
+                     "removing stale lost pkn=%" PRId64, ent->hd.pkt_num);
 
     --rtb->num_lost_pkts;
 
@@ -1403,9 +1403,9 @@ int ngtcp2_rtb_reclaim_on_retry(ngtcp2_rtb *rtb, ngtcp2_conn *conn,
     assert(!(ent->flags & NGTCP2_RTB_ENTRY_FLAG_PMTUD_PROBE));
 
     if (ent->flags & NGTCP2_RTB_ENTRY_FLAG_PTO_RECLAIMED) {
-      ngtcp2_log_info(rtb->log, NGTCP2_LOG_EVENT_LDC,
-                      "pkn=%" PRId64 " has already been reclaimed on PTO",
-                      ent->hd.pkt_num);
+      ngtcp2_log_infof(rtb->log, NGTCP2_LOG_EVENT_LDC,
+                       "pkn=%" PRId64 " has already been reclaimed on PTO",
+                       ent->hd.pkt_num);
       continue;
     }
 


### PR DESCRIPTION
Do not format string in the library, just pass format and args to the callback, and let an application deal with them.