### PR TITLE
Reduce NGTCP2_HARD_MAX_UDP_PAYLOAD_SIZE to 64k

### DIFF
--- a/examples/client.cc
+++ b/examples/client.cc
@@ -3089,8 +3089,8 @@ int main(int argc, char **argv) {
         if (auto n = util::parse_uint_iec(optarg); !n) {
           std::cerr << "max-udp-payload-size: invalid argument" << std::endl;
           exit(EXIT_FAILURE);
-        } else if (*n > 64_k) {
-          std::cerr << "max-udp-payload-size: must not exceed 65536"
+        } else if (*n > 65527) {
+          std::cerr << "max-udp-payload-size: must not exceed 65527"
                     << std::endl;
           exit(EXIT_FAILURE);
         } else if (*n == 0) {
@@ -3209,9 +3209,9 @@ int main(int argc, char **argv) {
           if (auto n = util::parse_uint_iec(s); !n) {
             std::cerr << "pmtud-probes: invalid argument" << std::endl;
             exit(EXIT_FAILURE);
-          } else if (*n <= 1200 || *n >= 64_k) {
+          } else if (*n <= 1200 || *n > 65527) {
             std::cerr
-              << "pmtud-probes: must be in range [1201, 65535], inclusive."
+              << "pmtud-probes: must be in range [1201, 65527], inclusive."
               << std::endl;
             exit(EXIT_FAILURE);
           } else {

--- a/examples/h09client.cc
+++ b/examples/h09client.cc
@@ -2588,8 +2588,8 @@ int main(int argc, char **argv) {
         if (auto n = util::parse_uint_iec(optarg); !n) {
           std::cerr << "max-udp-payload-size: invalid argument" << std::endl;
           exit(EXIT_FAILURE);
-        } else if (*n > 64_k) {
-          std::cerr << "max-udp-payload-size: must not exceed 65536"
+        } else if (*n > 65527) {
+          std::cerr << "max-udp-payload-size: must not exceed 65527"
                     << std::endl;
           exit(EXIT_FAILURE);
         } else if (*n == 0) {
@@ -2708,9 +2708,9 @@ int main(int argc, char **argv) {
           if (auto n = util::parse_uint_iec(s); !n) {
             std::cerr << "pmtud-probes: invalid argument" << std::endl;
             exit(EXIT_FAILURE);
-          } else if (*n <= 1200 || *n >= 64_k) {
+          } else if (*n <= 1200 || *n > 65527) {
             std::cerr
-              << "pmtud-probes: must be in range [1201, 65535], inclusive."
+              << "pmtud-probes: must be in range [1201, 65527], inclusive."
               << std::endl;
             exit(EXIT_FAILURE);
           } else {

--- a/examples/h09server.cc
+++ b/examples/h09server.cc
@@ -3068,8 +3068,8 @@ int main(int argc, char **argv) {
         if (auto n = util::parse_uint_iec(optarg); !n) {
           std::cerr << "max-udp-payload-size: invalid argument" << std::endl;
           exit(EXIT_FAILURE);
-        } else if (*n > 64_k) {
-          std::cerr << "max-udp-payload-size: must not exceed 65536"
+        } else if (*n > 65527) {
+          std::cerr << "max-udp-payload-size: must not exceed 65527"
                     << std::endl;
           exit(EXIT_FAILURE);
         } else {
@@ -3200,9 +3200,9 @@ int main(int argc, char **argv) {
           if (auto n = util::parse_uint_iec(s); !n) {
             std::cerr << "pmtud-probes: invalid argument" << std::endl;
             exit(EXIT_FAILURE);
-          } else if (*n <= 1200 || *n >= 64_k) {
+          } else if (*n <= 1200 || *n > 65527) {
             std::cerr
-              << "pmtud-probes: must be in range [1201, 65535], inclusive."
+              << "pmtud-probes: must be in range [1201, 65527], inclusive."
               << std::endl;
             exit(EXIT_FAILURE);
           } else {

--- a/examples/server.cc
+++ b/examples/server.cc
@@ -3798,8 +3798,8 @@ int main(int argc, char **argv) {
         if (auto n = util::parse_uint_iec(optarg); !n) {
           std::cerr << "max-udp-payload-size: invalid argument" << std::endl;
           exit(EXIT_FAILURE);
-        } else if (*n > 64_k) {
-          std::cerr << "max-udp-payload-size: must not exceed 65536"
+        } else if (*n > 65527) {
+          std::cerr << "max-udp-payload-size: must not exceed 65527"
                     << std::endl;
           exit(EXIT_FAILURE);
         } else {
@@ -3930,9 +3930,9 @@ int main(int argc, char **argv) {
           if (auto n = util::parse_uint_iec(s); !n) {
             std::cerr << "pmtud-probes: invalid argument" << std::endl;
             exit(EXIT_FAILURE);
-          } else if (*n <= 1200 || *n >= 64_k) {
+          } else if (*n <= 1200 || *n > 65527) {
             std::cerr
-              << "pmtud-probes: must be in range [1201, 65535], inclusive."
+              << "pmtud-probes: must be in range [1201, 65527], inclusive."
               << std::endl;
             exit(EXIT_FAILURE);
           } else {

--- a/lib/includes/ngtcp2/ngtcp2.h
+++ b/lib/includes/ngtcp2/ngtcp2.h
@@ -1787,7 +1787,8 @@ typedef struct ngtcp2_settings {
   /**
    * :member:`max_tx_udp_payload_size` is the maximum size of UDP
    * datagram payload that the local endpoint transmits.  This must be
-   * larger than or equal to :macro:`NGTCP2_MAX_UDP_PAYLOAD_SIZE`.
+   * larger than or equal to :macro:`NGTCP2_MAX_UDP_PAYLOAD_SIZE`, and
+   * less then or equal to 65527.
    */
   size_t max_tx_udp_payload_size;
   /**
@@ -1952,12 +1953,12 @@ typedef struct ngtcp2_settings {
   /**
    * :member:`pmtud_probes` is the array of UDP datagram payload size
    * to probe during Path MTU Discovery.  The discovery is done in the
-   * order appeared in this array.  The size must be strictly larger
-   * than 1200, otherwise the behavior is undefined.  The maximum
-   * value in this array should be set to
-   * :member:`max_tx_udp_payload_size`.  If this field is not set, the
-   * predefined PMTUD probes are made.  This field has been available
-   * since v1.4.0.
+   * order appeared in this array.  The payload size must be strictly
+   * larger than 1200, and less than or equal to 65527.  Otherwise the
+   * behavior is undefined.  The maximum value in this array should be
+   * set to :member:`max_tx_udp_payload_size`.  If this field is not
+   * set, the predefined PMTUD probes are made.  This field has been
+   * available since v1.4.0.
    */
   const uint16_t *pmtud_probes;
   /**

--- a/lib/ngtcp2_conn.c
+++ b/lib/ngtcp2_conn.c
@@ -1203,6 +1203,7 @@ static int conn_new(ngtcp2_conn **pconn, const ngtcp2_cid *dcid,
 
   for (i = 0; i < settings->pmtud_probeslen; ++i) {
     assert(settings->pmtud_probes[i] > NGTCP2_MAX_UDP_PAYLOAD_SIZE);
+    assert(settings->pmtud_probes[i] <= NGTCP2_HARD_MAX_UDP_PAYLOAD_SIZE);
   }
 
   if (mem == NULL) {

--- a/lib/ngtcp2_pkt.h
+++ b/lib/ngtcp2_pkt.h
@@ -105,7 +105,8 @@
 
 /* NGTCP2_HARD_MAX_UDP_PAYLOAD_SIZE is the maximum UDP datagram
    payload size that this library can write. */
-#define NGTCP2_HARD_MAX_UDP_PAYLOAD_SIZE ((1 << 24) - 1)
+#define NGTCP2_HARD_MAX_UDP_PAYLOAD_SIZE                                       \
+  NGTCP2_DEFAULT_MAX_RECV_UDP_PAYLOAD_SIZE
 
 /* NGTCP2_PKT_LENGTHLEN is the number of bytes that is occupied by
    Length field in Long packet header. */


### PR DESCRIPTION
I cannot not recall why I set it to 16MiB which is too large.  It is completely safe to set the maximum size to 64k which is theoretical limit of IP packet size.