### PR TITLE
examples: Fix linker error in examplestest by adding shared.cc dependency

### DIFF
--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -262,6 +262,7 @@ check_PROGRAMS = examplestest
 examplestest_SOURCES = examplestest.cc \
 	util_test.cc util_test.h util.cc util.h \
 	siphash_test.cc siphash_test.h siphash.cc siphash.h \
+	shared.cc shared.h \
 	siphash_vector.h \
 	$(top_srcdir)/tests/munit/munit.c $(top_srcdir)/tests/munit/munit.h
 examplestest_CPPFLAGS = ${AM_CPPFLAGS} -I$(top_srcdir)/tests/munit \
@@ -272,7 +273,6 @@ if ENABLE_EXAMPLE_WOLFSSL
 examplestest_SOURCES += \
 	sim.cc sim.h \
 	sim_test.cc sim_test.h \
-	shared.cc shared.h \
 	debug.cc debug.h
 examplestest_CPPFLAGS += @WOLFSSL_CFLAGS@ -DWITH_EXAMPLE_WOLFSSL
 examplestest_LDADD += \


### PR DESCRIPTION
Fix undefined reference errors when building examplestest target

The examplestest target was failing to link due to missing Address class
method implementations (size() and as_sockaddr()) that are called from
util.cc. These methods are implemented in shared.cc but were not included
in the examplestest_SOURCES.

Changes:
- Add shared.cc and shared.h to examplestest_SOURCES 
- Remove duplicate shared.cc/shared.h from ENABLE_EXAMPLE_WOLFSSL section
  to avoid build conflicts

This aligns examplestest with other targets (qtlsclient, qtlsserver, etc.)
that already include shared.cc through SERVER_SRCS or CLIENT_SRCS.

Fixes linker errors:
  undefined reference to `ngtcp2::Address::size() const'
  undefined reference to `ngtcp2::Address::as_sockaddr() const'