### PR TITLE
Update RTT when the largest packet number is acked

### DIFF
--- a/lib/ngtcp2_rtb.c
+++ b/lib/ngtcp2_rtb.c
@@ -851,7 +851,7 @@ ngtcp2_ssize ngtcp2_rtb_recv_ack(ngtcp2_rtb *rtb, const ngtcp2_ack *fr,
       goto fail;
     }
 
-    if (largest_ack == pkt_num) {
+    if (rtb->largest_acked_tx_pkt_num == pkt_num) {
       cc_ack.largest_pkt_sent_ts = ent->ts;
     }
 


### PR DESCRIPTION
This avoids inflating RTT due to packet reordering.