### PR TITLE
Include array in siphash example

### DIFF
--- a/examples/siphash.h
+++ b/examples/siphash.h
@@ -40,6 +40,7 @@
 #ifndef SIPHASH_H
 #define SIPHASH_H
 
+#include <array>
 #include <bit>
 #include <concepts>
 #include <algorithm>


### PR DESCRIPTION
For `std::array`. Compilation fails on macOS with C++23 support otherwise.

Fixes this error:
```
../../deps/ngtcp2/ngtcp2/examples/siphash.cc:98:41: error: implicit instantiation of undefined template 'std::array<unsigned char, 8>'
   98 |   std::array<uint8_t, sizeof(uint64_t)> last_block{};
      |                                         ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/__fwd/array.h:23:29: note: template is declared here
   23 | struct _LIBCPP_TEMPLATE_VIS array;
      |                             ^
1 error generated.
```