### PR TITLE
cc: Increase minimum send_quantum to 10

### DIFF
--- a/lib/ngtcp2_cc.c
+++ b/lib/ngtcp2_cc.c
@@ -72,7 +72,7 @@ static void set_pacing_rate(ngtcp2_conn_stat *cstat) {
                                            cstat->pacing_interval_m));
 
   cstat->send_quantum =
-    ngtcp2_max_size(send_quantum, 2 * cstat->max_tx_udp_payload_size);
+    ngtcp2_max_size(send_quantum, 10 * cstat->max_tx_udp_payload_size);
 }
 
 ngtcp2_cc_pkt *ngtcp2_cc_pkt_init(ngtcp2_cc_pkt *pkt, int64_t pkt_num,


### PR DESCRIPTION
The previous value of minimum value 2 is too small because usually an event loop cannot keep up the 1ms tick and UDP send call is too expensive.  RFC 9002 says that the burst should be limited to the initial congestion window, which is 10 packets, which suggests that 10 packets burst is acceptable for the traditional loss based congestion controller with pacing over smoothed RTT and CWND.  10 is still conservative against full GSO buffer.