### PR TITLE
cc: Compute pacing interval and send_quantum

### DIFF
--- a/lib/ngtcp2_cc.h
+++ b/lib/ngtcp2_cc.h
@@ -308,7 +308,8 @@ typedef struct ngtcp2_cc_reno {
   uint64_t pending_add;
 } ngtcp2_cc_reno;
 
-void ngtcp2_cc_reno_init(ngtcp2_cc_reno *reno, ngtcp2_log *log);
+void ngtcp2_cc_reno_init(ngtcp2_cc_reno *reno, ngtcp2_log *log,
+                         ngtcp2_conn_stat *cstat);
 
 void ngtcp2_cc_reno_cc_on_pkt_acked(ngtcp2_cc *cc, ngtcp2_conn_stat *cstat,
                                     const ngtcp2_cc_pkt *pkt, ngtcp2_tstamp ts);
@@ -370,7 +371,7 @@ typedef struct ngtcp2_cc_cubic {
 } ngtcp2_cc_cubic;
 
 void ngtcp2_cc_cubic_init(ngtcp2_cc_cubic *cc, ngtcp2_log *log,
-                          ngtcp2_rst *rst);
+                          ngtcp2_conn_stat *cstat, ngtcp2_rst *rst);
 
 void ngtcp2_cc_cubic_cc_on_ack_recv(ngtcp2_cc *cc, ngtcp2_conn_stat *cstat,
                                     const ngtcp2_cc_ack *ack, ngtcp2_tstamp ts);

--- a/tests/ngtcp2_rtb_test.c
+++ b/tests/ngtcp2_rtb_test.c
@@ -48,8 +48,10 @@ const MunitSuite rtb_suite = {
 };
 
 static void conn_stat_init(ngtcp2_conn_stat *cstat) {
-  memset(cstat, 0, sizeof(*cstat));
-  cstat->max_tx_udp_payload_size = NGTCP2_MAX_UDP_PAYLOAD_SIZE;
+  *cstat = (ngtcp2_conn_stat){
+    .cwnd = 10 * NGTCP2_MAX_UDP_PAYLOAD_SIZE,
+    .max_tx_udp_payload_size = NGTCP2_MAX_UDP_PAYLOAD_SIZE,
+  };
 }
 
 void test_ngtcp2_rtb_add(void) {
@@ -74,7 +76,7 @@ void test_ngtcp2_rtb_add(void) {
   conn_stat_init(&cstat);
   ngtcp2_rst_init(&rst);
   ngtcp2_log_init(&log, NULL, NULL, 0, NULL);
-  ngtcp2_cc_reno_init(&cc, &log);
+  ngtcp2_cc_reno_init(&cc, &log, &cstat);
   ngtcp2_rtb_init(&rtb, &rst, &cc.cc, 0, &log, NULL, &rtb_entry_objalloc,
                   &frc_objalloc, mem);
 
@@ -208,7 +210,7 @@ void test_ngtcp2_rtb_recv_ack(void) {
   /* no ack block */
   conn_stat_init(&cstat);
   ngtcp2_rst_init(&rst);
-  ngtcp2_cc_reno_init(&cc, &log);
+  ngtcp2_cc_reno_init(&cc, &log, &cstat);
   ngtcp2_rtb_init(&rtb, &rst, &cc.cc, 0, &log, NULL, &rtb_entry_objalloc,
                   &frc_objalloc, mem);
   setup_rtb_fixture(&rtb, &cstat, &rtb_entry_objalloc);
@@ -232,7 +234,7 @@ void test_ngtcp2_rtb_recv_ack(void) {
 
   /* with ack block */
   conn_stat_init(&cstat);
-  ngtcp2_cc_reno_init(&cc, &log);
+  ngtcp2_cc_reno_init(&cc, &log, &cstat);
   ngtcp2_rtb_init(&rtb, &rst, &cc.cc, 0, &log, NULL, &rtb_entry_objalloc,
                   &frc_objalloc, mem);
   setup_rtb_fixture(&rtb, &cstat, &rtb_entry_objalloc);
@@ -264,7 +266,7 @@ void test_ngtcp2_rtb_recv_ack(void) {
 
   /* gap+len points to pkt_num 0 */
   conn_stat_init(&cstat);
-  ngtcp2_cc_reno_init(&cc, &log);
+  ngtcp2_cc_reno_init(&cc, &log, &cstat);
   ngtcp2_rtb_init(&rtb, &rst, &cc.cc, 0, &log, NULL, &rtb_entry_objalloc,
                   &frc_objalloc, mem);
   add_rtb_entry_range(&rtb, 0, 1, &cstat, &rtb_entry_objalloc);
@@ -285,7 +287,7 @@ void test_ngtcp2_rtb_recv_ack(void) {
 
   /* pkt_num = 0 (first ack block) */
   conn_stat_init(&cstat);
-  ngtcp2_cc_reno_init(&cc, &log);
+  ngtcp2_cc_reno_init(&cc, &log, &cstat);
   ngtcp2_rtb_init(&rtb, &rst, &cc.cc, 0, &log, NULL, &rtb_entry_objalloc,
                   &frc_objalloc, mem);
   add_rtb_entry_range(&rtb, 0, 1, &cstat, &rtb_entry_objalloc);
@@ -302,7 +304,7 @@ void test_ngtcp2_rtb_recv_ack(void) {
 
   /* pkt_num = 0 */
   conn_stat_init(&cstat);
-  ngtcp2_cc_reno_init(&cc, &log);
+  ngtcp2_cc_reno_init(&cc, &log, &cstat);
   ngtcp2_rtb_init(&rtb, &rst, &cc.cc, 0, &log, NULL, &rtb_entry_objalloc,
                   &frc_objalloc, mem);
   add_rtb_entry_range(&rtb, 0, 1, &cstat, &rtb_entry_objalloc);
@@ -322,7 +324,7 @@ void test_ngtcp2_rtb_recv_ack(void) {
 
   /* acknowledging skipped packet number in the first block */
   conn_stat_init(&cstat);
-  ngtcp2_cc_reno_init(&cc, &log);
+  ngtcp2_cc_reno_init(&cc, &log, &cstat);
   ngtcp2_rtb_init(&rtb, &rst, &cc.cc, 0, &log, NULL, &rtb_entry_objalloc,
                   &frc_objalloc, mem);
   add_rtb_entry_range_with_flags(&rtb, 0, 1, NGTCP2_RTB_ENTRY_FLAG_SKIP, &cstat,
@@ -339,7 +341,7 @@ void test_ngtcp2_rtb_recv_ack(void) {
 
   /* acknowledging skipped packet number in the second block */
   conn_stat_init(&cstat);
-  ngtcp2_cc_reno_init(&cc, &log);
+  ngtcp2_cc_reno_init(&cc, &log, &cstat);
   ngtcp2_rtb_init(&rtb, &rst, &cc.cc, 0, &log, NULL, &rtb_entry_objalloc,
                   &frc_objalloc, mem);
   add_rtb_entry_range_with_flags(&rtb, 0, 1, NGTCP2_RTB_ENTRY_FLAG_SKIP, &cstat,
@@ -380,7 +382,7 @@ void test_ngtcp2_rtb_lost_pkt_ts(void) {
 
   conn_stat_init(&cstat);
   ngtcp2_rst_init(&rst);
-  ngtcp2_cc_reno_init(&cc, &log);
+  ngtcp2_cc_reno_init(&cc, &log, &cstat);
   ngtcp2_rtb_init(&rtb, &rst, &cc.cc, 0, &log, NULL, &rtb_entry_objalloc,
                   &frc_objalloc, mem);
 
@@ -422,7 +424,7 @@ void test_ngtcp2_rtb_remove_expired_lost_pkt(void) {
 
   conn_stat_init(&cstat);
   ngtcp2_rst_init(&rst);
-  ngtcp2_cc_reno_init(&cc, &log);
+  ngtcp2_cc_reno_init(&cc, &log, &cstat);
   ngtcp2_rtb_init(&rtb, &rst, &cc.cc, 0, &log, NULL, &rtb_entry_objalloc,
                   &frc_objalloc, mem);
 
@@ -483,7 +485,7 @@ void test_ngtcp2_rtb_remove_excessive_lost_pkt(void) {
 
   conn_stat_init(&cstat);
   ngtcp2_rst_init(&rst);
-  ngtcp2_cc_reno_init(&cc, &log);
+  ngtcp2_cc_reno_init(&cc, &log, &cstat);
   ngtcp2_rtb_init(&rtb, &rst, &cc.cc, 0, &log, NULL, &rtb_entry_objalloc,
                   &frc_objalloc, mem);
 


### PR DESCRIPTION
Compute pacing interval and send_quantum as we do in BBR.  Previously we always set send_quantum to 64k, which is too bursty.  It might be good for benchmark on loopback but has severe impact on real internet traffic due to extra burstiness.  The idea is send 1ms worth of data at once.  This change does not affect 1 connection throughput as long as event loop keeps up to this 1ms interval.