### PR TITLE
More app controllable ngtcp2_conn_write_aggregate_pkt2

### DIFF
--- a/examples/h09client.cc
+++ b/examples/h09client.cc
@@ -1058,16 +1058,19 @@ int Client::write_streams() {
   size_t gso_size;
   auto ts = util::timestamp();
   auto txbuf = std::span{tx_.data};
+  auto buflen = util::clamp_buffer_size(conn_, txbuf.size(), config.gso_burst);
 
   ngtcp2_path_storage_zero(&ps);
 
   auto nwrite = ngtcp2_conn_write_aggregate_pkt2(
-    conn_, &ps.path, &pi, txbuf.data(), txbuf.size(), &gso_size, ::write_pkt,
+    conn_, &ps.path, &pi, txbuf.data(), buflen, &gso_size, ::write_pkt,
     config.gso_burst, ts);
   if (nwrite < 0) {
     disconnect();
     return -1;
   }
+
+  ngtcp2_conn_update_pkt_tx_time(conn_, ts);
 
   if (nwrite == 0) {
     return 0;

--- a/examples/h09server.cc
+++ b/examples/h09server.cc
@@ -1031,15 +1031,18 @@ int Handler::write_streams() {
   size_t gso_size;
   auto ts = util::timestamp();
   auto txbuf = std::span{tx_.data.get(), NGTCP2_TX_BUFLEN};
+  auto buflen = util::clamp_buffer_size(conn_, txbuf.size(), config.gso_burst);
 
   ngtcp2_path_storage_zero(&ps);
 
   auto nwrite = ngtcp2_conn_write_aggregate_pkt2(
-    conn_, &ps.path, &pi, txbuf.data(), txbuf.size(), &gso_size, ::write_pkt,
+    conn_, &ps.path, &pi, txbuf.data(), buflen, &gso_size, ::write_pkt,
     config.gso_burst, ts);
   if (nwrite < 0) {
     return handle_error();
   }
+
+  ngtcp2_conn_update_pkt_tx_time(conn_, ts);
 
   if (nwrite == 0) {
     return 0;

--- a/examples/server.cc
+++ b/examples/server.cc
@@ -1789,15 +1789,18 @@ int Handler::write_streams() {
   size_t gso_size;
   auto ts = util::timestamp();
   auto txbuf = std::span{tx_.data.get(), NGTCP2_TX_BUFLEN};
+  auto buflen = util::clamp_buffer_size(conn_, txbuf.size(), config.gso_burst);
 
   ngtcp2_path_storage_zero(&ps);
 
   auto nwrite = ngtcp2_conn_write_aggregate_pkt2(
-    conn_, &ps.path, &pi, txbuf.data(), txbuf.size(), &gso_size, ::write_pkt,
+    conn_, &ps.path, &pi, txbuf.data(), buflen, &gso_size, ::write_pkt,
     config.gso_burst, ts);
   if (nwrite < 0) {
     return handle_error();
   }
+
+  ngtcp2_conn_update_pkt_tx_time(conn_, ts);
 
   if (nwrite == 0) {
     return 0;

--- a/examples/util.cc
+++ b/examples/util.cc
@@ -816,6 +816,14 @@ std::optional<std::vector<uint8_t>> read_file(const std::string_view &path) {
   return {{p, p + size}};
 }
 
+size_t clamp_buffer_size(ngtcp2_conn *conn, size_t buflen, size_t gso_burst) {
+  return std::min(gso_burst == 0
+                    ? ngtcp2_conn_get_send_quantum(conn)
+                    : ngtcp2_conn_get_path_max_tx_udp_payload_size(conn) *
+                        gso_burst,
+                  buflen);
+}
+
 std::optional<ECHServerConfig>
 read_ech_server_config(const std::string_view &path) {
   auto pkey = read_hpke_private_key_pem(path);

--- a/examples/util.h
+++ b/examples/util.h
@@ -539,6 +539,8 @@ std::optional<uint32_t> parse_version(const std::string_view &s);
 // read_file reads a file denoted by |path| and returns its content.
 std::optional<std::vector<uint8_t>> read_file(const std::string_view &path);
 
+size_t clamp_buffer_size(ngtcp2_conn *conn, size_t buflen, size_t gso_burst);
+
 enum HPKEPrivateKeyType : uint16_t {
   HPKE_DHKEM_X25519_HKDF_SHA256 = 0x0020,
 };

--- a/lib/includes/ngtcp2/ngtcp2.h
+++ b/lib/includes/ngtcp2/ngtcp2.h
@@ -5748,7 +5748,11 @@ typedef ngtcp2_ssize (*ngtcp2_write_pkt)(ngtcp2_conn *conn, ngtcp2_path *path,
  * `ngtcp2_conn_update_pkt_tx_time`.
  *
  * This function is equivalent to call
- * `ngtcp2_conn_write_aggregate_pkt2` with num_pkts = 0.
+ * `ngtcp2_conn_write_aggregate_pkt2` with |buflen| = min(|buflen|,
+ * `ngtcp2_conn_get_send_quantum(conn)
+ * <ngtcp2_conn_get_send_quantum>`) and |num_pkts| = 0 followed by
+ * `ngtcp2_conn_update_pkt_tx_time(conn)
+ * <ngtcp2_conn_update_pkt_tx_time>`.
  *
  * This function returns the number of bytes written to the buffer, or
  * a negative error code returned by |write_pkt|.
@@ -5769,7 +5773,12 @@ NGTCP2_EXTERN ngtcp2_ssize ngtcp2_conn_write_aggregate_pkt_versioned(
  * 0, this function writes packets as much as possible.  The actual
  * number of packets to write is determined by the connection state
  * (e.g., the congestion controller, data available to send) and the
- * length of packet produced.
+ * length of packet produced.  It also does not clamp |buflen|, and
+ * does not call `ngtcp2_conn_update_pkt_tx_time`.
+ *
+ * This function offers more flexibility and optimization chances to
+ * an application.  It can experiment different GSO buffer size
+ * strategy and number of GSO writes per event loop.
  *
  * This function has been available since v1.17.0.
  */


### PR DESCRIPTION
This change makes ngtcp2_conn_write_aggregate_pkt2 more controllable by an application by removing buffer size clamping and pacing timer updates, so that the application can experiment its own GSO buffer strategy and number of GSO writes per event loop.