### PR TITLE
Relax the timer handling further

### DIFF
--- a/doc/source/programmers-guide.rst
+++ b/doc/source/programmers-guide.rst
@@ -404,12 +404,17 @@ is :type:`ngtcp2_duration` which is also nanosecond resolution.
 When it fires, call `ngtcp2_conn_handle_expiry()`.  If it returns
 :macro:`NGTCP2_ERR_IDLE_CLOSE`, it means that an idle timer has fired
 for this particular connection.  In this case, drop the connection
-without calling `ngtcp2_conn_write_connection_close()`.  Otherwise,
-call `ngtcp2_conn_writev_stream()`.  An application may call
-`ngtcp2_conn_read_pkt()` before calling `ngtcp2_conn_writev_stream()`.
-After calling `ngtcp2_conn_handle_expiry()` and
+without calling `ngtcp2_conn_write_connection_close()`.  If it returns
+any of the other negative error codes, close the connection by sending
+the terminal packet produced by
+`ngtcp2_conn_write_connection_close()`.  Otherwise, schedule
+`ngtcp2_conn_writev_stream()` call.  An application may call any
+number of additional `ngtcp2_conn_read_pkt()` and
+`ngtcp2_conn_handle_expiry()` before calling
+`ngtcp2_conn_writev_stream()`.  After calling
 `ngtcp2_conn_writev_stream()`, new expiry is set.  The application
-should call `ngtcp2_conn_get_expiry()` to get a new deadline.
+should call `ngtcp2_conn_get_expiry()` to get a new deadline and set
+the timer.
 
 Please note that :type:`ngtcp2_tstamp` of value ``UINT64_MAX`` is
 treated as an invalid timestamp.  Do not pass ``UINT64_MAX`` to any

--- a/lib/includes/ngtcp2/ngtcp2.h
+++ b/lib/includes/ngtcp2/ngtcp2.h
@@ -4172,10 +4172,7 @@ NGTCP2_EXTERN void ngtcp2_conn_set_keep_alive_timeout(ngtcp2_conn *conn,
  * `ngtcp2_conn_get_expiry` returns the next expiry time.  It returns
  * ``UINT64_MAX`` if there is no next expiry.
  *
- * Call `ngtcp2_conn_handle_expiry` and then
- * `ngtcp2_conn_writev_stream` (or `ngtcp2_conn_writev_datagram`) when
- * the expiry time has passed.  An application may call
- * `ngtcp2_conn_read_pkt` before calling `ngtcp2_conn_writev_stream`.
+ * Call `ngtcp2_conn_handle_expiry` when the expiry time has passed.
  */
 NGTCP2_EXTERN ngtcp2_tstamp ngtcp2_conn_get_expiry(ngtcp2_conn *conn);
 
@@ -4183,6 +4180,20 @@ NGTCP2_EXTERN ngtcp2_tstamp ngtcp2_conn_get_expiry(ngtcp2_conn *conn);
  * @function
  *
  * `ngtcp2_conn_handle_expiry` handles expired timer.
+ *
+ * If it returns :macro:`NGTCP2_ERR_IDLE_CLOSE`, it means that an idle
+ * timer has fired for this particular connection.  In this case, drop
+ * the connection without calling
+ * `ngtcp2_conn_write_connection_close`.  If it returns any of the
+ * other negative error codes, close the connection by sending the
+ * terminal packet produced by `ngtcp2_conn_write_connection_close`.
+ * Otherwise, schedule `ngtcp2_conn_writev_stream` call.  An
+ * application may call any number of additional
+ * `ngtcp2_conn_read_pkt` and `ngtcp2_conn_handle_expiry` before
+ * calling `ngtcp2_conn_writev_stream`.  After calling
+ * `ngtcp2_conn_writev_stream`, new expiry is set.  The application
+ * should call `ngtcp2_conn_get_expiry` to get a new deadline and set
+ * the timer.
  */
 NGTCP2_EXTERN int ngtcp2_conn_handle_expiry(ngtcp2_conn *conn,
                                             ngtcp2_tstamp ts);


### PR DESCRIPTION
Relax the timer handling further by explicitly stating that ngtcp2_conn_handle_expiry can be called multiple times before ngtcp2_conn_writev_stream, so that an application does not need to stop the timer when it expires because sometimes stopping timer may incur the additional overhead.