### PR TITLE
ngtcp2_map: Optimize a little bit further

### DIFF
--- a/lib/ngtcp2_map.h
+++ b/lib/ngtcp2_map.h
@@ -38,14 +38,13 @@
 
 typedef uint64_t ngtcp2_map_key_type;
 
-typedef struct ngtcp2_map_bucket {
-  size_t psl;
-  ngtcp2_map_key_type key;
-  void *data;
-} ngtcp2_map_bucket;
-
 typedef struct ngtcp2_map {
-  ngtcp2_map_bucket *table;
+  ngtcp2_map_key_type *keys;
+  void **data;
+  /* psl is the Probe Sequence Length.  0 has special meaning that the
+     element is not stored at i-th position if psl[i] == 0.  Because
+     of this, the actual psl value is psl[i] - 1 if psl[i] > 0. */
+  uint8_t *psl;
   const ngtcp2_mem *mem;
   uint64_t seed;
   size_t size;


### PR DESCRIPTION
Now separate key, data and psl so that they are more cache friendly because primarily we use psl to probe the sequences.  Previously, data == NULL means that no element is stored there, but now it is replaced by psl[i] == 0.  psl is now uint8_t and the maximum probe sequence length is 254 (because we allocate 0 for special purpose).  The probability of fail probing 255 times with the load factor 7 / 8 is vanishingly small (~10**-15), and thus it does not happen in practice when considering the usage of this hash table in our library.