### PR TITLE
examples: Disable signed-conversion warning for format_hex

### DIFF
--- a/examples/util.h
+++ b/examples/util.h
@@ -85,10 +85,15 @@ inline constexpr char LOWER_XDIGITS[] = "0123456789abcdef";
 template <std::weakly_incrementable O>
 requires(std::indirectly_writable<O, char>)
 constexpr O format_hex_uint8(uint8_t b, O result) {
-  using result_type = std::iter_value_t<O>;
-
-  *result++ = static_cast<result_type>(LOWER_XDIGITS[b >> 4]);
-  *result++ = static_cast<result_type>(LOWER_XDIGITS[b & 0xf]);
+#ifdef __GNUC__
+#  pragma GCC diagnostic push
+#  pragma GCC diagnostic ignored "-Wsign-conversion"
+#endif // __GNUC__
+  *result++ = LOWER_XDIGITS[b >> 4];
+  *result++ = LOWER_XDIGITS[b & 0xf];
+#ifdef __GNUC__
+#  pragma GCC diagnostic pop
+#endif // __GNUC__
 
   return result;
 }

--- a/examples/util_test.cc
+++ b/examples/util_test.cc
@@ -448,6 +448,21 @@ void test_util_format_hex() {
     (std::string_view{std::ranges::begin(buf),
                       util::format_hex(std::numeric_limits<uint64_t>::max(),
                                        std::ranges::begin(buf))}));
+
+  std::vector<char> char_vec;
+  util::format_hex(a, std::back_inserter(char_vec));
+
+  assert_stdsv_equal("deadbeef"sv,
+                     (std::string_view{std::ranges::begin(char_vec),
+                                       std::ranges::end(char_vec)}));
+
+  std::vector<uint8_t> uint8_vec;
+  util::format_hex(a, std::back_inserter(uint8_vec));
+
+  assert_stdsv_equal(
+    "deadbeef"sv,
+    (std::string_view{reinterpret_cast<const char *>(uint8_vec.data()),
+                      uint8_vec.size()}));
 }
 
 void test_util_decode_hex() {


### PR DESCRIPTION
Workaround signed/unsigned conversion warnings.  Just casting to a type (e.g., std::iter_value_t<O>) does not work with a proxy type like std::back_insert_iterator without fragile hacks.