### PR TITLE
ngtcp2_str: Use char buffer for cstr functions

### DIFF
--- a/lib/ngtcp2_conn.c
+++ b/lib/ngtcp2_conn.c
@@ -5409,7 +5409,7 @@ static int conn_on_retry(ngtcp2_conn *conn, const ngtcp2_pkt_hd *hd,
   ngtcp2_pktns *in_pktns = conn->in_pktns;
   ngtcp2_rtb *rtb = &conn->pktns.rtb;
   ngtcp2_rtb *in_rtb;
-  uint8_t cidbuf[sizeof(retry.odcid.data) * 2 + 1];
+  char cidbuf[sizeof(retry.odcid.data) * 2 + 1];
   uint8_t *token;
 
   if (!in_pktns || (conn->flags & NGTCP2_CONN_FLAG_RECV_RETRY)) {
@@ -5434,9 +5434,9 @@ static int conn_on_retry(ngtcp2_conn *conn, const ngtcp2_pkt_hd *hd,
     return rv;
   }
 
-  ngtcp2_log_infof(&conn->log, NGTCP2_LOG_EVENT_PKT, "odcid=0x%s",
-                   (const char *)ngtcp2_encode_hex_cstr(
-                     cidbuf, retry.odcid.data, retry.odcid.datalen));
+  ngtcp2_log_infof(
+    &conn->log, NGTCP2_LOG_EVENT_PKT, "odcid=0x%s",
+    ngtcp2_encode_hex_cstr(cidbuf, retry.odcid.data, retry.odcid.datalen));
 
   if (retry.tokenlen == 0) {
     return NGTCP2_ERR_PROTO;

--- a/lib/ngtcp2_log.c
+++ b/lib/ngtcp2_log.c
@@ -335,8 +335,8 @@ static void log_fr_streams_blocked(ngtcp2_log *log, const ngtcp2_pkt_hd *hd,
 static void log_fr_new_connection_id(ngtcp2_log *log, const ngtcp2_pkt_hd *hd,
                                      const ngtcp2_new_connection_id *fr,
                                      const char *dir) {
-  uint8_t buf[sizeof(fr->stateless_reset_token) * 2 + 1];
-  uint8_t cid[sizeof(fr->cid.data) * 2 + 1];
+  char buf[sizeof(fr->stateless_reset_token) * 2 + 1];
+  char cid[sizeof(fr->cid.data) * 2 + 1];
 
   ngtcp2_log_infof_raw(
     log, NGTCP2_LOG_EVENT_FRM,
@@ -344,10 +344,10 @@ static void log_fr_new_connection_id(ngtcp2_log *log, const ngtcp2_pkt_hd *hd,
                    " cid=0x%s retire_prior_to=%" PRIu64
                    " stateless_reset_token=0x%s",
     NGTCP2_LOG_PKT_HD_FIELDS(dir), fr->type, fr->seq,
-    (const char *)ngtcp2_encode_hex_cstr(cid, fr->cid.data, fr->cid.datalen),
+    ngtcp2_encode_hex_cstr(cid, fr->cid.data, fr->cid.datalen),
     fr->retire_prior_to,
-    (const char *)ngtcp2_encode_hex_cstr(buf, fr->stateless_reset_token,
-                                         sizeof(fr->stateless_reset_token)));
+    ngtcp2_encode_hex_cstr(buf, fr->stateless_reset_token,
+                           sizeof(fr->stateless_reset_token)));
 }
 
 static void log_fr_stop_sending(ngtcp2_log *log, const ngtcp2_pkt_hd *hd,
@@ -364,25 +364,25 @@ static void log_fr_stop_sending(ngtcp2_log *log, const ngtcp2_pkt_hd *hd,
 static void log_fr_path_challenge(ngtcp2_log *log, const ngtcp2_pkt_hd *hd,
                                   const ngtcp2_path_challenge *fr,
                                   const char *dir) {
-  uint8_t buf[sizeof(fr->data) * 2 + 1];
+  char buf[sizeof(fr->data) * 2 + 1];
 
-  ngtcp2_log_infof_raw(
-    log, NGTCP2_LOG_EVENT_FRM,
-    NGTCP2_LOG_PKT " PATH_CHALLENGE(0x%02" PRIx64 ") data=0x%s",
-    NGTCP2_LOG_PKT_HD_FIELDS(dir), fr->type,
-    (const char *)ngtcp2_encode_hex_cstr(buf, fr->data, sizeof(fr->data)));
+  ngtcp2_log_infof_raw(log, NGTCP2_LOG_EVENT_FRM,
+                       NGTCP2_LOG_PKT " PATH_CHALLENGE(0x%02" PRIx64
+                                      ") data=0x%s",
+                       NGTCP2_LOG_PKT_HD_FIELDS(dir), fr->type,
+                       ngtcp2_encode_hex_cstr(buf, fr->data, sizeof(fr->data)));
 }
 
 static void log_fr_path_response(ngtcp2_log *log, const ngtcp2_pkt_hd *hd,
                                  const ngtcp2_path_response *fr,
                                  const char *dir) {
-  uint8_t buf[sizeof(fr->data) * 2 + 1];
+  char buf[sizeof(fr->data) * 2 + 1];
 
-  ngtcp2_log_infof_raw(
-    log, NGTCP2_LOG_EVENT_FRM,
-    NGTCP2_LOG_PKT " PATH_RESPONSE(0x%02" PRIx64 ") data=0x%s",
-    NGTCP2_LOG_PKT_HD_FIELDS(dir), fr->type,
-    (const char *)ngtcp2_encode_hex_cstr(buf, fr->data, sizeof(fr->data)));
+  ngtcp2_log_infof_raw(log, NGTCP2_LOG_EVENT_FRM,
+                       NGTCP2_LOG_PKT " PATH_RESPONSE(0x%02" PRIx64
+                                      ") data=0x%s",
+                       NGTCP2_LOG_PKT_HD_FIELDS(dir), fr->type,
+                       ngtcp2_encode_hex_cstr(buf, fr->data, sizeof(fr->data)));
 }
 
 static void log_fr_crypto(ngtcp2_log *log, const ngtcp2_pkt_hd *hd,
@@ -398,8 +398,8 @@ static void log_fr_new_token(ngtcp2_log *log, const ngtcp2_pkt_hd *hd,
                              const ngtcp2_new_token *fr, const char *dir) {
   /* Show at most first 64 bytes of token.  If token is longer than 64
      bytes, log first 64 bytes and then append "*" */
-  uint8_t buf[128 + 1 + 1];
-  uint8_t *p;
+  char buf[128 + 1 + 1];
+  char *p;
 
   if (fr->tokenlen > 64) {
     p = ngtcp2_encode_hex_cstr(buf, fr->token, 64);
@@ -412,7 +412,7 @@ static void log_fr_new_token(ngtcp2_log *log, const ngtcp2_pkt_hd *hd,
   ngtcp2_log_infof_raw(
     log, NGTCP2_LOG_EVENT_FRM,
     NGTCP2_LOG_PKT " NEW_TOKEN(0x%02" PRIx64 ") token=0x%s len=%zu",
-    NGTCP2_LOG_PKT_HD_FIELDS(dir), fr->type, (const char *)p, fr->tokenlen);
+    NGTCP2_LOG_PKT_HD_FIELDS(dir), fr->type, p, fr->tokenlen);
 }
 
 static void log_fr_retire_connection_id(ngtcp2_log *log,
@@ -550,7 +550,7 @@ void ngtcp2_log_rx_vn(ngtcp2_log *log, const ngtcp2_pkt_hd *hd,
 }
 
 void ngtcp2_log_rx_sr(ngtcp2_log *log, const ngtcp2_pkt_stateless_reset *sr) {
-  uint8_t buf[sizeof(sr->stateless_reset_token) * 2 + 1];
+  char buf[sizeof(sr->stateless_reset_token) * 2 + 1];
   ngtcp2_pkt_hd shd;
   ngtcp2_pkt_hd *hd = &shd;
 
@@ -565,16 +565,16 @@ void ngtcp2_log_rx_sr(ngtcp2_log *log, const ngtcp2_pkt_stateless_reset *sr) {
   ngtcp2_log_infof_raw(
     log, NGTCP2_LOG_EVENT_PKT, NGTCP2_LOG_PKT " token=0x%s randlen=%zu",
     NGTCP2_LOG_PKT_HD_FIELDS("rx"),
-    (const char *)ngtcp2_encode_hex_cstr(buf, sr->stateless_reset_token,
-                                         sizeof(sr->stateless_reset_token)),
+    ngtcp2_encode_hex_cstr(buf, sr->stateless_reset_token,
+                           sizeof(sr->stateless_reset_token)),
     sr->randlen);
 }
 
 void ngtcp2_log_remote_tp(ngtcp2_log *log,
                           const ngtcp2_transport_params *params) {
-  uint8_t token[NGTCP2_STATELESS_RESET_TOKENLEN * 2 + 1];
-  uint8_t addr[16 * 2 + 7 + 1];
-  uint8_t cid[NGTCP2_MAX_CIDLEN * 2 + 1];
+  char token[NGTCP2_STATELESS_RESET_TOKENLEN * 2 + 1];
+  char addr[16 * 2 + 7 + 1];
+  char cid[NGTCP2_MAX_CIDLEN * 2 + 1];
   size_t i;
   const ngtcp2_sockaddr_in *sa_in;
   const ngtcp2_sockaddr_in6 *sa_in6;
@@ -586,21 +586,20 @@ void ngtcp2_log_remote_tp(ngtcp2_log *log,
   }
 
   if (params->stateless_reset_token_present) {
-    ngtcp2_log_infof_raw(log, NGTCP2_LOG_EVENT_CRY,
-                         NGTCP2_LOG_TP " stateless_reset_token=0x%s",
-                         (const char *)ngtcp2_encode_hex_cstr(
-                           token, params->stateless_reset_token,
-                           sizeof(params->stateless_reset_token)));
+    ngtcp2_log_infof_raw(
+      log, NGTCP2_LOG_EVENT_CRY, NGTCP2_LOG_TP " stateless_reset_token=0x%s",
+      ngtcp2_encode_hex_cstr(token, params->stateless_reset_token,
+                             sizeof(params->stateless_reset_token)));
   }
 
   if (params->preferred_addr_present) {
     if (params->preferred_addr.ipv4_present) {
       sa_in = &params->preferred_addr.ipv4;
 
-      ngtcp2_log_infof_raw(log, NGTCP2_LOG_EVENT_CRY,
-                           NGTCP2_LOG_TP " preferred_address.ipv4_addr=%s",
-                           (const char *)ngtcp2_encode_ipv4_cstr(
-                             addr, (const uint8_t *)&sa_in->sin_addr));
+      ngtcp2_log_infof_raw(
+        log, NGTCP2_LOG_EVENT_CRY,
+        NGTCP2_LOG_TP " preferred_address.ipv4_addr=%s",
+        ngtcp2_encode_ipv4_cstr(addr, (const uint8_t *)&sa_in->sin_addr));
       ngtcp2_log_infof_raw(log, NGTCP2_LOG_EVENT_CRY,
                            NGTCP2_LOG_TP " preferred_address.ipv4_port=%u",
                            ngtcp2_ntohs(sa_in->sin_port));
@@ -609,10 +608,10 @@ void ngtcp2_log_remote_tp(ngtcp2_log *log,
     if (params->preferred_addr.ipv6_present) {
       sa_in6 = &params->preferred_addr.ipv6;
 
-      ngtcp2_log_infof_raw(log, NGTCP2_LOG_EVENT_CRY,
-                           NGTCP2_LOG_TP " preferred_address.ipv6_addr=%s",
-                           (const char *)ngtcp2_encode_ipv6_cstr(
-                             addr, (const uint8_t *)&sa_in6->sin6_addr));
+      ngtcp2_log_infof_raw(
+        log, NGTCP2_LOG_EVENT_CRY,
+        NGTCP2_LOG_TP " preferred_address.ipv6_addr=%s",
+        ngtcp2_encode_ipv6_cstr(addr, (const uint8_t *)&sa_in6->sin6_addr));
       ngtcp2_log_infof_raw(log, NGTCP2_LOG_EVENT_CRY,
                            NGTCP2_LOG_TP " preferred_address.ipv6_port=%u",
                            ngtcp2_ntohs(sa_in6->sin6_port));
@@ -620,38 +619,36 @@ void ngtcp2_log_remote_tp(ngtcp2_log *log,
 
     ngtcp2_log_infof_raw(
       log, NGTCP2_LOG_EVENT_CRY, NGTCP2_LOG_TP " preferred_address.cid=0x%s",
-      (const char *)ngtcp2_encode_hex_cstr(cid, params->preferred_addr.cid.data,
-                                           params->preferred_addr.cid.datalen));
+      ngtcp2_encode_hex_cstr(cid, params->preferred_addr.cid.data,
+                             params->preferred_addr.cid.datalen));
     ngtcp2_log_infof_raw(
       log, NGTCP2_LOG_EVENT_CRY,
       NGTCP2_LOG_TP " preferred_address.stateless_reset_token=0x%s",
-      (const char *)ngtcp2_encode_hex_cstr(
+      ngtcp2_encode_hex_cstr(
         token, params->preferred_addr.stateless_reset_token,
         sizeof(params->preferred_addr.stateless_reset_token)));
   }
 
   if (params->original_dcid_present) {
-    ngtcp2_log_infof_raw(
-      log, NGTCP2_LOG_EVENT_CRY,
-      NGTCP2_LOG_TP " original_destination_connection_id=0x%s",
-      (const char *)ngtcp2_encode_hex_cstr(cid, params->original_dcid.data,
-                                           params->original_dcid.datalen));
+    ngtcp2_log_infof_raw(log, NGTCP2_LOG_EVENT_CRY,
+                         NGTCP2_LOG_TP
+                         " original_destination_connection_id=0x%s",
+                         ngtcp2_encode_hex_cstr(cid, params->original_dcid.data,
+                                                params->original_dcid.datalen));
   }
 
   if (params->retry_scid_present) {
-    ngtcp2_log_infof_raw(
-      log, NGTCP2_LOG_EVENT_CRY,
-      NGTCP2_LOG_TP " retry_source_connection_id=0x%s",
-      (const char *)ngtcp2_encode_hex_cstr(cid, params->retry_scid.data,
-                                           params->retry_scid.datalen));
+    ngtcp2_log_infof_raw(log, NGTCP2_LOG_EVENT_CRY,
+                         NGTCP2_LOG_TP " retry_source_connection_id=0x%s",
+                         ngtcp2_encode_hex_cstr(cid, params->retry_scid.data,
+                                                params->retry_scid.datalen));
   }
 
   if (params->initial_scid_present) {
-    ngtcp2_log_infof_raw(
-      log, NGTCP2_LOG_EVENT_CRY,
-      NGTCP2_LOG_TP " initial_source_connection_id=0x%s",
-      (const char *)ngtcp2_encode_hex_cstr(cid, params->initial_scid.data,
-                                           params->initial_scid.datalen));
+    ngtcp2_log_infof_raw(log, NGTCP2_LOG_EVENT_CRY,
+                         NGTCP2_LOG_TP " initial_source_connection_id=0x%s",
+                         ngtcp2_encode_hex_cstr(cid, params->initial_scid.data,
+                                                params->initial_scid.datalen));
   }
 
   ngtcp2_log_infof_raw(log, NGTCP2_LOG_EVENT_CRY,
@@ -733,8 +730,8 @@ void ngtcp2_log_pkt_lost(ngtcp2_log *log, int64_t pkt_num, uint8_t type,
 
 static void log_pkt_hd(ngtcp2_log *log, const ngtcp2_pkt_hd *hd,
                        const char *dir) {
-  uint8_t dcid[sizeof(hd->dcid.data) * 2 + 1];
-  uint8_t scid[sizeof(hd->scid.data) * 2 + 1];
+  char dcid[sizeof(hd->dcid.data) * 2 + 1];
+  char scid[sizeof(hd->scid.data) * 2 + 1];
 
   if (!log->log_printf || !(log->events & NGTCP2_LOG_EVENT_PKT)) {
     return;
@@ -744,19 +741,16 @@ static void log_pkt_hd(ngtcp2_log *log, const ngtcp2_pkt_hd *hd,
     ngtcp2_log_infof(
       log, NGTCP2_LOG_EVENT_PKT, "%s pkn=%" PRId64 " dcid=0x%s type=%s k=%d",
       dir, hd->pkt_num,
-      (const char *)ngtcp2_encode_hex_cstr(dcid, hd->dcid.data,
-                                           hd->dcid.datalen),
+      ngtcp2_encode_hex_cstr(dcid, hd->dcid.data, hd->dcid.datalen),
       strpkttype(hd), (hd->flags & NGTCP2_PKT_FLAG_KEY_PHASE) != 0);
   } else {
-    ngtcp2_log_infof(log, NGTCP2_LOG_EVENT_PKT,
-                     "%s pkn=%" PRId64
-                     " dcid=0x%s scid=0x%s version=0x%08x type=%s len=%zu",
-                     dir, hd->pkt_num,
-                     (const char *)ngtcp2_encode_hex_cstr(dcid, hd->dcid.data,
-                                                          hd->dcid.datalen),
-                     (const char *)ngtcp2_encode_hex_cstr(scid, hd->scid.data,
-                                                          hd->scid.datalen),
-                     hd->version, strpkttype(hd), hd->len);
+    ngtcp2_log_infof(
+      log, NGTCP2_LOG_EVENT_PKT,
+      "%s pkn=%" PRId64 " dcid=0x%s scid=0x%s version=0x%08x type=%s len=%zu",
+      dir, hd->pkt_num,
+      ngtcp2_encode_hex_cstr(dcid, hd->dcid.data, hd->dcid.datalen),
+      ngtcp2_encode_hex_cstr(scid, hd->scid.data, hd->scid.datalen),
+      hd->version, strpkttype(hd), hd->len);
   }
 }
 

--- a/lib/ngtcp2_log.h
+++ b/lib/ngtcp2_log.h
@@ -49,7 +49,7 @@ typedef struct ngtcp2_log {
      log_pritnf. */
   void *user_data;
   /* scid is SCID encoded as NULL-terminated hex string. */
-  uint8_t scid[NGTCP2_MAX_CIDLEN * 2 + 1];
+  char scid[NGTCP2_MAX_CIDLEN * 2 + 1];
 } ngtcp2_log;
 
 /**

--- a/lib/ngtcp2_str.c
+++ b/lib/ngtcp2_str.c
@@ -57,9 +57,8 @@ uint8_t *ngtcp2_encode_hex(uint8_t *dest, const uint8_t *data, size_t len) {
   return p;
 }
 
-uint8_t *ngtcp2_encode_hex_cstr(uint8_t *dest, const uint8_t *data,
-                                size_t len) {
-  uint8_t *p = ngtcp2_encode_hex(dest, data, len);
+char *ngtcp2_encode_hex_cstr(char *dest, const uint8_t *data, size_t len) {
+  uint8_t *p = ngtcp2_encode_hex((uint8_t *)dest, data, len);
 
   *p = '\0';
 
@@ -86,15 +85,15 @@ char *ngtcp2_encode_printable_ascii_cstr(char *dest, const uint8_t *data,
   return dest;
 }
 
-uint8_t *ngtcp2_encode_ipv4_cstr(uint8_t *dest, const uint8_t *addr) {
+char *ngtcp2_encode_ipv4_cstr(char *dest, const uint8_t *addr) {
   size_t i;
-  uint8_t *p = dest;
+  char *p = dest;
 
-  p = ngtcp2_encode_uint(p, addr[0]);
+  p = (char *)ngtcp2_encode_uint((uint8_t *)p, addr[0]);
 
   for (i = 1; i < 4; ++i) {
     *p++ = '.';
-    p = ngtcp2_encode_uint(p, addr[i]);
+    p = (char *)ngtcp2_encode_uint((uint8_t *)p, addr[i]);
   }
 
   *p = '\0';
@@ -107,9 +106,9 @@ uint8_t *ngtcp2_encode_ipv4_cstr(uint8_t *dest, const uint8_t *addr) {
  * length |len| to |dest| in hex string.  Any leading zeros are
  * suppressed.  It returns |dest| plus the number of bytes written.
  */
-static uint8_t *write_hex_zsup(uint8_t *dest, const uint8_t *data, size_t len) {
+static char *write_hex_zsup(char *dest, const uint8_t *data, size_t len) {
   size_t i;
-  uint8_t *p = dest;
+  char *p = dest;
   uint8_t d;
 
   for (i = 0; i < len; ++i) {
@@ -121,7 +120,7 @@ static uint8_t *write_hex_zsup(uint8_t *dest, const uint8_t *data, size_t len) {
     d &= 0xf;
 
     if (d) {
-      *p++ = (uint8_t)LOWER_XDIGITS[d];
+      *p++ = LOWER_XDIGITS[d];
       ++i;
       break;
     }
@@ -134,19 +133,19 @@ static uint8_t *write_hex_zsup(uint8_t *dest, const uint8_t *data, size_t len) {
 
   for (; i < len; ++i) {
     d = data[i];
-    *p++ = (uint8_t)LOWER_XDIGITS[d >> 4];
-    *p++ = (uint8_t)LOWER_XDIGITS[d & 0xf];
+    *p++ = LOWER_XDIGITS[d >> 4];
+    *p++ = LOWER_XDIGITS[d & 0xf];
   }
 
   return p;
 }
 
-uint8_t *ngtcp2_encode_ipv6_cstr(uint8_t *dest, const uint8_t *addr) {
+char *ngtcp2_encode_ipv6_cstr(char *dest, const uint8_t *addr) {
   uint16_t blks[8];
   size_t i;
   size_t zlen, zoff;
   size_t max_zlen = 0, max_zoff = 8;
-  uint8_t *p = dest;
+  char *p = dest;
 
   for (i = 0; i < 16; i += sizeof(uint16_t)) {
     /* Copy in network byte order. */

--- a/lib/ngtcp2_str.h
+++ b/lib/ngtcp2_str.h
@@ -58,7 +58,7 @@ uint8_t *ngtcp2_encode_hex(uint8_t *dest, const uint8_t *data, size_t len);
  * The buffer pointed by |dest| must have at least |len| * 2 + 1 bytes
  * space.  This function returns |dest|.
  */
-uint8_t *ngtcp2_encode_hex_cstr(uint8_t *dest, const uint8_t *data, size_t len);
+char *ngtcp2_encode_hex_cstr(char *dest, const uint8_t *data, size_t len);
 
 /*
  * ngtcp2_encode_ipv4_cstr encodes binary form IPv4 address stored in
@@ -67,7 +67,7 @@ uint8_t *ngtcp2_encode_hex_cstr(uint8_t *dest, const uint8_t *data, size_t len);
  * plus a terminating NULL byte.  The resulting text form ends with
  * NULL byte.  The function returns |dest|.
  */
-uint8_t *ngtcp2_encode_ipv4_cstr(uint8_t *dest, const uint8_t *addr);
+char *ngtcp2_encode_ipv4_cstr(char *dest, const uint8_t *addr);
 
 /*
  * ngtcp2_encode_ipv6_cstr encodes binary form IPv6 address stored in
@@ -79,7 +79,7 @@ uint8_t *ngtcp2_encode_ipv4_cstr(uint8_t *dest, const uint8_t *addr);
  * https://tools.ietf.org/html/rfc5952#section-4.  The function
  * returns |dest|.
  */
-uint8_t *ngtcp2_encode_ipv6_cstr(uint8_t *dest, const uint8_t *addr);
+char *ngtcp2_encode_ipv6_cstr(char *dest, const uint8_t *addr);
 
 /*
  * ngtcp2_encode_printable_ascii encodes |data| of length |len| in

--- a/tests/ngtcp2_str_test.c
+++ b/tests/ngtcp2_str_test.c
@@ -44,48 +44,48 @@ const MunitSuite str_suite = {
 };
 
 void test_ngtcp2_encode_ipv4_cstr(void) {
-  uint8_t buf[16];
+  char buf[16];
 
-  assert_string_equal("192.168.0.1",
-                      (const char *)ngtcp2_encode_ipv4_cstr(
-                        buf, (const uint8_t *)"\xc0\xa8\x00\x01"));
-  assert_string_equal("127.0.0.1", (const char *)ngtcp2_encode_ipv4_cstr(
+  assert_string_equal(
+    "192.168.0.1",
+    ngtcp2_encode_ipv4_cstr(buf, (const uint8_t *)"\xc0\xa8\x00\x01"));
+  assert_string_equal("127.0.0.1", ngtcp2_encode_ipv4_cstr(
                                      buf, (const uint8_t *)"\x7f\x00\x00\x01"));
 }
 
 void test_ngtcp2_encode_ipv6_cstr(void) {
-  uint8_t buf[32 + 7 + 1];
+  char buf[32 + 7 + 1];
 
   assert_string_equal("2001:db8::2:1",
-                      (const char *)ngtcp2_encode_ipv6_cstr(
+                      ngtcp2_encode_ipv6_cstr(
                         buf,
                         (const uint8_t *)"\x20\x01\x0d\xb8\x00\x00\x00\x00\x00"
                                          "\x00\x00\x00\x00\x02\x00\x01"));
   assert_string_equal("2001:db8:0:1:1:1:1:1",
-                      (const char *)ngtcp2_encode_ipv6_cstr(
+                      ngtcp2_encode_ipv6_cstr(
                         buf,
                         (const uint8_t *)"\x20\x01\x0d\xb8\x00\x00\x00\x01\x00"
                                          "\x01\x00\x01\x00\x01\x00\x01"));
   assert_string_equal("2001:db8::1:0:0:1",
-                      (const char *)ngtcp2_encode_ipv6_cstr(
+                      ngtcp2_encode_ipv6_cstr(
                         buf,
                         (const uint8_t *)"\x20\x01\x0d\xb8\x00\x00\x00\x00\x00"
                                          "\x01\x00\x00\x00\x00\x00\x01"));
   assert_string_equal("2001:db8::8:800:200c:417a",
-                      (const char *)ngtcp2_encode_ipv6_cstr(
+                      ngtcp2_encode_ipv6_cstr(
                         buf,
                         (const uint8_t *)"\x20\x01\x0d\xb8\x00\x00\x00\x00\x00"
                                          "\x08\x08\x00\x20\x0C\x41\x7a"));
   assert_string_equal(
-    "ff01::101", (const char *)ngtcp2_encode_ipv6_cstr(
+    "ff01::101", ngtcp2_encode_ipv6_cstr(
                    buf, (const uint8_t *)"\xff\x01\x00\x00\x00\x00\x00\x00\x00"
                                          "\x00\x00\x00\x00\x00\x01\x01"));
   assert_string_equal(
-    "::1", (const char *)ngtcp2_encode_ipv6_cstr(
+    "::1", ngtcp2_encode_ipv6_cstr(
              buf, (const uint8_t *)"\x00\x00\x00\x00\x00\x00\x00\x00\x00"
                                    "\x00\x00\x00\x00\x00\x00\x01"));
   assert_string_equal(
-    "::", (const char *)ngtcp2_encode_ipv6_cstr(
+    "::", ngtcp2_encode_ipv6_cstr(
             buf, (const uint8_t *)"\x00\x00\x00\x00\x00\x00\x00\x00\x00"
                                   "\x00\x00\x00\x00\x00\x00\x00"));
 }


### PR DESCRIPTION
Use char buffer for functions that return C string.  Mixing char and uint8_t (unsigned char) is a mess.  We limit char buffer for those functions that return C string.