### PR TITLE
Always call CC on_ack_recv

### DIFF
--- a/lib/ngtcp2_bbr.c
+++ b/lib/ngtcp2_bbr.c
@@ -1364,6 +1364,11 @@ static void bbr_cc_on_ack_recv(ngtcp2_cc *cc, ngtcp2_conn_stat *cstat,
   ngtcp2_cc_bbr *bbr = ngtcp2_struct_of(cc, ngtcp2_cc_bbr, cc);
 
   bbr_handle_recovery(bbr, cstat, ack);
+
+  if (ack->bytes_delivered == 0) {
+    return;
+  }
+
   bbr_update_on_ack(bbr, cstat, ack, ts);
 }
 

--- a/lib/ngtcp2_cc.c
+++ b/lib/ngtcp2_cc.c
@@ -272,7 +272,8 @@ void ngtcp2_cc_cubic_cc_on_ack_recv(ngtcp2_cc *cc, ngtcp2_conn_stat *cstat,
   int is_app_limited =
     cubic->rst->rs.is_app_limited && !cubic->rst->is_cwnd_limited;
 
-  if (in_congestion_recovery(cstat, ack->largest_pkt_sent_ts)) {
+  if (ack->bytes_delivered == 0 ||
+      in_congestion_recovery(cstat, ack->largest_pkt_sent_ts)) {
     return;
   }
 

--- a/lib/ngtcp2_rtb.c
+++ b/lib/ngtcp2_rtb.c
@@ -961,7 +961,7 @@ ngtcp2_ssize ngtcp2_rtb_recv_ack(ngtcp2_rtb *rtb, const ngtcp2_ack *fr,
   }
 
   cc_ack.largest_pkt_sent_ts = largest_pkt_sent_ts;
-  if (num_acked && cc->on_ack_recv) {
+  if (cc->on_ack_recv) {
     cc->on_ack_recv(cc, cstat, &cc_ack, ts);
   }
 


### PR DESCRIPTION
Always call CC on_ack_recv so that bbr_handle_recovery is called for ACK that triggers the congestion event.