### PR TITLE
examples: Increase number of packets to read

### DIFF
--- a/examples/client.cc
+++ b/examples/client.cc
@@ -934,7 +934,14 @@ int Client::on_read(const Endpoint &ep) {
     .msg_control = msg_ctrl,
   };
 
-  for (;;) {
+  auto start = util::timestamp();
+
+  for (; pktcnt < MAX_RECV_PKTS;) {
+    if (util::recv_pkt_time_threshold_exceeded(
+          config.cc_algo == NGTCP2_CC_ALGO_BBR, start, pktcnt)) {
+      break;
+    }
+
     msg.msg_namelen = sizeof(su);
     msg.msg_controllen = sizeof(msg_ctrl);
 
@@ -994,10 +1001,6 @@ int Client::on_read(const Endpoint &ep) {
       if (data.empty()) {
         break;
       }
-    }
-
-    if (pktcnt >= 10) {
-      break;
     }
   }
 

--- a/examples/h09client.cc
+++ b/examples/h09client.cc
@@ -863,7 +863,14 @@ int Client::on_read(const Endpoint &ep) {
     .msg_control = msg_ctrl,
   };
 
-  for (;;) {
+  auto start = util::timestamp();
+
+  for (; pktcnt < MAX_RECV_PKTS;) {
+    if (util::recv_pkt_time_threshold_exceeded(
+          config.cc_algo == NGTCP2_CC_ALGO_BBR, start, pktcnt)) {
+      break;
+    }
+
     msg.msg_namelen = sizeof(su);
     msg.msg_controllen = sizeof(msg_ctrl);
 
@@ -923,10 +930,6 @@ int Client::on_read(const Endpoint &ep) {
       if (data.empty()) {
         break;
       }
-    }
-
-    if (pktcnt >= 10) {
-      break;
     }
   }
 

--- a/examples/h09server.cc
+++ b/examples/h09server.cc
@@ -1718,7 +1718,14 @@ int Server::on_read(const Endpoint &ep) {
     .msg_control = msg_ctrl,
   };
 
-  for (; pktcnt < 10;) {
+  auto start = util::timestamp();
+
+  for (; pktcnt < MAX_RECV_PKTS;) {
+    if (util::recv_pkt_time_threshold_exceeded(
+          config.cc_algo == NGTCP2_CC_ALGO_BBR, start, pktcnt)) {
+      return 0;
+    }
+
     msg.msg_namelen = sizeof(su);
     msg.msg_controllen = sizeof(msg_ctrl);
 

--- a/examples/server.cc
+++ b/examples/server.cc
@@ -2443,7 +2443,14 @@ int Server::on_read(const Endpoint &ep) {
     .msg_control = msg_ctrl,
   };
 
-  for (; pktcnt < 10;) {
+  auto start = util::timestamp();
+
+  for (; pktcnt < MAX_RECV_PKTS;) {
+    if (util::recv_pkt_time_threshold_exceeded(
+          config.cc_algo == NGTCP2_CC_ALGO_BBR, start, pktcnt)) {
+      return 0;
+    }
+
     msg.msg_namelen = sizeof(su);
     msg.msg_controllen = sizeof(msg_ctrl);
 

--- a/examples/shared.h
+++ b/examples/shared.h
@@ -61,6 +61,8 @@ inline constexpr auto H3_ALPN_V1 = as_uint8_span(RAW_H3_ALPN);
 
 inline constexpr uint32_t TLS_ALERT_ECH_REQUIRED = 121;
 
+inline constexpr size_t MAX_RECV_PKTS = 64;
+
 // msghdr_get_ecn gets ECN bits from |msg|.  |family| is the address
 // family from which packet is received.
 uint8_t msghdr_get_ecn(msghdr *msg, int family);

--- a/examples/util.cc
+++ b/examples/util.cc
@@ -824,6 +824,12 @@ size_t clamp_buffer_size(ngtcp2_conn *conn, size_t buflen, size_t gso_burst) {
                   buflen);
 }
 
+bool recv_pkt_time_threshold_exceeded(bool time_sensitive, ngtcp2_tstamp start,
+                                      size_t pktcnt) {
+  return time_sensitive && pktcnt &&
+         util::timestamp() - start >= NGTCP2_MILLISECONDS;
+}
+
 std::optional<ECHServerConfig>
 read_ech_server_config(const std::string_view &path) {
   auto pkey = read_hpke_private_key_pem(path);

--- a/examples/util.h
+++ b/examples/util.h
@@ -541,6 +541,9 @@ std::optional<std::vector<uint8_t>> read_file(const std::string_view &path);
 
 size_t clamp_buffer_size(ngtcp2_conn *conn, size_t buflen, size_t gso_burst);
 
+bool recv_pkt_time_threshold_exceeded(bool time_sensitive, ngtcp2_tstamp start,
+                                      size_t pktcnt);
+
 enum HPKEPrivateKeyType : uint16_t {
   HPKE_DHKEM_X25519_HKDF_SHA256 = 0x0020,
 };


### PR DESCRIPTION
It turns out that the limit of 10 packets per event loop is too small, that prevents an endpoint from consuming ACKs and other control frames (e.g., MAX_STREAM_DATA, MAX_STREAMS), resulting in the loss of throughput.  This change increases maximum number of packets to read to 64.  Meanwhile, BBR is very sensitive to event loop tick because its GSO burst is limited to 1ms window.  For BBR, keep reading packets until 1ms is passed or 64 packets are read.