### PR TITLE
Optimize ngtcp2_ksl

### DIFF
--- a/lib/ngtcp2_ksl.c
+++ b/lib/ngtcp2_ksl.c
@@ -37,33 +37,31 @@ static ngtcp2_ksl_blk null_blk;
 
 ngtcp2_objalloc_def(ksl_blk, ngtcp2_ksl_blk, oplent)
 
-static size_t ksl_nodelen(size_t keylen) {
-  assert(keylen >= sizeof(uint64_t));
-
-  return (sizeof(ngtcp2_ksl_node) + keylen - sizeof(uint64_t) + 0x7u) &
-         ~(uintptr_t)0x7u;
-}
-
-static size_t ksl_blklen(size_t nodelen) {
-  return sizeof(ngtcp2_ksl_blk) + nodelen * NGTCP2_KSL_MAX_NBLK -
+static size_t ksl_blklen(size_t aligned_keylen) {
+  return sizeof(ngtcp2_ksl_blk) + NGTCP2_KSL_MAX_NBLK * aligned_keylen -
          sizeof(uint64_t);
 }
 
 /*
- * ksl_node_set_key sets |key| to |node|.
+ * ksl_set_nth_key sets |key| to |n|th node under |blk|.
  */
-static void ksl_node_set_key(ngtcp2_ksl *ksl, ngtcp2_ksl_node *node,
-                             const void *key) {
-  memcpy(node->key, key, ksl->keylen);
+static void ksl_set_nth_key(const ngtcp2_ksl *ksl, ngtcp2_ksl_blk *blk,
+                            size_t n, const ngtcp2_ksl_key *key) {
+  memcpy(blk->keys + n * ksl->aligned_keylen, key, ksl->keylen);
 }
 
 void ngtcp2_ksl_init(ngtcp2_ksl *ksl, ngtcp2_ksl_compar compar,
                      ngtcp2_ksl_search search, size_t keylen,
                      const ngtcp2_mem *mem) {
-  size_t nodelen = ksl_nodelen(keylen);
+  size_t aligned_keylen;
+
+  assert(keylen >= sizeof(uint64_t));
+
+  aligned_keylen = (keylen + 0x7u) & ~0x7u;
 
   ngtcp2_objalloc_init(&ksl->blkalloc,
-                       (ksl_blklen(nodelen) + 0xfu) & ~(uintptr_t)0xfu, mem);
+                       (ksl_blklen(aligned_keylen) + 0xfu) & ~(uintptr_t)0xfu,
+                       mem);
 
   ksl->head = NULL;
   ksl->front = ksl->back = NULL;
@@ -71,12 +69,12 @@ void ngtcp2_ksl_init(ngtcp2_ksl *ksl, ngtcp2_ksl_compar compar,
   ksl->search = search;
   ksl->n = 0;
   ksl->keylen = keylen;
-  ksl->nodelen = nodelen;
+  ksl->aligned_keylen = aligned_keylen;
 }
 
 static ngtcp2_ksl_blk *ksl_blk_objalloc_new(ngtcp2_ksl *ksl) {
   return ngtcp2_objalloc_ksl_blk_len_get(&ksl->blkalloc,
-                                         ksl_blklen(ksl->nodelen));
+                                         ksl_blklen(ksl->aligned_keylen));
 }
 
 static void ksl_blk_objalloc_del(ngtcp2_ksl *ksl, ngtcp2_ksl_blk *blk) {
@@ -109,7 +107,7 @@ static void ksl_free_blk(ngtcp2_ksl *ksl, ngtcp2_ksl_blk *blk) {
 
   if (!blk->leaf) {
     for (i = 0; i < blk->n; ++i) {
-      ksl_free_blk(ksl, ngtcp2_ksl_nth_node(ksl, blk, i)->blk);
+      ksl_free_blk(ksl, blk->nodes[i].blk);
     }
   }
 
@@ -160,8 +158,10 @@ static ngtcp2_ksl_blk *ksl_split_blk(ngtcp2_ksl *ksl, ngtcp2_ksl_blk *blk) {
   rblk->n = blk->n / 2;
   blk->n -= rblk->n;
 
-  memcpy(rblk->nodes, blk->nodes + ksl->nodelen * blk->n,
-         ksl->nodelen * rblk->n);
+  memcpy(rblk->nodes, blk->nodes + blk->n, rblk->n * sizeof(ngtcp2_ksl_node));
+
+  memcpy(rblk->keys, blk->keys + blk->n * ksl->aligned_keylen,
+         rblk->n * ksl->aligned_keylen);
 
   assert(blk->n >= NGTCP2_KSL_MIN_NBLK);
   assert(rblk->n >= NGTCP2_KSL_MIN_NBLK);
@@ -181,25 +181,25 @@ static ngtcp2_ksl_blk *ksl_split_blk(ngtcp2_ksl *ksl, ngtcp2_ksl_blk *blk) {
  *     Out of memory.
  */
 static int ksl_split_node(ngtcp2_ksl *ksl, ngtcp2_ksl_blk *blk, size_t i) {
-  ngtcp2_ksl_node *node;
-  ngtcp2_ksl_blk *lblk = ngtcp2_ksl_nth_node(ksl, blk, i)->blk, *rblk;
+  ngtcp2_ksl_blk *lblk = blk->nodes[i].blk, *rblk;
 
   rblk = ksl_split_blk(ksl, lblk);
   if (rblk == NULL) {
     return NGTCP2_ERR_NOMEM;
   }
 
-  memmove(blk->nodes + (i + 2) * ksl->nodelen,
-          blk->nodes + (i + 1) * ksl->nodelen,
-          ksl->nodelen * (blk->n - (i + 1)));
+  memmove(blk->nodes + (i + 2), blk->nodes + (i + 1),
+          (blk->n - (i + 1)) * sizeof(ngtcp2_ksl_node));
 
-  node = ngtcp2_ksl_nth_node(ksl, blk, i + 1);
-  node->blk = rblk;
+  memmove(blk->keys + (i + 2) * ksl->aligned_keylen,
+          blk->keys + (i + 1) * ksl->aligned_keylen,
+          (blk->n - (i + 1)) * ksl->aligned_keylen);
+
+  blk->nodes[i + 1].blk = rblk;
   ++blk->n;
-  ksl_node_set_key(ksl, node, ngtcp2_ksl_nth_node(ksl, rblk, rblk->n - 1)->key);
+  ksl_set_nth_key(ksl, blk, i + 1, ngtcp2_ksl_nth_key(ksl, rblk, rblk->n - 1));
 
-  node = ngtcp2_ksl_nth_node(ksl, blk, i);
-  ksl_node_set_key(ksl, node, ngtcp2_ksl_nth_node(ksl, lblk, lblk->n - 1)->key);
+  ksl_set_nth_key(ksl, blk, i, ngtcp2_ksl_nth_key(ksl, lblk, lblk->n - 1));
 
   return 0;
 }
@@ -216,7 +216,6 @@ static int ksl_split_node(ngtcp2_ksl *ksl, ngtcp2_ksl_blk *blk, size_t i) {
  */
 static int ksl_split_head(ngtcp2_ksl *ksl) {
   ngtcp2_ksl_blk *rblk = NULL, *lblk, *nhead = NULL;
-  ngtcp2_ksl_node *node;
 
   rblk = ksl_split_blk(ksl, ksl->head);
   if (rblk == NULL) {
@@ -236,13 +235,11 @@ static int ksl_split_head(ngtcp2_ksl *ksl) {
   nhead->n = 2;
   nhead->leaf = 0;
 
-  node = ngtcp2_ksl_nth_node(ksl, nhead, 0);
-  ksl_node_set_key(ksl, node, ngtcp2_ksl_nth_node(ksl, lblk, lblk->n - 1)->key);
-  node->blk = lblk;
+  ksl_set_nth_key(ksl, nhead, 0, ngtcp2_ksl_nth_key(ksl, lblk, lblk->n - 1));
+  nhead->nodes[0].blk = lblk;
 
-  node = ngtcp2_ksl_nth_node(ksl, nhead, 1);
-  ksl_node_set_key(ksl, node, ngtcp2_ksl_nth_node(ksl, rblk, rblk->n - 1)->key);
-  node->blk = rblk;
+  ksl_set_nth_key(ksl, nhead, 1, ngtcp2_ksl_nth_key(ksl, rblk, rblk->n - 1));
+  nhead->nodes[1].blk = rblk;
 
   ksl->head = nhead;
 
@@ -257,16 +254,17 @@ static int ksl_split_head(ngtcp2_ksl *ksl) {
  */
 static void ksl_insert_node(ngtcp2_ksl *ksl, ngtcp2_ksl_blk *blk, size_t i,
                             const ngtcp2_ksl_key *key, void *data) {
-  ngtcp2_ksl_node *node;
-
   assert(blk->n < NGTCP2_KSL_MAX_NBLK);
 
-  memmove(blk->nodes + (i + 1) * ksl->nodelen, blk->nodes + i * ksl->nodelen,
-          ksl->nodelen * (blk->n - i));
+  memmove(blk->nodes + (i + 1), blk->nodes + i,
+          (blk->n - i) * sizeof(ngtcp2_ksl_node));
 
-  node = ngtcp2_ksl_nth_node(ksl, blk, i);
-  ksl_node_set_key(ksl, node, key);
-  node->data = data;
+  memmove(blk->keys + (i + 1) * ksl->aligned_keylen,
+          blk->keys + i * ksl->aligned_keylen,
+          (blk->n - i) * ksl->aligned_keylen);
+
+  ksl_set_nth_key(ksl, blk, i, key);
+  blk->nodes[i].data = data;
 
   ++blk->n;
 }
@@ -298,8 +296,7 @@ int ngtcp2_ksl_insert(ngtcp2_ksl *ksl, ngtcp2_ksl_it *it,
     i = ksl->search(ksl, blk, key);
 
     if (blk->leaf) {
-      if (i < blk->n &&
-          !ksl->compar(key, ngtcp2_ksl_nth_node(ksl, blk, i)->key)) {
+      if (i < blk->n && !ksl->compar(key, ngtcp2_ksl_nth_key(ksl, blk, i))) {
         if (it) {
           *it = ngtcp2_ksl_end(ksl);
         }
@@ -320,17 +317,17 @@ int ngtcp2_ksl_insert(ngtcp2_ksl *ksl, ngtcp2_ksl_it *it,
     if (i == blk->n) {
       /* This insertion extends the largest key in this subtree. */
       for (; !blk->leaf;) {
-        node = ngtcp2_ksl_nth_node(ksl, blk, blk->n - 1);
+        node = &blk->nodes[blk->n - 1];
         if (node->blk->n == NGTCP2_KSL_MAX_NBLK) {
           rv = ksl_split_node(ksl, blk, blk->n - 1);
           if (rv != 0) {
             return rv;
           }
 
-          node = ngtcp2_ksl_nth_node(ksl, blk, blk->n - 1);
+          node = &blk->nodes[blk->n - 1];
         }
 
-        ksl_node_set_key(ksl, node, key);
+        ksl_set_nth_key(ksl, blk, blk->n - 1, key);
         blk = node->blk;
       }
 
@@ -344,7 +341,7 @@ int ngtcp2_ksl_insert(ngtcp2_ksl *ksl, ngtcp2_ksl_it *it,
       return 0;
     }
 
-    node = ngtcp2_ksl_nth_node(ksl, blk, i);
+    node = &blk->nodes[i];
 
     if (node->blk->n == NGTCP2_KSL_MAX_NBLK) {
       rv = ksl_split_node(ksl, blk, i);
@@ -352,11 +349,11 @@ int ngtcp2_ksl_insert(ngtcp2_ksl *ksl, ngtcp2_ksl_it *it,
         return rv;
       }
 
-      if (ksl->compar((ngtcp2_ksl_key *)node->key, key)) {
-        node = ngtcp2_ksl_nth_node(ksl, blk, i + 1);
+      if (ksl->compar(ngtcp2_ksl_nth_key(ksl, blk, i), key)) {
+        node = &blk->nodes[i + 1];
 
-        if (ksl->compar((ngtcp2_ksl_key *)node->key, key)) {
-          ksl_node_set_key(ksl, node, key);
+        if (ksl->compar(ngtcp2_ksl_nth_key(ksl, blk, i + 1), key)) {
+          ksl_set_nth_key(ksl, blk, i + 1, key);
         }
       }
     }
@@ -370,8 +367,12 @@ int ngtcp2_ksl_insert(ngtcp2_ksl *ksl, ngtcp2_ksl_it *it,
  * |i|.
  */
 static void ksl_remove_node(ngtcp2_ksl *ksl, ngtcp2_ksl_blk *blk, size_t i) {
-  memmove(blk->nodes + i * ksl->nodelen, blk->nodes + (i + 1) * ksl->nodelen,
-          ksl->nodelen * (blk->n - (i + 1)));
+  memmove(blk->nodes + i, blk->nodes + (i + 1),
+          (blk->n - (i + 1)) * sizeof(ngtcp2_ksl_node));
+
+  memmove(blk->keys + i * ksl->aligned_keylen,
+          blk->keys + (i + 1) * ksl->aligned_keylen,
+          (blk->n - (i + 1)) * ksl->aligned_keylen);
 
   --blk->n;
 }
@@ -393,15 +394,17 @@ static ngtcp2_ksl_blk *ksl_merge_node(ngtcp2_ksl *ksl, ngtcp2_ksl_blk *blk,
 
   assert(i + 1 < blk->n);
 
-  lnode = ngtcp2_ksl_nth_node(ksl, blk, i);
+  lnode = &blk->nodes[i];
 
   lblk = lnode->blk;
-  rblk = ngtcp2_ksl_nth_node(ksl, blk, i + 1)->blk;
+  rblk = blk->nodes[i + 1].blk;
 
   assert(lblk->n + rblk->n < NGTCP2_KSL_MAX_NBLK);
 
-  memcpy(lblk->nodes + ksl->nodelen * lblk->n, rblk->nodes,
-         ksl->nodelen * rblk->n);
+  memcpy(lblk->nodes + lblk->n, rblk->nodes, rblk->n * sizeof(ngtcp2_ksl_node));
+
+  memcpy(lblk->keys + lblk->n * ksl->aligned_keylen, rblk->keys,
+         rblk->n * ksl->aligned_keylen);
 
   lblk->n += rblk->n;
   lblk->next = rblk->next;
@@ -419,8 +422,7 @@ static ngtcp2_ksl_blk *ksl_merge_node(ngtcp2_ksl *ksl, ngtcp2_ksl_blk *blk,
     ksl->head = lblk;
   } else {
     ksl_remove_node(ksl, blk, i + 1);
-    ksl_node_set_key(ksl, lnode,
-                     ngtcp2_ksl_nth_node(ksl, lblk, lblk->n - 1)->key);
+    ksl_set_nth_key(ksl, blk, i, ngtcp2_ksl_nth_key(ksl, lblk, lblk->n - 1));
   }
 
   return lblk;
@@ -438,8 +440,8 @@ static void ksl_shift_left(ngtcp2_ksl *ksl, ngtcp2_ksl_blk *blk, size_t i) {
 
   assert(i > 0);
 
-  lnode = ngtcp2_ksl_nth_node(ksl, blk, i - 1);
-  rnode = ngtcp2_ksl_nth_node(ksl, blk, i);
+  lnode = &blk->nodes[i - 1];
+  rnode = &blk->nodes[i];
 
   lblk = lnode->blk;
   rblk = rnode->blk;
@@ -453,15 +455,20 @@ static void ksl_shift_left(ngtcp2_ksl *ksl, ngtcp2_ksl_blk *blk, size_t i) {
   assert(lblk->n <= NGTCP2_KSL_MAX_NBLK - n);
   assert(rblk->n >= NGTCP2_KSL_MIN_NBLK + n);
 
-  memcpy(lblk->nodes + ksl->nodelen * lblk->n, rblk->nodes, ksl->nodelen * n);
+  memcpy(lblk->nodes + lblk->n, rblk->nodes, n * sizeof(ngtcp2_ksl_node));
+
+  memcpy(lblk->keys + lblk->n * ksl->aligned_keylen, rblk->keys,
+         n * ksl->aligned_keylen);
 
   lblk->n += (uint32_t)n;
   rblk->n -= (uint32_t)n;
 
-  ksl_node_set_key(ksl, lnode,
-                   ngtcp2_ksl_nth_node(ksl, lblk, lblk->n - 1)->key);
+  ksl_set_nth_key(ksl, blk, i - 1, ngtcp2_ksl_nth_key(ksl, lblk, lblk->n - 1));
 
-  memmove(rblk->nodes, rblk->nodes + ksl->nodelen * n, ksl->nodelen * rblk->n);
+  memmove(rblk->nodes, rblk->nodes + n, rblk->n * sizeof(ngtcp2_ksl_node));
+
+  memmove(rblk->keys, rblk->keys + n * ksl->aligned_keylen,
+          rblk->n * ksl->aligned_keylen);
 }
 
 /*
@@ -476,8 +483,8 @@ static void ksl_shift_right(ngtcp2_ksl *ksl, ngtcp2_ksl_blk *blk, size_t i) {
 
   assert(i < blk->n - 1);
 
-  lnode = ngtcp2_ksl_nth_node(ksl, blk, i);
-  rnode = ngtcp2_ksl_nth_node(ksl, blk, i + 1);
+  lnode = &blk->nodes[i];
+  rnode = &blk->nodes[i + 1];
 
   lblk = lnode->blk;
   rblk = rnode->blk;
@@ -491,15 +498,20 @@ static void ksl_shift_right(ngtcp2_ksl *ksl, ngtcp2_ksl_blk *blk, size_t i) {
   assert(lblk->n >= NGTCP2_KSL_MIN_NBLK + n);
   assert(rblk->n <= NGTCP2_KSL_MAX_NBLK - n);
 
-  memmove(rblk->nodes + ksl->nodelen * n, rblk->nodes, ksl->nodelen * rblk->n);
+  memmove(rblk->nodes + n, rblk->nodes, rblk->n * sizeof(ngtcp2_ksl_node));
+
+  memmove(rblk->keys + n * ksl->aligned_keylen, rblk->keys,
+          rblk->n * ksl->aligned_keylen);
 
   rblk->n += (uint32_t)n;
   lblk->n -= (uint32_t)n;
 
-  memcpy(rblk->nodes, lblk->nodes + ksl->nodelen * lblk->n, ksl->nodelen * n);
+  memcpy(rblk->nodes, lblk->nodes + lblk->n, n * sizeof(ngtcp2_ksl_node));
 
-  ksl_node_set_key(ksl, lnode,
-                   ngtcp2_ksl_nth_node(ksl, lblk, lblk->n - 1)->key);
+  memcpy(rblk->keys, lblk->keys + lblk->n * ksl->aligned_keylen,
+         n * ksl->aligned_keylen);
+
+  ksl_set_nth_key(ksl, blk, i, ngtcp2_ksl_nth_key(ksl, lblk, lblk->n - 1));
 }
 
 /*
@@ -548,8 +560,8 @@ int ngtcp2_ksl_remove(ngtcp2_ksl *ksl, ngtcp2_ksl_it *it,
   }
 
   if (!blk->leaf && blk->n == 2 &&
-      ngtcp2_ksl_nth_node(ksl, blk, 0)->blk->n == NGTCP2_KSL_MIN_NBLK &&
-      ngtcp2_ksl_nth_node(ksl, blk, 1)->blk->n == NGTCP2_KSL_MIN_NBLK) {
+      blk->nodes[0].blk->n == NGTCP2_KSL_MIN_NBLK &&
+      blk->nodes[1].blk->n == NGTCP2_KSL_MIN_NBLK) {
     blk = ksl_merge_node(ksl, blk, 0);
   }
 
@@ -565,7 +577,7 @@ int ngtcp2_ksl_remove(ngtcp2_ksl *ksl, ngtcp2_ksl_it *it,
     }
 
     if (blk->leaf) {
-      if (ksl->compar(key, ngtcp2_ksl_nth_node(ksl, blk, i)->key)) {
+      if (ksl->compar(key, ngtcp2_ksl_nth_key(ksl, blk, i))) {
         if (it) {
           *it = ngtcp2_ksl_end(ksl);
         }
@@ -587,7 +599,7 @@ int ngtcp2_ksl_remove(ngtcp2_ksl *ksl, ngtcp2_ksl_it *it,
       return 0;
     }
 
-    node = ngtcp2_ksl_nth_node(ksl, blk, i);
+    node = &blk->nodes[i];
 
     if (node->blk->n > NGTCP2_KSL_MIN_NBLK) {
       blk = node->blk;
@@ -596,16 +608,14 @@ int ngtcp2_ksl_remove(ngtcp2_ksl *ksl, ngtcp2_ksl_it *it,
 
     assert(node->blk->n == NGTCP2_KSL_MIN_NBLK);
 
-    if (i + 1 < blk->n &&
-        ngtcp2_ksl_nth_node(ksl, blk, i + 1)->blk->n > NGTCP2_KSL_MIN_NBLK) {
+    if (i + 1 < blk->n && blk->nodes[i + 1].blk->n > NGTCP2_KSL_MIN_NBLK) {
       ksl_shift_left(ksl, blk, i + 1);
       blk = node->blk;
 
       continue;
     }
 
-    if (i > 0 &&
-        ngtcp2_ksl_nth_node(ksl, blk, i - 1)->blk->n > NGTCP2_KSL_MIN_NBLK) {
+    if (i > 0 && blk->nodes[i - 1].blk->n > NGTCP2_KSL_MIN_NBLK) {
       ksl_shift_right(ksl, blk, i - 1);
       blk = node->blk;
 
@@ -657,7 +667,7 @@ ngtcp2_ksl_it ngtcp2_ksl_lower_bound_search(const ngtcp2_ksl *ksl,
     if (i == blk->n) {
       /* This happens if descendant has smaller key.  Fast forward to
          find last node in this subtree. */
-      for (; !blk->leaf; blk = ngtcp2_ksl_nth_node(ksl, blk, blk->n - 1)->blk)
+      for (; !blk->leaf; blk = blk->nodes[blk->n - 1].blk)
         ;
 
       if (blk->next) {
@@ -672,7 +682,7 @@ ngtcp2_ksl_it ngtcp2_ksl_lower_bound_search(const ngtcp2_ksl *ksl,
       return it;
     }
 
-    blk = ngtcp2_ksl_nth_node(ksl, blk, i)->blk;
+    blk = blk->nodes[i].blk;
   }
 }
 
@@ -680,6 +690,7 @@ void ngtcp2_ksl_update_key(ngtcp2_ksl *ksl, const ngtcp2_ksl_key *old_key,
                            const ngtcp2_ksl_key *new_key) {
   ngtcp2_ksl_blk *blk = ksl->head;
   ngtcp2_ksl_node *node;
+  const ngtcp2_ksl_key *node_key;
   size_t i;
 
   assert(ksl->head);
@@ -688,18 +699,19 @@ void ngtcp2_ksl_update_key(ngtcp2_ksl *ksl, const ngtcp2_ksl_key *old_key,
     i = ksl->search(ksl, blk, old_key);
 
     assert(i < blk->n);
-    node = ngtcp2_ksl_nth_node(ksl, blk, i);
+    node = &blk->nodes[i];
+    node_key = ngtcp2_ksl_nth_key(ksl, blk, i);
 
     if (blk->leaf) {
-      assert(key_equal(ksl->compar, (ngtcp2_ksl_key *)node->key, old_key));
-      ksl_node_set_key(ksl, node, new_key);
+      assert(key_equal(ksl->compar, node_key, old_key));
+      ksl_set_nth_key(ksl, blk, i, new_key);
 
       return;
     }
 
-    if (key_equal(ksl->compar, (ngtcp2_ksl_key *)node->key, old_key) ||
-        ksl->compar((ngtcp2_ksl_key *)node->key, new_key)) {
-      ksl_node_set_key(ksl, node, new_key);
+    if (key_equal(ksl->compar, node_key, old_key) ||
+        ksl->compar(node_key, new_key)) {
+      ksl_set_nth_key(ksl, blk, i, new_key);
     }
 
     blk = node->blk;
@@ -727,14 +739,12 @@ void ngtcp2_ksl_clear(ngtcp2_ksl *ksl) {
 static void ksl_print(const ngtcp2_ksl *ksl, ngtcp2_ksl_blk *blk,
                       size_t level) {
   size_t i;
-  ngtcp2_ksl_node *node;
 
   fprintf(stderr, "LV=%zu n=%u\n", level, blk->n);
 
   if (blk->leaf) {
     for (i = 0; i < blk->n; ++i) {
-      node = ngtcp2_ksl_nth_node(ksl, blk, i);
-      fprintf(stderr, " %" PRId64, *(int64_t *)(void *)node->key);
+      fprintf(stderr, " %" PRId64, *(int64_t *)ngtcp2_ksl_nth_key(ksl, blk, i));
     }
 
     fprintf(stderr, "\n");
@@ -743,7 +753,7 @@ static void ksl_print(const ngtcp2_ksl *ksl, ngtcp2_ksl_blk *blk,
   }
 
   for (i = 0; i < blk->n; ++i) {
-    ksl_print(ksl, ngtcp2_ksl_nth_node(ksl, blk, i)->blk, level + 1);
+    ksl_print(ksl, blk->nodes[i].blk, level + 1);
   }
 }
 

--- a/lib/ngtcp2_ksl.h
+++ b/lib/ngtcp2_ksl.h
@@ -55,21 +55,12 @@ typedef struct ngtcp2_ksl_blk ngtcp2_ksl_blk;
 /*
  * ngtcp2_ksl_node is a node which contains either ngtcp2_ksl_blk or
  * opaque data.  If a node is an internal node, it contains
- * ngtcp2_ksl_blk.  Otherwise, it has data.  The key is stored at the
- * location starting at key.
+ * ngtcp2_ksl_blk.  Otherwise, it has data.
  */
 struct ngtcp2_ksl_node {
   union {
     ngtcp2_ksl_blk *blk;
     void *data;
-  };
-  union {
-    uint64_t align;
-    /* key is a buffer to include key associated to this node.
-       Because the length of key is unknown until ngtcp2_ksl_init is
-       called, the actual buffer will be allocated after this
-       field. */
-    uint8_t key[1];
   };
 };
 
@@ -88,14 +79,14 @@ struct ngtcp2_ksl_blk {
       uint32_t n;
       /* leaf is nonzero if this block contains leaf nodes. */
       uint32_t leaf;
+      ngtcp2_ksl_node nodes[NGTCP2_KSL_MAX_NBLK];
       union {
         uint64_t align;
-        /* nodes is a buffer to contain NGTCP2_KSL_MAX_NBLK
-           ngtcp2_ksl_node objects.  Because ngtcp2_ksl_node object is
-           allocated along with the additional variable length key
-           storage, the size of buffer is unknown until ngtcp2_ksl_init is
-           called. */
-        uint8_t nodes[1];
+        /* keys is a buffer to include NGTCP2_KSL_MAX_NBLK keys.
+           Because the length of key is unknown until ngtcp2_ksl_init
+           is called, the actual buffer will be allocated after this
+           field. */
+        uint8_t keys[1];
       };
     };
 
@@ -131,11 +122,10 @@ typedef size_t (*ngtcp2_ksl_search)(const ngtcp2_ksl *ksl, ngtcp2_ksl_blk *blk,
   static size_t ksl_##NAME##_search(                                           \
     const ngtcp2_ksl *ksl, ngtcp2_ksl_blk *blk, const ngtcp2_ksl_key *key) {   \
     size_t i;                                                                  \
-    ngtcp2_ksl_node *node;                                                     \
+    uint8_t *node_key;                                                         \
                                                                                \
-    for (i = 0, node = (ngtcp2_ksl_node *)(void *)blk->nodes;                  \
-         i < blk->n && COMPAR((ngtcp2_ksl_key *)node->key, key); ++i,          \
-        node = (ngtcp2_ksl_node *)(void *)((uint8_t *)node + ksl->nodelen))    \
+    for (i = 0, node_key = blk->keys; i < blk->n && COMPAR(node_key, key);     \
+         ++i, node_key += ksl->aligned_keylen)                                 \
       ;                                                                        \
                                                                                \
     return i;                                                                  \
@@ -169,9 +159,7 @@ struct ngtcp2_ksl {
   size_t n;
   /* keylen is the size of key */
   size_t keylen;
-  /* nodelen is the actual size of ngtcp2_ksl_node including key
-     storage. */
-  size_t nodelen;
+  size_t aligned_keylen;
 };
 
 /*
@@ -290,12 +278,11 @@ size_t ngtcp2_ksl_len(const ngtcp2_ksl *ksl);
 void ngtcp2_ksl_clear(ngtcp2_ksl *ksl);
 
 /*
- * ngtcp2_ksl_nth_node returns the |n|th node under |blk|.
+ * ngtcp2_ksl_nth_key returns the |n|th key under |blk|.
  */
-static inline ngtcp2_ksl_node *ngtcp2_ksl_nth_node(const ngtcp2_ksl *ksl,
-                                                   const ngtcp2_ksl_blk *blk,
-                                                   size_t n) {
-  return (ngtcp2_ksl_node *)(void *)(blk->nodes + ksl->nodelen * n);
+static inline const ngtcp2_ksl_key *
+ngtcp2_ksl_nth_key(const ngtcp2_ksl *ksl, const ngtcp2_ksl_blk *blk, size_t n) {
+  return blk->keys + n * ksl->aligned_keylen;
 }
 
 #ifndef WIN32
@@ -319,7 +306,7 @@ void ngtcp2_ksl_it_init(ngtcp2_ksl_it *it, const ngtcp2_ksl *ksl,
  * ngtcp2_ksl_it_end(it) returns nonzero.
  */
 static inline void *ngtcp2_ksl_it_get(const ngtcp2_ksl_it *it) {
-  return ngtcp2_ksl_nth_node(it->ksl, it->blk, it->i)->data;
+  return it->blk->nodes[it->i].data;
 }
 
 /*
@@ -361,8 +348,8 @@ int ngtcp2_ksl_it_begin(const ngtcp2_ksl_it *it);
  * It is undefined to call this function when ngtcp2_ksl_it_end(it)
  * returns nonzero.
  */
-static inline ngtcp2_ksl_key *ngtcp2_ksl_it_key(const ngtcp2_ksl_it *it) {
-  return (ngtcp2_ksl_key *)ngtcp2_ksl_nth_node(it->ksl, it->blk, it->i)->key;
+static inline const ngtcp2_ksl_key *ngtcp2_ksl_it_key(const ngtcp2_ksl_it *it) {
+  return ngtcp2_ksl_nth_key(it->ksl, it->blk, it->i);
 }
 
 /*

--- a/tests/ngtcp2_ksl_test.c
+++ b/tests/ngtcp2_ksl_test.c
@@ -163,8 +163,8 @@ void test_ngtcp2_ksl_insert(void) {
   assert_int(0, ==, ngtcp2_ksl_remove(&ksl, NULL, &k));
 
   assert_size(2, ==, ksl.head->n);
-  assert_size(29, ==, ngtcp2_ksl_nth_node(&ksl, ksl.head, 0)->blk->n);
-  assert_size(18, ==, ngtcp2_ksl_nth_node(&ksl, ksl.head, 1)->blk->n);
+  assert_size(29, ==, ksl.head->nodes[0].blk->n);
+  assert_size(18, ==, ksl.head->nodes[1].blk->n);
 
   ngtcp2_ksl_free(&ksl);
 
@@ -349,8 +349,8 @@ void test_ngtcp2_ksl_range(void) {
   assert_int(0, ==, ngtcp2_ksl_remove(&ksl, NULL, &r));
 
   assert_size(2, ==, ksl.head->n);
-  assert_size(29, ==, ngtcp2_ksl_nth_node(&ksl, ksl.head, 0)->blk->n);
-  assert_size(18, ==, ngtcp2_ksl_nth_node(&ksl, ksl.head, 1)->blk->n);
+  assert_size(29, ==, ksl.head->nodes[0].blk->n);
+  assert_size(18, ==, ksl.head->nodes[1].blk->n);
 
   ngtcp2_ksl_free(&ksl);
 
@@ -368,9 +368,8 @@ void test_ngtcp2_ksl_range(void) {
   ngtcp2_range_init(&r, 1401, 1402);
   assert_int(0, ==, ngtcp2_ksl_remove(&ksl, NULL, &r));
 
-  r = *(ngtcp2_range *)(void *)ngtcp2_ksl_nth_node(
-         &ksl, ngtcp2_ksl_nth_node(&ksl, ksl.head, 1)->blk, 0)
-         ->key;
+  r = *(ngtcp2_range *)(void *)ngtcp2_ksl_nth_key(&ksl, ksl.head->nodes[1].blk,
+                                                  0);
 
   assert_uint64(1701, ==, r.begin);
 
@@ -390,10 +389,9 @@ void test_ngtcp2_ksl_range(void) {
   ngtcp2_range_init(&r, 16, 17);
   assert_int(0, ==, ngtcp2_ksl_remove(&ksl, NULL, &r));
 
-  node = ngtcp2_ksl_nth_node(&ksl, ksl.head, 0);
-  r = *(ngtcp2_range *)(void *)ngtcp2_ksl_nth_node(&ksl, node->blk,
-                                                   node->blk->n - 1)
-         ->key;
+  node = &ksl.head->nodes[0];
+  r = *(ngtcp2_range *)(void *)ngtcp2_ksl_nth_key(&ksl, node->blk,
+                                                  node->blk->n - 1);
 
   assert_uint64(14, ==, r.begin);
 


### PR DESCRIPTION
Split keys from ngtcp2_ksl_node, making keys compact, and contagious, thus cache friendly.  Now looking up ngtcp2_ksl_node is much easier with just index.