### PR TITLE
Revise libngtcp2 include dir setup

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -75,8 +75,9 @@ set(ngtcp2_SOURCES
 )
 
 set(ngtcp2_INCLUDE_DIRS
-  "${CMAKE_CURRENT_SOURCE_DIR}/includes"
-  "${CMAKE_CURRENT_BINARY_DIR}/includes"
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/includes>"
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/includes>"
+  "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>"
 )
 
 set(NGTCP2_GENERATED_DIR "${CMAKE_CURRENT_BINARY_DIR}/generated")
@@ -107,11 +108,7 @@ if(ENABLE_SHARED_LIB)
     C_VISIBILITY_PRESET hidden
     POSITION_INDEPENDENT_CODE ON
   )
-  foreach(include_DIR IN LISTS ngtcp2_INCLUDE_DIRS)
-    target_include_directories(ngtcp2 PUBLIC $<BUILD_INTERFACE:${include_DIR}>)
-  endforeach()
-
-  target_include_directories(ngtcp2 PUBLIC $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+  target_include_directories(ngtcp2 PUBLIC ${ngtcp2_INCLUDE_DIRS})
 
   install(TARGETS ngtcp2
     EXPORT ${NGTCP2_TARGETS_EXPORT_NAME}
@@ -130,11 +127,7 @@ if(ENABLE_STATIC_LIB)
     C_VISIBILITY_PRESET hidden
   )
   target_compile_definitions(ngtcp2_static PUBLIC "-DNGTCP2_STATICLIB")
-  foreach(include_DIR IN LISTS ngtcp2_INCLUDE_DIRS)
-    target_include_directories(ngtcp2_static PUBLIC $<BUILD_INTERFACE:${include_DIR}>)
-  endforeach()
-
-  target_include_directories(ngtcp2_static PUBLIC $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+  target_include_directories(ngtcp2_static PUBLIC ${ngtcp2_INCLUDE_DIRS})
 
   install(TARGETS ngtcp2_static
     EXPORT ${NGTCP2_TARGETS_EXPORT_NAME}


### PR DESCRIPTION
Includes are installed to `CMAKE_INSTALL_INCLUDEDIR`, not literal `include`. So this variable must be used also in the install interface. This change also remove the redundant `./` path component.

In addition, the generator expressions can be applied directly in the `ngtcp2_INCLUDE_DIRS`, simplifying later processing.

Installed target properties after this change (vcpkg x64-linux-dynamic `ngtcp2Targets.cmake`):
~~~
# Create imported target ngtcp2::ngtcp2
add_library(ngtcp2::ngtcp2 SHARED IMPORTED)

set_target_properties(ngtcp2::ngtcp2 PROPERTIES
  INTERFACE_INCLUDE_DIRECTORIES "${_IMPORT_PREFIX}/include"
)
~~~