### PR TITLE
examples: Avoid tx buffer being value-initialized

### DIFF
--- a/examples/client.cc
+++ b/examples/client.cc
@@ -1160,7 +1160,7 @@ int Client::write_streams() {
   ngtcp2_pkt_info pi;
   size_t gso_size;
   auto ts = util::timestamp();
-  auto txbuf = std::span{tx_.data};
+  auto txbuf = std::span{txbuf_};
   auto buflen = util::clamp_buffer_size(conn_, txbuf.size(), config.gso_burst);
 
   ngtcp2_path_storage_zero(&ps);

--- a/examples/client.h
+++ b/examples/client.h
@@ -191,8 +191,8 @@ private:
       std::span<const uint8_t> data;
       size_t gso_size;
     } blocked;
-    std::array<uint8_t, 64_k> data;
   } tx_;
+  std::array<uint8_t, 64_k> txbuf_;
 };
 
 #endif // !defined(CLIENT_H)

--- a/examples/h09client.cc
+++ b/examples/h09client.cc
@@ -1060,7 +1060,7 @@ int Client::write_streams() {
   ngtcp2_pkt_info pi;
   size_t gso_size;
   auto ts = util::timestamp();
-  auto txbuf = std::span{tx_.data};
+  auto txbuf = std::span{txbuf_};
   auto buflen = util::clamp_buffer_size(conn_, txbuf.size(), config.gso_burst);
 
   ngtcp2_path_storage_zero(&ps);

--- a/examples/h09client.h
+++ b/examples/h09client.h
@@ -195,8 +195,8 @@ private:
       std::span<const uint8_t> data;
       size_t gso_size;
     } blocked;
-    std::array<uint8_t, 64_k> data;
   } tx_;
+  std::array<uint8_t, 64_k> txbuf_;
 };
 
 #endif // !defined(H09CLIENT_H)

--- a/examples/h09server.cc
+++ b/examples/h09server.cc
@@ -71,10 +71,6 @@ constexpr size_t NGTCP2_STATELESS_RESET_BURST = 100;
 } // namespace
 
 namespace {
-constexpr size_t NGTCP2_TX_BUFLEN = 64_k;
-} // namespace
-
-namespace {
 auto randgen = util::make_mt19937();
 } // namespace
 
@@ -351,9 +347,7 @@ Handler::Handler(struct ev_loop *loop, Server *server)
     close_wait_{
       .next_pkts_recv = 1,
     },
-    tx_{
-      .data = std::make_unique_for_overwrite<uint8_t[]>(NGTCP2_TX_BUFLEN),
-    } {
+    tx_{} {
   ev_io_init(&wev_, writecb, 0, EV_WRITE);
   wev_.data = this;
   ev_timer_init(&timer_, timeoutcb, 0., 0.);
@@ -1027,7 +1021,7 @@ int Handler::write_streams() {
   ngtcp2_pkt_info pi;
   size_t gso_size;
   auto ts = util::timestamp();
-  auto txbuf = std::span{tx_.data.get(), NGTCP2_TX_BUFLEN};
+  auto txbuf = std::span{txbuf_};
   auto buflen = util::clamp_buffer_size(conn_, txbuf.size(), config.gso_burst);
 
   ngtcp2_path_storage_zero(&ps);

--- a/examples/h09server.h
+++ b/examples/h09server.h
@@ -195,8 +195,8 @@ private:
       std::span<const uint8_t> data;
       size_t gso_size;
     } blocked;
-    std::unique_ptr<uint8_t[]> data;
   } tx_;
+  std::array<uint8_t, 64_k> txbuf_;
 };
 
 class Server {

--- a/examples/server.cc
+++ b/examples/server.cc
@@ -70,10 +70,6 @@ constexpr size_t NGTCP2_STATELESS_RESET_BURST = 100;
 } // namespace
 
 namespace {
-constexpr size_t NGTCP2_TX_BUFLEN = 64_k;
-} // namespace
-
-namespace {
 auto randgen = util::make_mt19937();
 } // namespace
 
@@ -651,9 +647,7 @@ Handler::Handler(struct ev_loop *loop, Server *server)
     close_wait_{
       .next_pkts_recv = 1,
     },
-    tx_{
-      .data = std::make_unique_for_overwrite<uint8_t[]>(NGTCP2_TX_BUFLEN),
-    } {
+    tx_{} {
   ev_io_init(&wev_, writecb, 0, EV_WRITE);
   wev_.data = this;
   ev_timer_init(&timer_, timeoutcb, 0., 0.);
@@ -1785,7 +1779,7 @@ int Handler::write_streams() {
   ngtcp2_pkt_info pi;
   size_t gso_size;
   auto ts = util::timestamp();
-  auto txbuf = std::span{tx_.data.get(), NGTCP2_TX_BUFLEN};
+  auto txbuf = std::span{txbuf_};
   auto buflen = util::clamp_buffer_size(conn_, txbuf.size(), config.gso_burst);
 
   ngtcp2_path_storage_zero(&ps);

--- a/examples/server.h
+++ b/examples/server.h
@@ -214,8 +214,8 @@ private:
       std::span<const uint8_t> data;
       size_t gso_size;
     } blocked;
-    std::unique_ptr<uint8_t[]> data;
   } tx_;
+  std::array<uint8_t, 64_k> txbuf_;
 };
 
 class Server {


### PR DESCRIPTION
For server, embed tx buffer to Handler to avoid the extra allocation.