### PR TITLE
Export CMake target for ngtcp2_crypto_ossl(_static)

### DIFF
--- a/crypto/ossl/CMakeLists.txt
+++ b/crypto/ossl/CMakeLists.txt
@@ -29,11 +29,11 @@ set(ngtcp2_crypto_ossl_SOURCES
 )
 
 set(ngtcp2_crypto_ossl_INCLUDE_DIRS
-  "${CMAKE_CURRENT_SOURCE_DIR}/../../lib"
-  "${CMAKE_CURRENT_SOURCE_DIR}/../../crypto/includes"
-  "${CMAKE_CURRENT_BINARY_DIR}/../../crypto/includes"
-  "${CMAKE_CURRENT_SOURCE_DIR}/../../crypto"
-  "${CMAKE_CURRENT_BINARY_DIR}/../../crypto"
+  "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/lib>"
+  "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/crypto/includes>"
+  "$<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/crypto/includes>"
+  "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/crypto>"
+  "$<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/crypto>"
 )
 
 foreach(name libngtcp2_crypto_ossl.pc)
@@ -55,6 +55,7 @@ if(ENABLE_SHARED_LIB)
   target_link_libraries(ngtcp2_crypto_ossl PUBLIC ngtcp2 OpenSSL::SSL)
 
   install(TARGETS ngtcp2_crypto_ossl
+    EXPORT "${PROJECT_NAME}Targets"
     ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
     LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
     RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")
@@ -77,6 +78,7 @@ if(ENABLE_STATIC_LIB)
   target_link_libraries(ngtcp2_crypto_ossl_static PUBLIC ngtcp2_static OpenSSL::SSL)
 
   install(TARGETS ngtcp2_crypto_ossl_static
+    EXPORT "${PROJECT_NAME}Targets"
     DESTINATION "${CMAKE_INSTALL_LIBDIR}")
 endif()
 

--- a/lib/config.cmake.in
+++ b/lib/config.cmake.in
@@ -1,3 +1,6 @@
 include(CMakeFindDependencyMacro)
+if("@HAVE_OSSL@")
+    find_dependency(OpenSSL)
+endif()
 
 include("${CMAKE_CURRENT_LIST_DIR}/@NGTCP2_TARGETS_EXPORT_NAME@.cmake")


### PR DESCRIPTION
POC for #1961, openssl-only at the moment -> Draft.

For simplicity, this change reuses the existing `${PROJECT_NAME}Targets` export set.
- It might make sense to move the `install(EXPORT ...)` and the corresponding `config.cmake.in` from `lib` to the top-level directory.
- Transitive dependencies like OpenSSL are subject to the actual crypto backend used in the downstream project. It might make sense to offer a `find_package(... COMPONENTS ...)` interface to let the consumers filter backends and dependencies.

By switching to `PROJECT_SOURCE_DIR`/`PROJECT_BINARY_DIR` for include path construction, the directories get rid of the `../../` components.