### PR TITLE
examples: Limit tx buffer for non-GSO case

### DIFF
--- a/examples/client.cc
+++ b/examples/client.cc
@@ -1157,7 +1157,10 @@ int Client::write_streams() {
   ngtcp2_pkt_info pi;
   size_t gso_size;
   auto ts = util::timestamp();
-  auto txbuf = std::span{tx_.data};
+  auto txbuf = std::span{
+    tx_.data.data(),
+    no_gso_ ? ngtcp2_conn_get_max_tx_udp_payload_size(conn_) : tx_.data.size(),
+  };
 
   ngtcp2_path_storage_zero(&ps);
 

--- a/examples/h09client.cc
+++ b/examples/h09client.cc
@@ -1057,7 +1057,10 @@ int Client::write_streams() {
   ngtcp2_pkt_info pi;
   size_t gso_size;
   auto ts = util::timestamp();
-  auto txbuf = std::span{tx_.data};
+  auto txbuf = std::span{
+    tx_.data.data(),
+    no_gso_ ? ngtcp2_conn_get_max_tx_udp_payload_size(conn_) : tx_.data.size(),
+  };
 
   ngtcp2_path_storage_zero(&ps);
 

--- a/examples/h09server.cc
+++ b/examples/h09server.cc
@@ -1030,7 +1030,10 @@ int Handler::write_streams() {
   ngtcp2_pkt_info pi;
   size_t gso_size;
   auto ts = util::timestamp();
-  auto txbuf = std::span{tx_.data.get(), NGTCP2_TX_BUFLEN};
+  auto txbuf = std::span{
+    tx_.data.get(),
+    no_gso_ ? ngtcp2_conn_get_max_tx_udp_payload_size(conn_) : NGTCP2_TX_BUFLEN,
+  };
 
   ngtcp2_path_storage_zero(&ps);
 

--- a/examples/server.cc
+++ b/examples/server.cc
@@ -1788,7 +1788,10 @@ int Handler::write_streams() {
   ngtcp2_pkt_info pi;
   size_t gso_size;
   auto ts = util::timestamp();
-  auto txbuf = std::span{tx_.data.get(), NGTCP2_TX_BUFLEN};
+  auto txbuf = std::span{
+    tx_.data.get(),
+    no_gso_ ? ngtcp2_conn_get_max_tx_udp_payload_size(conn_) : NGTCP2_TX_BUFLEN,
+  };
 
   ngtcp2_path_storage_zero(&ps);
 


### PR DESCRIPTION
For non-GSO case, limit tx buffer to
ngtcp2_conn_get_max_tx_udp_payload_size which is most likely 1 packet. This helps small queue and bandwidth simulated environment to test congestion controllers for cross traffic because QUIC tends to send too much and causes losses.  This change makes connection slower for other cases, but one cannot expect good performance without GSO in QUIC, so it is fine for now.