### PR TITLE
Relax the timer handling

### DIFF
--- a/doc/source/programmers-guide.rst
+++ b/doc/source/programmers-guide.rst
@@ -405,10 +405,11 @@ When it fires, call `ngtcp2_conn_handle_expiry()`.  If it returns
 :macro:`NGTCP2_ERR_IDLE_CLOSE`, it means that an idle timer has fired
 for this particular connection.  In this case, drop the connection
 without calling `ngtcp2_conn_write_connection_close()`.  Otherwise,
-call `ngtcp2_conn_writev_stream()`.  After calling
-`ngtcp2_conn_handle_expiry()` and `ngtcp2_conn_writev_stream()`, new
-expiry is set.  The application should call `ngtcp2_conn_get_expiry()`
-to get a new deadline.
+call `ngtcp2_conn_writev_stream()`.  An application may call
+`ngtcp2_conn_read_pkt()` before calling `ngtcp2_conn_writev_stream()`.
+After calling `ngtcp2_conn_handle_expiry()` and
+`ngtcp2_conn_writev_stream()`, new expiry is set.  The application
+should call `ngtcp2_conn_get_expiry()` to get a new deadline.
 
 Please note that :type:`ngtcp2_tstamp` of value ``UINT64_MAX`` is
 treated as an invalid timestamp.  Do not pass ``UINT64_MAX`` to any

--- a/lib/includes/ngtcp2/ngtcp2.h
+++ b/lib/includes/ngtcp2/ngtcp2.h
@@ -4174,7 +4174,8 @@ NGTCP2_EXTERN void ngtcp2_conn_set_keep_alive_timeout(ngtcp2_conn *conn,
  *
  * Call `ngtcp2_conn_handle_expiry` and then
  * `ngtcp2_conn_writev_stream` (or `ngtcp2_conn_writev_datagram`) when
- * the expiry time has passed.
+ * the expiry time has passed.  An application may call
+ * `ngtcp2_conn_read_pkt` before calling `ngtcp2_conn_writev_stream`.
  */
 NGTCP2_EXTERN ngtcp2_tstamp ngtcp2_conn_get_expiry(ngtcp2_conn *conn);
 


### PR DESCRIPTION
Explicitly state that after ngtcp2_conn_handle_expiry, an application may call ngtcp2_conn_read_pkt before calling
ngtcp2_conn_writev_stream.