### PR TITLE
ngtcp2_ksl: Remove alignment enforcement for keys

### DIFF
--- a/lib/ngtcp2_ksl.h
+++ b/lib/ngtcp2_ksl.h
@@ -84,7 +84,7 @@ struct ngtcp2_ksl_blk {
          NGTCP2_KSL_MAX_NBLK keys.  Because the length of key is
          unknown until ngtcp2_ksl_init is called, the actual buffer
          will be allocated after this field. */
-      NGTCP2_ALIGN(8) uint8_t *keys;
+      uint8_t *keys;
     };
 
     ngtcp2_opl_entry oplent;


### PR DESCRIPTION
The intent to add this alignment is align key data to 8 bytes boundary so that we can read uint64_t variable by pointer cast.  But it turns out that aligning keys is useless.

On 64-bit systems, uint8_t *keys is aligned to 8 bytes boundary, then the actual keys following this field are aligned to 8 bytes too.

On 32-bit systems, uint8_t *keys is aligned to 4 bytes boundary, then the keys is also aligned to 4 bytes boundary.  On these systems, 64-bit integer is aligned to 4 bytes boundary as well, so no need to care about the alignment.