### PR TITLE
Replace POPCNT-based ispow2 with portable bitwise implementation to prevent illegal instruction crashes

### DIFF
--- a/lib/ngtcp2_ringbuf.c
+++ b/lib/ngtcp2_ringbuf.c
@@ -34,7 +34,7 @@
 #ifndef NDEBUG
 /* Power-of-two test; simple portable bit trick. */
 static int ispow2(size_t n) { return n && !(n & (n - 1)); }
-#endif /* !NDEBUG */
+#endif /* !defined(NDEBUG) */
 
 int ngtcp2_ringbuf_init(ngtcp2_ringbuf *rb, size_t nmemb, size_t size,
                         const ngtcp2_mem *mem) {

--- a/lib/ngtcp2_ringbuf.c
+++ b/lib/ngtcp2_ringbuf.c
@@ -32,42 +32,9 @@
 #include "ngtcp2_macro.h"
 
 #ifndef NDEBUG
-/* Provide fastest path when POPCNT is available: we detect once and then
-   call the selected implementation without an extra branch each time. */
-#  if defined(_MSC_VER) && !defined(__clang__) &&                              \
-    (defined(_M_ARM) || (defined(_M_ARM64) && _MSC_VER < 1941))
-static int ispow2(size_t n) { /* Simple portable fallback */
-  return n && !(n & (n - 1));
-}
-#  elif defined(WIN32)
-#    if defined(_M_IX86) || defined(_M_X64)
-static int ispow2_popcnt(size_t n) { return 1 == __popcnt((unsigned int)n); }
-#    endif /* x86/x64 */
-static int ispow2_fallback(size_t n) { return n && !(n & (n - 1)); }
-#    if defined(_M_IX86) || defined(_M_X64)
-static int ispow2_runtime(size_t n) {
-  int info[4] = {0};
-  __cpuid(info, 1);
-  /* ECX bit 23 indicates POPCNT support */
-  if (info[2] & (1 << 23)) {
-    /* Publish chosen implementation; benign data race acceptable in debug */
-    extern int (*ngtcp2_ispow2_impl)(size_t); /* forward */
-    ngtcp2_ispow2_impl = ispow2_popcnt;
-  } else {
-    extern int (*ngtcp2_ispow2_impl)(size_t);
-    ngtcp2_ispow2_impl = ispow2_fallback;
-  }
-  return ngtcp2_ispow2_impl(n);
-}
-static int (*ngtcp2_ispow2_impl)(size_t) = ispow2_runtime;
-static int ispow2(size_t n) { return ngtcp2_ispow2_impl(n); }
-#    else  /* non x86/x64 WIN32 (e.g. ARM) */
-static int ispow2(size_t n) { return ispow2_fallback(n); }
-#    endif /* defined(_M_IX86) || defined(_M_X64) */
-#  else  /* other toolchains */
-static int ispow2(size_t n) { return 1 == __builtin_popcount((unsigned int)n); }
-#  endif /* platform selection */
-#endif /* !defined(NDEBUG) */
+/* Power-of-two test; simple portable bit trick. */
+static int ispow2(size_t n) { return n && !(n & (n - 1)); }
+#endif /* !NDEBUG */
 
 int ngtcp2_ringbuf_init(ngtcp2_ringbuf *rb, size_t nmemb, size_t size,
                         const ngtcp2_mem *mem) {


### PR DESCRIPTION
Resolves #1810. This PR removes all POPCNT intrinsic usage from the debug-only ispow2 helper in ngtcp2_ringbuf.c, replacing it with the canonical bitwise power-of-two test: n && !(n & (n - 1)). This resolves crashes on CPUs without POPCNT while preserving performance.
#### Root Cause:
•	ispow2 used POPCNT intrinsics under #ifndef NDEBUG.
•	CMakeLists.txt strips -DNDEBUG from Release-like builds, so the code executed everywhere.
•	On CPUs lacking POPCNT, the intrinsic produced an illegal instruction fault.
#### Why This Implementation:
•	The bitwise formulation is architecture-neutral, constant-time, and emits just a few basic instructions.
•	For a single power-of-two check, POPCNT provides negligible benefit versus its complexity.
•	Avoids runtime CPUID dispatch and platform-specific branches.
•	Eliminates risk of crashes on older or constrained environments (legacy hardware, minimal VMs).
#### Benchmarks (Windows, C++20 test harness):
64-bit (ns/element):
•	Bitwise: 1.58346
•	__popcnt64: 1.52366
•	_mm_popcnt_u64: 1.50899
•	std::popcount: 1.78225
32-bit (ns/element):
•	Bitwise: 9.47397
•	__popcnt: 9.26461
•	std::popcount: 10.3988
Differences are marginal; bitwise is close to hardware POPCNT and faster than fallback or std::popcount cases.
#### Changes Made:
•	Removed previous POPCNT and runtime dispatch logic.
•	Added a single debug-only implementation:
```
#ifndef NDEBUG
    static int ispow2(size_t n) { return n && !(n & (n - 1)); }
#endif
```
•	No functional changes elsewhere.
#### Safety / Risk:
Low. Used only in assertions; logic is well-known and widely used. No ABI changes.
#### Performance Impact:
Neutral to positive. Simplifies code and avoids feature detection overhead.
#### Future Considerations:
If a future hot path in release code requires ispow2, reuse the same bitwise form; add POPCNT only if profiling proves a measurable win across supported CPUs.
