### PR TITLE
Set NULL to ngtcp2_conn if its initialization fails

### DIFF
--- a/lib/ngtcp2_conn.c
+++ b/lib/ngtcp2_conn.c
@@ -1527,6 +1527,8 @@ fail_seqgap_push:
 fail_token:
   ngtcp2_mem_free(mem, *pconn);
 
+  *pconn = NULL;
+
   return rv;
 }
 
@@ -1554,6 +1556,8 @@ int ngtcp2_conn_client_new_versioned(
   rv = ngtcp2_conn_commit_local_transport_params(*pconn);
   if (rv != 0) {
     ngtcp2_conn_del(*pconn);
+    *pconn = NULL;
+
     return rv;
   }
 


### PR DESCRIPTION
Set NULL to ngtcp2_conn so that caller can still call ngtcp2_conn_del safely.