### PR TITLE
Raise glitch counter initial limits

### DIFF
--- a/lib/includes/ngtcp2/ngtcp2.h
+++ b/lib/includes/ngtcp2/ngtcp2.h
@@ -5916,9 +5916,9 @@ NGTCP2_EXTERN void ngtcp2_path_storage_zero(ngtcp2_path_storage *ps);
  * * :member:`handshake_timeout <ngtcp2_settings.handshake_timeout>` =
  *   ``UINT64_MAX``
  * * :member:`glitch_ratelim_burst
- *   <ngtcp2_settings.glitch_ratelim_burst>` = 1000
+ *   <ngtcp2_settings.glitch_ratelim_burst>` = 4000
  * * :member:`glitch_ratelim_rate
- *   <ngtcp2_settings.glitch_ratelim_rate>` = 33
+ *   <ngtcp2_settings.glitch_ratelim_rate>` = 132
  */
 NGTCP2_EXTERN void ngtcp2_settings_default_versioned(int settings_version,
                                                      ngtcp2_settings *settings);

--- a/lib/ngtcp2_settings.h
+++ b/lib/ngtcp2_settings.h
@@ -33,10 +33,10 @@
 
 /* NGTCP2_DEFAULT_GLITCH_RATELIM_BURST is the maximum number of tokens
    in glitch rate limiter.  It is also the initial value. */
-#define NGTCP2_DEFAULT_GLITCH_RATELIM_BURST 1000
+#define NGTCP2_DEFAULT_GLITCH_RATELIM_BURST 4000
 /* NGTCP2_DEFAULT_GLITCH_RATELIM_RATE is the rate of tokens generated
    per second for glitch rate limiter. */
-#define NGTCP2_DEFAULT_GLITCH_RATELIM_RATE 33
+#define NGTCP2_DEFAULT_GLITCH_RATELIM_RATE 132
 
 /*
  * ngtcp2_settings_convert_to_latest converts |src| of version


### PR DESCRIPTION
The previous limits seem too low.  Let make them 4x, and see whether they fly or not.

See #1850