### PR TITLE
Add man and doc targets

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -35,7 +35,7 @@ BUILDDIR      = build
 help:
 	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
-.PHONY: help html apiref cryptoapiref
+.PHONY: help html apiref cryptoapiref man doc
 
 apiref: mkapiref.py \
 	$(top_builddir)/lib/includes/ngtcp2/version.h \
@@ -61,6 +61,11 @@ cryptoapiref: mkapiref.py \
 
 html-local: apiref cryptoapiref
 	@$(SPHINXBUILD) -M html "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+man: apiref cryptoapiref
+	@$(SPHINXBUILD) -M man "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+doc: html-local man
 
 clean-local:
 	-rm -rf "$(BUILDDIR)"

--- a/doc/source/conf.py.in
+++ b/doc/source/conf.py.in
@@ -92,3 +92,11 @@ highlight_language = 'c'
 version = '@PACKAGE_VERSION@'
 # The full version, including alpha/beta/rc tags.
 release = '@PACKAGE_VERSION@'
+
+# -- Options for manual pages output
+man_pages = [
+        ('index', 'ngtcp2', 'ngtcp2 complete manual', ['ngtcp2 contributors'], '3'),
+        ('programmers-guide', 'ngtcp2-guide', 'ngtcp2 programmers\' guide', ['ngtcp2 contributors'], '3'),
+        ('apiref', 'ngtcp2-api', 'ngtcp2 API reference', ['ngtcp2 contributors'], '3'),
+        ('crypto_apiref', 'ngtcp2-crypto-api', 'ngtcp2 crypto API reference', ['ngtcp2 contributors'], '3'),
+]


### PR DESCRIPTION
Sphinx allows simple building of man pages. Add man target in doc directory and create 4 separate manual pages from existing files.

Separates just man target from PR #1404 