### PR TITLE
Revert "examples: Limit tx buffer for non-GSO case"

### DIFF
--- a/examples/client.cc
+++ b/examples/client.cc
@@ -1157,10 +1157,7 @@ int Client::write_streams() {
   ngtcp2_pkt_info pi;
   size_t gso_size;
   auto ts = util::timestamp();
-  auto txbuf = std::span{
-    tx_.data.data(),
-    no_gso_ ? ngtcp2_conn_get_max_tx_udp_payload_size(conn_) : tx_.data.size(),
-  };
+  auto txbuf = std::span{tx_.data};
 
   ngtcp2_path_storage_zero(&ps);
 

--- a/examples/h09client.cc
+++ b/examples/h09client.cc
@@ -1057,10 +1057,7 @@ int Client::write_streams() {
   ngtcp2_pkt_info pi;
   size_t gso_size;
   auto ts = util::timestamp();
-  auto txbuf = std::span{
-    tx_.data.data(),
-    no_gso_ ? ngtcp2_conn_get_max_tx_udp_payload_size(conn_) : tx_.data.size(),
-  };
+  auto txbuf = std::span{tx_.data};
 
   ngtcp2_path_storage_zero(&ps);
 

--- a/examples/h09server.cc
+++ b/examples/h09server.cc
@@ -1030,10 +1030,7 @@ int Handler::write_streams() {
   ngtcp2_pkt_info pi;
   size_t gso_size;
   auto ts = util::timestamp();
-  auto txbuf = std::span{
-    tx_.data.get(),
-    no_gso_ ? ngtcp2_conn_get_max_tx_udp_payload_size(conn_) : NGTCP2_TX_BUFLEN,
-  };
+  auto txbuf = std::span{tx_.data.get(), NGTCP2_TX_BUFLEN};
 
   ngtcp2_path_storage_zero(&ps);
 

--- a/examples/server.cc
+++ b/examples/server.cc
@@ -1788,10 +1788,7 @@ int Handler::write_streams() {
   ngtcp2_pkt_info pi;
   size_t gso_size;
   auto ts = util::timestamp();
-  auto txbuf = std::span{
-    tx_.data.get(),
-    no_gso_ ? ngtcp2_conn_get_max_tx_udp_payload_size(conn_) : NGTCP2_TX_BUFLEN,
-  };
+  auto txbuf = std::span{tx_.data.get(), NGTCP2_TX_BUFLEN};
 
   ngtcp2_path_storage_zero(&ps);
 


### PR DESCRIPTION
Reverts ngtcp2/ngtcp2#1812

It turns out that this change does not affect the result of the cross traffic test.