### PR TITLE
acktr: Refactor ACK creation function

### DIFF
--- a/lib/ngtcp2_acktr.c
+++ b/lib/ngtcp2_acktr.c
@@ -337,16 +337,14 @@ void ngtcp2_acktr_immediate_ack(ngtcp2_acktr *acktr) {
   acktr->flags |= NGTCP2_ACKTR_FLAG_IMMEDIATE_ACK;
 }
 
-ngtcp2_frame *ngtcp2_acktr_create_ack_frame(ngtcp2_acktr *acktr,
-                                            ngtcp2_frame *fr, uint8_t type,
-                                            ngtcp2_tstamp ts,
-                                            ngtcp2_duration ack_delay,
-                                            uint64_t ack_delay_exponent) {
+int ngtcp2_acktr_create_ack_frame(ngtcp2_acktr *acktr, ngtcp2_ack *ack,
+                                  uint8_t type, ngtcp2_tstamp ts,
+                                  ngtcp2_duration ack_delay,
+                                  uint64_t ack_delay_exponent) {
   int64_t last_pkt_num;
   ngtcp2_ack_range *range;
   ngtcp2_ksl_it it;
   ngtcp2_acktr_entry *rpkt;
-  ngtcp2_ack *ack = &fr->ack;
   ngtcp2_tstamp largest_ack_ts;
   size_t num_acks;
 
@@ -355,13 +353,13 @@ ngtcp2_frame *ngtcp2_acktr_create_ack_frame(ngtcp2_acktr *acktr,
   }
 
   if (!ngtcp2_acktr_require_active_ack(acktr, ack_delay, ts)) {
-    return NULL;
+    return -1;
   }
 
   it = ngtcp2_acktr_get(acktr);
   if (ngtcp2_ksl_it_end(&it)) {
     ngtcp2_acktr_commit_ack(acktr);
-    return NULL;
+    return -1;
   }
 
   num_acks = ngtcp2_ksl_len(&acktr->ents);
@@ -424,7 +422,7 @@ ngtcp2_frame *ngtcp2_acktr_create_ack_frame(ngtcp2_acktr *acktr,
     last_pkt_num = rpkt->pkt_num - (int64_t)(rpkt->len - 1);
   }
 
-  return fr;
+  return 0;
 }
 
 void ngtcp2_acktr_increase_ecn_counts(ngtcp2_acktr *acktr,

--- a/lib/ngtcp2_acktr.h
+++ b/lib/ngtcp2_acktr.h
@@ -235,19 +235,18 @@ void ngtcp2_acktr_immediate_ack(ngtcp2_acktr *acktr);
 
 /*
  * ngtcp2_acktr_create_ack_frame creates ACK frame in the object
- * pointed by |fr|, and returns |fr| if there are any received packets
- * to acknowledge.  If there are no packets to acknowledge, this
- * function returns NULL.  fr->ack.ranges must be able to contain at
+ * pointed by |ack|, and returns 0 if it successfully creates ACK
+ * frame in |ack|.  If there are no packets to acknowledge, this
+ * function returns -1.  |ack|->ranges must be able to contain at
  * least NGTCP2_MAX_ACK_RANGES elements.
  *
  * Call ngtcp2_acktr_commit_ack after a created ACK frame is
  * successfully serialized into a packet.
  */
-ngtcp2_frame *ngtcp2_acktr_create_ack_frame(ngtcp2_acktr *acktr,
-                                            ngtcp2_frame *fr, uint8_t type,
-                                            ngtcp2_tstamp ts,
-                                            ngtcp2_duration ack_delay,
-                                            uint64_t ack_delay_exponent);
+int ngtcp2_acktr_create_ack_frame(ngtcp2_acktr *acktr, ngtcp2_ack *ack,
+                                  uint8_t type, ngtcp2_tstamp ts,
+                                  ngtcp2_duration ack_delay,
+                                  uint64_t ack_delay_exponent);
 
 /*
  * ngtcp2_acktr_increase_ecn_counts increases ECN counts from |pi|.

--- a/tests/ngtcp2_acktr_test.c
+++ b/tests/ngtcp2_acktr_test.c
@@ -441,6 +441,7 @@ void test_ngtcp2_acktr_create_ack_frame(void) {
   ngtcp2_frame fr;
   ngtcp2_pkt_info pi = {0};
   size_t i;
+  int rv;
 
   ngtcp2_log_init(&log, NULL, NULL, 0, NULL);
 
@@ -460,9 +461,9 @@ void test_ngtcp2_acktr_create_ack_frame(void) {
   assert_uint64(0, ==, acktr.first_unacked_ts);
 
   fr.ack.ranges = ack_ranges;
+  rv = ngtcp2_acktr_create_ack_frame(&acktr, &fr.ack, NGTCP2_PKT_1RTT, 0, 0, 0);
 
-  assert_null(
-    ngtcp2_acktr_create_ack_frame(&acktr, &fr, NGTCP2_PKT_1RTT, 0, 0, 0));
+  assert_int(-1, ==, rv);
   assert_uint64(UINT64_MAX, ==, acktr.first_unacked_ts);
 
   ngtcp2_acktr_free(&acktr);
@@ -487,9 +488,12 @@ void test_ngtcp2_acktr_create_ack_frame(void) {
   ngtcp2_acktr_increase_ecn_counts(&acktr, &pi);
   ngtcp2_acktr_increase_ecn_counts(&acktr, &pi);
 
-  assert_not_null(ngtcp2_acktr_create_ack_frame(&acktr, &fr, NGTCP2_PKT_1RTT,
-                                                30 * NGTCP2_MILLISECONDS,
-                                                25 * NGTCP2_MILLISECONDS, 2));
+  fr.ack.ranges = ack_ranges;
+  rv = ngtcp2_acktr_create_ack_frame(&acktr, &fr.ack, NGTCP2_PKT_1RTT,
+                                     30 * NGTCP2_MILLISECONDS,
+                                     25 * NGTCP2_MILLISECONDS, 2);
+
+  assert_int(0, ==, rv);
   assert_uint64(NGTCP2_FRAME_ACK_ECN, ==, fr.ack.type);
   assert_uint64(1, ==, fr.ack.ecn.ect0);
   assert_uint64(2, ==, fr.ack.ecn.ect1);
@@ -509,9 +513,13 @@ void test_ngtcp2_acktr_create_ack_frame(void) {
   }
 
   assert_size(NGTCP2_ACKTR_MAX_ENT, ==, ngtcp2_ksl_len(&acktr.ents));
-  assert_not_null(ngtcp2_acktr_create_ack_frame(&acktr, &fr, NGTCP2_PKT_1RTT,
-                                                30 * NGTCP2_MILLISECONDS,
-                                                30 * NGTCP2_MILLISECONDS, 0));
+
+  fr.ack.ranges = ack_ranges;
+  rv = ngtcp2_acktr_create_ack_frame(&acktr, &fr.ack, NGTCP2_PKT_1RTT,
+                                     30 * NGTCP2_MILLISECONDS,
+                                     30 * NGTCP2_MILLISECONDS, 0);
+
+  assert_int(0, ==, rv);
   assert_int64(2 * (NGTCP2_MAX_ACK_RANGES + 1), ==, fr.ack.largest_ack);
   assert_uint64(0, ==, fr.ack.first_ack_range);
   assert_size(NGTCP2_MAX_ACK_RANGES, ==, fr.ack.rangecnt);
@@ -530,9 +538,13 @@ void test_ngtcp2_acktr_create_ack_frame(void) {
   ++acktr.max_pkt_num;
 
   assert_size(NGTCP2_ACKTR_MAX_ENT, ==, ngtcp2_ksl_len(&acktr.ents));
-  assert_not_null(ngtcp2_acktr_create_ack_frame(&acktr, &fr, NGTCP2_PKT_1RTT,
-                                                30 * NGTCP2_MILLISECONDS,
-                                                30 * NGTCP2_MILLISECONDS, 0));
+
+  fr.ack.ranges = ack_ranges;
+  rv = ngtcp2_acktr_create_ack_frame(&acktr, &fr.ack, NGTCP2_PKT_1RTT,
+                                     30 * NGTCP2_MILLISECONDS,
+                                     30 * NGTCP2_MILLISECONDS, 0);
+
+  assert_int(0, ==, rv);
   assert_int64(2 * (NGTCP2_MAX_ACK_RANGES + 1) + 1, ==, fr.ack.largest_ack);
   assert_uint64(1, ==, fr.ack.first_ack_range);
   assert_size(NGTCP2_MAX_ACK_RANGES, ==, fr.ack.rangecnt);
@@ -551,9 +563,13 @@ void test_ngtcp2_acktr_create_ack_frame(void) {
   acktr.max_pkt_num += 2;
 
   assert_size(NGTCP2_ACKTR_MAX_ENT, ==, ngtcp2_ksl_len(&acktr.ents));
-  assert_not_null(ngtcp2_acktr_create_ack_frame(&acktr, &fr, NGTCP2_PKT_1RTT,
-                                                30 * NGTCP2_MILLISECONDS,
-                                                30 * NGTCP2_MILLISECONDS, 0));
+
+  fr.ack.ranges = ack_ranges;
+  rv = ngtcp2_acktr_create_ack_frame(&acktr, &fr.ack, NGTCP2_PKT_1RTT,
+                                     30 * NGTCP2_MILLISECONDS,
+                                     30 * NGTCP2_MILLISECONDS, 0);
+
+  assert_int(0, ==, rv);
   assert_int64(2 * (NGTCP2_MAX_ACK_RANGES + 1) + 2, ==, fr.ack.largest_ack);
   assert_uint64(0, ==, fr.ack.first_ack_range);
   assert_size(NGTCP2_MAX_ACK_RANGES, ==, fr.ack.rangecnt);

--- a/tests/ngtcp2_conn_test.c
+++ b/tests/ngtcp2_conn_test.c
@@ -15317,9 +15317,10 @@ void test_ngtcp2_conn_create_ack_frame(void) {
   setup_default_server(&conn);
 
   fr.ack.ranges = ack_ranges;
+  rv = ngtcp2_acktr_create_ack_frame(&conn->pktns.acktr, &fr.ack,
+                                     NGTCP2_PKT_1RTT, 0, 0, 0);
 
-  assert_null(ngtcp2_acktr_create_ack_frame(&conn->pktns.acktr, &fr,
-                                            NGTCP2_PKT_1RTT, 0, 0, 0));
+  assert_int(-1, ==, rv);
 
   ngtcp2_conn_del(conn);
 
@@ -15340,9 +15341,10 @@ void test_ngtcp2_conn_create_ack_frame(void) {
 
   /* PADDING does not elicit ACK */
   fr.ack.ranges = ack_ranges;
+  rv = ngtcp2_acktr_create_ack_frame(&conn->pktns.acktr, &fr.ack,
+                                     NGTCP2_PKT_1RTT, 0, 0, 0);
 
-  assert_null(ngtcp2_acktr_create_ack_frame(&conn->pktns.acktr, &fr,
-                                            NGTCP2_PKT_1RTT, 0, 0, 0));
+  assert_int(-1, ==, rv);
 
   fr.ping.type = NGTCP2_FRAME_PING;
 
@@ -15354,17 +15356,19 @@ void test_ngtcp2_conn_create_ack_frame(void) {
 
   /* PING elicits ACK, but ACK is not generated due to ack delay. */
   fr.ack.ranges = ack_ranges;
+  rv =
+    ngtcp2_acktr_create_ack_frame(&conn->pktns.acktr, &fr.ack, NGTCP2_PKT_1RTT,
+                                  0, 25 * NGTCP2_MILLISECONDS, 0);
 
-  assert_null(ngtcp2_acktr_create_ack_frame(
-    &conn->pktns.acktr, &fr, NGTCP2_PKT_1RTT, 0, 25 * NGTCP2_MILLISECONDS, 0));
+  assert_int(-1, ==, rv);
 
   /* ACK delay passed. */
   fr.ack.ranges = ack_ranges;
+  rv = ngtcp2_acktr_create_ack_frame(
+    &conn->pktns.acktr, &fr.ack, NGTCP2_PKT_1RTT, 25 * NGTCP2_MILLISECONDS,
+    25 * NGTCP2_MILLISECONDS, NGTCP2_DEFAULT_ACK_DELAY_EXPONENT);
 
-  assert_not_null(ngtcp2_acktr_create_ack_frame(
-    &conn->pktns.acktr, &fr, NGTCP2_PKT_1RTT, 25 * NGTCP2_MILLISECONDS,
-    25 * NGTCP2_MILLISECONDS, NGTCP2_DEFAULT_ACK_DELAY_EXPONENT));
-
+  assert_int(0, ==, rv);
   assert_int64(1, ==, fr.ack.largest_ack);
   assert_uint64(1, ==, fr.ack.first_ack_range);
   assert_uint64(25 * NGTCP2_MILLISECONDS, ==, fr.ack.ack_delay_unscaled);
@@ -15390,10 +15394,11 @@ void test_ngtcp2_conn_create_ack_frame(void) {
   assert_int(0, ==, rv);
 
   fr.ack.ranges = ack_ranges;
+  rv = ngtcp2_acktr_create_ack_frame(
+    &conn->pktns.acktr, &fr.ack, NGTCP2_PKT_1RTT, 25 * NGTCP2_MILLISECONDS,
+    25 * NGTCP2_MILLISECONDS, NGTCP2_DEFAULT_ACK_DELAY_EXPONENT);
 
-  assert_not_null(ngtcp2_acktr_create_ack_frame(
-    &conn->pktns.acktr, &fr, NGTCP2_PKT_1RTT, 25 * NGTCP2_MILLISECONDS,
-    25 * NGTCP2_MILLISECONDS, NGTCP2_DEFAULT_ACK_DELAY_EXPONENT));
+  assert_int(0, ==, rv);
   assert_int64(1, ==, fr.ack.largest_ack);
   assert_uint64(0, ==, fr.ack.first_ack_range);
   assert_uint64(25 * NGTCP2_MILLISECONDS, ==, fr.ack.ack_delay_unscaled);
@@ -15419,10 +15424,11 @@ void test_ngtcp2_conn_create_ack_frame(void) {
   assert_int(0, ==, rv);
 
   fr.ack.ranges = ack_ranges;
+  rv = ngtcp2_acktr_create_ack_frame(
+    &conn->pktns.acktr, &fr.ack, NGTCP2_PKT_1RTT, 25 * NGTCP2_MILLISECONDS,
+    25 * NGTCP2_MILLISECONDS, NGTCP2_DEFAULT_ACK_DELAY_EXPONENT);
 
-  assert_not_null(ngtcp2_acktr_create_ack_frame(
-    &conn->pktns.acktr, &fr, NGTCP2_PKT_1RTT, 25 * NGTCP2_MILLISECONDS,
-    25 * NGTCP2_MILLISECONDS, NGTCP2_DEFAULT_ACK_DELAY_EXPONENT));
+  assert_int(0, ==, rv);
   assert_int64(1, ==, fr.ack.largest_ack);
   assert_uint64(1, ==, fr.ack.first_ack_range);
   assert_uint64(25 * NGTCP2_MILLISECONDS, ==, fr.ack.ack_delay_unscaled);
@@ -15448,10 +15454,11 @@ void test_ngtcp2_conn_create_ack_frame(void) {
   assert_int(0, ==, rv);
 
   fr.ack.ranges = ack_ranges;
+  rv = ngtcp2_acktr_create_ack_frame(
+    &conn->pktns.acktr, &fr.ack, NGTCP2_PKT_1RTT, 25 * NGTCP2_MILLISECONDS,
+    25 * NGTCP2_MILLISECONDS, NGTCP2_DEFAULT_ACK_DELAY_EXPONENT);
 
-  assert_not_null(ngtcp2_acktr_create_ack_frame(
-    &conn->pktns.acktr, &fr, NGTCP2_PKT_1RTT, 25 * NGTCP2_MILLISECONDS,
-    25 * NGTCP2_MILLISECONDS, NGTCP2_DEFAULT_ACK_DELAY_EXPONENT));
+  assert_int(0, ==, rv);
   assert_int64(10, ==, fr.ack.largest_ack);
   assert_uint64(0, ==, fr.ack.first_ack_range);
   assert_uint64(25 * NGTCP2_MILLISECONDS, ==, fr.ack.ack_delay_unscaled);
@@ -15500,11 +15507,11 @@ void test_ngtcp2_conn_create_ack_frame(void) {
   assert_int(0, ==, rv);
 
   fr.ack.ranges = ack_ranges;
+  rv = ngtcp2_acktr_create_ack_frame(
+    &conn->pktns.acktr, &fr.ack, NGTCP2_PKT_1RTT, 25 * NGTCP2_MILLISECONDS,
+    25 * NGTCP2_MILLISECONDS, NGTCP2_DEFAULT_ACK_DELAY_EXPONENT);
 
-  assert_not_null(ngtcp2_acktr_create_ack_frame(
-    &conn->pktns.acktr, &fr, NGTCP2_PKT_1RTT, 25 * NGTCP2_MILLISECONDS,
-    25 * NGTCP2_MILLISECONDS, NGTCP2_DEFAULT_ACK_DELAY_EXPONENT));
-
+  assert_int(0, ==, rv);
   assert_int64(10, ==, fr.ack.largest_ack);
   assert_uint64(1, ==, fr.ack.first_ack_range);
   assert_uint64(25 * NGTCP2_MILLISECONDS, ==, fr.ack.ack_delay_unscaled);
@@ -15538,10 +15545,11 @@ void test_ngtcp2_conn_create_ack_frame(void) {
   assert_int(0, ==, rv);
 
   fr.ack.ranges = ack_ranges;
+  rv = ngtcp2_acktr_create_ack_frame(
+    &conn->pktns.acktr, &fr.ack, NGTCP2_PKT_1RTT, 25 * NGTCP2_MILLISECONDS,
+    25 * NGTCP2_MILLISECONDS, NGTCP2_DEFAULT_ACK_DELAY_EXPONENT);
 
-  assert_not_null(ngtcp2_acktr_create_ack_frame(
-    &conn->pktns.acktr, &fr, NGTCP2_PKT_1RTT, 25 * NGTCP2_MILLISECONDS,
-    25 * NGTCP2_MILLISECONDS, NGTCP2_DEFAULT_ACK_DELAY_EXPONENT));
+  assert_int(0, ==, rv);
   assert_int64(10, ==, fr.ack.largest_ack);
   assert_uint64(0, ==, fr.ack.first_ack_range);
   assert_uint64(25 * NGTCP2_MILLISECONDS, ==, fr.ack.ack_delay_unscaled);
@@ -15570,10 +15578,11 @@ void test_ngtcp2_conn_create_ack_frame(void) {
   }
 
   fr.ack.ranges = ack_ranges;
+  rv = ngtcp2_acktr_create_ack_frame(
+    &conn->pktns.acktr, &fr.ack, NGTCP2_PKT_1RTT, 25 * NGTCP2_MILLISECONDS,
+    25 * NGTCP2_MILLISECONDS, NGTCP2_DEFAULT_ACK_DELAY_EXPONENT);
 
-  assert_not_null(ngtcp2_acktr_create_ack_frame(
-    &conn->pktns.acktr, &fr, NGTCP2_PKT_1RTT, 25 * NGTCP2_MILLISECONDS,
-    25 * NGTCP2_MILLISECONDS, NGTCP2_DEFAULT_ACK_DELAY_EXPONENT));
+  assert_int(0, ==, rv);
   assert_int64(10, ==, fr.ack.largest_ack);
   assert_uint64(0, ==, fr.ack.first_ack_range);
   assert_uint64(25 * NGTCP2_MILLISECONDS, ==, fr.ack.ack_delay_unscaled);
@@ -15604,10 +15613,11 @@ void test_ngtcp2_conn_create_ack_frame(void) {
   }
 
   fr.ack.ranges = ack_ranges;
+  rv = ngtcp2_acktr_create_ack_frame(
+    &conn->pktns.acktr, &fr.ack, NGTCP2_PKT_1RTT, 25 * NGTCP2_MILLISECONDS,
+    25 * NGTCP2_MILLISECONDS, NGTCP2_DEFAULT_ACK_DELAY_EXPONENT);
 
-  assert_not_null(ngtcp2_acktr_create_ack_frame(
-    &conn->pktns.acktr, &fr, NGTCP2_PKT_1RTT, 25 * NGTCP2_MILLISECONDS,
-    25 * NGTCP2_MILLISECONDS, NGTCP2_DEFAULT_ACK_DELAY_EXPONENT));
+  assert_int(0, ==, rv);
   assert_int64(66, ==, fr.ack.largest_ack);
   assert_uint64(0, ==, fr.ack.first_ack_range);
   assert_uint64(25 * NGTCP2_MILLISECONDS, ==, fr.ack.ack_delay_unscaled);
@@ -15646,10 +15656,11 @@ void test_ngtcp2_conn_create_ack_frame(void) {
   assert_int(0, ==, rv);
 
   fr.ack.ranges = ack_ranges;
+  rv = ngtcp2_acktr_create_ack_frame(
+    &conn->pktns.acktr, &fr.ack, NGTCP2_PKT_1RTT, 0, 25 * NGTCP2_MILLISECONDS,
+    NGTCP2_DEFAULT_ACK_DELAY_EXPONENT);
 
-  assert_not_null(ngtcp2_acktr_create_ack_frame(
-    &conn->pktns.acktr, &fr, NGTCP2_PKT_1RTT, 0, 25 * NGTCP2_MILLISECONDS,
-    NGTCP2_DEFAULT_ACK_DELAY_EXPONENT));
+  assert_int(0, ==, rv);
   assert_int64(1, ==, fr.ack.largest_ack);
   assert_uint64(1, ==, fr.ack.first_ack_range);
   assert_uint64(0, ==, fr.ack.ack_delay_unscaled);
@@ -15686,10 +15697,11 @@ void test_ngtcp2_conn_create_ack_frame(void) {
   assert_int(0, ==, rv);
 
   fr.ack.ranges = ack_ranges;
+  rv = ngtcp2_acktr_create_ack_frame(
+    &conn->pktns.acktr, &fr.ack, NGTCP2_PKT_1RTT, 0, 25 * NGTCP2_MILLISECONDS,
+    NGTCP2_DEFAULT_ACK_DELAY_EXPONENT);
 
-  assert_not_null(ngtcp2_acktr_create_ack_frame(
-    &conn->pktns.acktr, &fr, NGTCP2_PKT_1RTT, 0, 25 * NGTCP2_MILLISECONDS,
-    NGTCP2_DEFAULT_ACK_DELAY_EXPONENT));
+  assert_int(0, ==, rv);
   assert_int64(2, ==, fr.ack.largest_ack);
   assert_uint64(0, ==, fr.ack.first_ack_range);
   assert_uint64(0, ==, fr.ack.ack_delay_unscaled);


### PR DESCRIPTION
- Return int to indicate success or failure
- Take ngtcp2_ack instead of ngtcp2_frame