### PR TITLE
Fix warning C2220 in pcg_rotr_32

### DIFF
--- a/lib/ngtcp2_pcg.c
+++ b/lib/ngtcp2_pcg.c
@@ -66,7 +66,7 @@ void ngtcp2_pcg32_init(ngtcp2_pcg32 *pcg, uint64_t seed) {
 }
 
 static uint32_t pcg_rotr_32(uint32_t value, unsigned int rot) {
-  return (value >> rot) | (value << ((0 - rot) & 31));
+  return (value >> rot) | (value << ((32 - rot) & 31));
 }
 
 static uint32_t pcg_output_xsh_rr_64_32(uint64_t state) {


### PR DESCRIPTION
ngtcp2\lib\ngtcp2_pcg.c(69): warning C4146: unary minus operator applied to unsigned type, result still unsigned