### PR TITLE
Make ngtcp2_stream.fin of type int

### DIFF
--- a/lib/ngtcp2_conn.c
+++ b/lib/ngtcp2_conn.c
@@ -3459,7 +3459,6 @@ static ngtcp2_ssize conn_write_pkt(ngtcp2_conn *conn, ngtcp2_pkt_info *pi,
   uint64_t crypto_offset;
   uint64_t stream_offset;
   ngtcp2_ssize num_reclaimed;
-  int fin;
   uint64_t target_max_data;
   ngtcp2_conn_stat *cstat = &conn->cstat;
   uint64_t delta;
@@ -4154,9 +4153,8 @@ static ngtcp2_ssize conn_write_pkt(ngtcp2_conn *conn, ngtcp2_pkt_info *pi,
     nfrc->fr.stream.datacnt = datacnt;
     ngtcp2_vec_copy(nfrc->fr.stream.data, data, datacnt);
 
-    fin = (vmsg->stream.flags & NGTCP2_WRITE_STREAM_FLAG_FIN) &&
-          ndatalen == datalen;
-    nfrc->fr.stream.fin = (uint8_t)fin;
+    nfrc->fr.stream.fin = (vmsg->stream.flags & NGTCP2_WRITE_STREAM_FLAG_FIN) &&
+                          ndatalen == datalen;
 
     rv = conn_ppe_write_frame_hd_log(conn, ppe, &hd_logged, hd, &nfrc->fr);
     if (rv != 0) {
@@ -4175,7 +4173,7 @@ static ngtcp2_ssize conn_write_pkt(ngtcp2_conn *conn, ngtcp2_pkt_info *pi,
     conn->tx.offset += ndatalen;
     vmsg->stream.strm->flags |= NGTCP2_STRM_FLAG_ANY_SENT;
 
-    if (fin) {
+    if (nfrc->fr.stream.fin) {
       ngtcp2_strm_shutdown(vmsg->stream.strm, NGTCP2_STRM_FLAG_SHUT_WR);
     }
 

--- a/lib/ngtcp2_pkt.h
+++ b/lib/ngtcp2_pkt.h
@@ -195,7 +195,7 @@ typedef struct ngtcp2_stream {
   uint8_t flags;
   /* CRYPTO frame does not include this field, and must set it to
      0. */
-  uint8_t fin;
+  int fin;
   /* CRYPTO frame does not include this field, and must set it to
      0. */
   int64_t stream_id;

--- a/tests/ngtcp2_pkt_test.c
+++ b/tests/ngtcp2_pkt_test.c
@@ -766,7 +766,7 @@ void test_ngtcp2_pkt_encode_stream_frame(void) {
   assert_ptrdiff((ngtcp2_ssize)framelen, ==, rv);
   assert_uint64(fr.type, ==, nfr.type);
   assert_uint8((NGTCP2_STREAM_OFF_BIT | NGTCP2_STREAM_LEN_BIT), ==, nfr.flags);
-  assert_uint8(fr.fin, ==, nfr.fin);
+  assert_int(fr.fin, ==, nfr.fin);
   assert_int64(fr.stream_id, ==, nfr.stream_id);
   assert_uint64(fr.offset, ==, nfr.offset);
   assert_size(1, ==, nfr.datacnt);
@@ -805,7 +805,7 @@ void test_ngtcp2_pkt_encode_stream_frame(void) {
   assert_ptrdiff((ngtcp2_ssize)framelen, ==, rv);
   assert_uint64(fr.type, ==, nfr.type);
   assert_uint8(NGTCP2_STREAM_LEN_BIT, ==, nfr.flags);
-  assert_uint8(fr.fin, ==, nfr.fin);
+  assert_int(fr.fin, ==, nfr.fin);
   assert_int64(fr.stream_id, ==, nfr.stream_id);
   assert_uint64(fr.offset, ==, nfr.offset);
   assert_size(1, ==, nfr.datacnt);
@@ -848,7 +848,7 @@ void test_ngtcp2_pkt_encode_stream_frame(void) {
   assert_uint8(
     (NGTCP2_STREAM_FIN_BIT | NGTCP2_STREAM_OFF_BIT | NGTCP2_STREAM_LEN_BIT), ==,
     nfr.flags);
-  assert_uint8(fr.fin, ==, nfr.fin);
+  assert_int(fr.fin, ==, nfr.fin);
   assert_int64(fr.stream_id, ==, nfr.stream_id);
   assert_uint64(fr.offset, ==, nfr.offset);
   assert_size(1, ==, nfr.datacnt);
@@ -1583,7 +1583,7 @@ void test_ngtcp2_pkt_encode_crypto_frame(void) {
   assert_ptrdiff((ngtcp2_ssize)framelen, ==, rv);
   assert_uint64(fr.type, ==, nfr.type);
   assert_uint8(fr.flags, ==, nfr.flags);
-  assert_uint8(fr.fin, ==, nfr.fin);
+  assert_int(fr.fin, ==, nfr.fin);
   assert_int64(fr.stream_id, ==, nfr.stream_id);
   assert_uint64(fr.offset, ==, nfr.offset);
   assert_size(fr.datacnt, ==, nfr.datacnt);


### PR DESCRIPTION
Make ngtcp2_stream.fin of type int so that we do not need any casts from integer operation.  The size of ngtcp2_stream does not change on 64-bit systems.