### PR TITLE
Optimize ngtcp2_frame_chain creation

### DIFF
--- a/lib/ngtcp2_strm.c
+++ b/lib/ngtcp2_strm.c
@@ -372,13 +372,12 @@ static int strm_streamfrq_unacked_pop(ngtcp2_strm *strm,
 int ngtcp2_strm_streamfrq_pop(ngtcp2_strm *strm, ngtcp2_frame_chain **pfrc,
                               size_t left) {
   ngtcp2_stream *fr, *nfr;
-  ngtcp2_frame_chain *frc, *nfrc, *sfrc;
+  ngtcp2_frame_chain *frc, *nfrc;
   int rv;
   size_t nmerged;
   uint64_t datalen;
-  ngtcp2_vec a[NGTCP2_MAX_STREAM_DATACNT];
-  ngtcp2_vec b[NGTCP2_MAX_STREAM_DATACNT];
-  size_t acnt, bcnt;
+  ngtcp2_vec data[NGTCP2_MAX_STREAM_DATACNT];
+  size_t datacnt;
   uint64_t unacked_offset;
 
   if (strm->tx.streamfrq == NULL || ngtcp2_ksl_len(strm->tx.streamfrq) == 0) {
@@ -418,17 +417,15 @@ int ngtcp2_strm_streamfrq_pop(ngtcp2_strm *strm, ngtcp2_frame_chain **pfrc,
   }
 
   if (datalen > left) {
-    ngtcp2_vec_copy(a, fr->data, fr->datacnt);
-    acnt = fr->datacnt;
+    datacnt = 0;
+    ngtcp2_vec_split(data, &datacnt, fr->data, &fr->datacnt, left,
+                     NGTCP2_MAX_STREAM_DATACNT);
 
-    bcnt = 0;
-    ngtcp2_vec_split(b, &bcnt, a, &acnt, left, NGTCP2_MAX_STREAM_DATACNT);
-
-    assert(acnt > 0);
-    assert(bcnt > 0);
+    assert(fr->datacnt > 0);
+    assert(datacnt > 0);
 
     rv = ngtcp2_frame_chain_stream_datacnt_objalloc_new(
-      &nfrc, bcnt, strm->frc_objalloc, strm->mem);
+      &nfrc, datacnt, strm->frc_objalloc, strm->mem);
     if (rv != 0) {
       assert(ngtcp2_err_is_fatal(rv));
       ngtcp2_frame_chain_objalloc_del(frc, strm->frc_objalloc, strm->mem);
@@ -441,8 +438,8 @@ int ngtcp2_strm_streamfrq_pop(ngtcp2_strm *strm, ngtcp2_frame_chain **pfrc,
     nfr->fin = fr->fin;
     nfr->stream_id = fr->stream_id;
     nfr->offset = fr->offset + left;
-    nfr->datacnt = bcnt;
-    ngtcp2_vec_copy(nfr->data, b, bcnt);
+    nfr->datacnt = datacnt;
+    ngtcp2_vec_copy(nfr->data, data, datacnt);
 
     rv = ngtcp2_ksl_insert(strm->tx.streamfrq, NULL, &nfr->offset, nfrc);
     if (rv != 0) {
@@ -453,34 +450,17 @@ int ngtcp2_strm_streamfrq_pop(ngtcp2_strm *strm, ngtcp2_frame_chain **pfrc,
       return rv;
     }
 
-    rv = ngtcp2_frame_chain_stream_datacnt_objalloc_new(
-      &nfrc, acnt, strm->frc_objalloc, strm->mem);
-    if (rv != 0) {
-      assert(ngtcp2_err_is_fatal(rv));
-      ngtcp2_frame_chain_objalloc_del(frc, strm->frc_objalloc, strm->mem);
-      return rv;
-    }
+    fr->fin = 0;
 
-    nfr = &nfrc->fr.stream;
-    nfr->type = fr->type;
-    nfr->flags = fr->flags;
-    nfr->fin = 0;
-    nfr->stream_id = fr->stream_id;
-    nfr->offset = fr->offset;
-    nfr->datacnt = acnt;
-    ngtcp2_vec_copy(nfr->data, a, acnt);
-
-    ngtcp2_frame_chain_objalloc_del(frc, strm->frc_objalloc, strm->mem);
-
-    *pfrc = nfrc;
+    *pfrc = frc;
 
     return 0;
   }
 
   left -= (size_t)datalen;
 
-  ngtcp2_vec_copy(a, fr->data, fr->datacnt);
-  acnt = fr->datacnt;
+  ngtcp2_vec_copy(data, fr->data, fr->datacnt);
+  datacnt = fr->datacnt;
 
   for (; left && ngtcp2_ksl_len(strm->tx.streamfrq);) {
     unacked_offset = ngtcp2_strm_streamfrq_unacked_offset(strm);
@@ -507,9 +487,7 @@ int ngtcp2_strm_streamfrq_pop(ngtcp2_strm *strm, ngtcp2_frame_chain **pfrc,
       break;
     }
 
-    bcnt = nfr->datacnt;
-
-    nmerged = ngtcp2_vec_merge(a, &acnt, nfr->data, &bcnt, left,
+    nmerged = ngtcp2_vec_merge(data, &datacnt, nfr->data, &nfr->datacnt, left,
                                NGTCP2_MAX_STREAM_DATACNT);
     if (nmerged == 0) {
       rv = ngtcp2_ksl_insert(strm->tx.streamfrq, NULL, &nfr->offset, nfrc);
@@ -527,54 +505,27 @@ int ngtcp2_strm_streamfrq_pop(ngtcp2_strm *strm, ngtcp2_frame_chain **pfrc,
     datalen += nmerged;
     left -= nmerged;
 
-    if (bcnt == 0) {
+    if (nfr->datacnt == 0) {
       fr->fin = nfr->fin;
       ngtcp2_frame_chain_objalloc_del(nfrc, strm->frc_objalloc, strm->mem);
       continue;
     }
 
-    if (nfr->datacnt <= NGTCP2_FRAME_CHAIN_STREAM_DATACNT_THRES ||
-        bcnt > NGTCP2_FRAME_CHAIN_STREAM_DATACNT_THRES) {
-      nfr->offset += nmerged;
-      nfr->datacnt = bcnt;
+    nfr->offset += nmerged;
 
-      rv = ngtcp2_ksl_insert(strm->tx.streamfrq, NULL, &nfr->offset, nfrc);
-      if (rv != 0) {
-        ngtcp2_frame_chain_objalloc_del(nfrc, strm->frc_objalloc, strm->mem);
-        ngtcp2_frame_chain_objalloc_del(frc, strm->frc_objalloc, strm->mem);
-        return rv;
-      }
-    } else {
-      rv = ngtcp2_frame_chain_stream_datacnt_objalloc_new(
-        &sfrc, bcnt, strm->frc_objalloc, strm->mem);
-      if (rv != 0) {
-        ngtcp2_frame_chain_objalloc_del(nfrc, strm->frc_objalloc, strm->mem);
-        ngtcp2_frame_chain_objalloc_del(frc, strm->frc_objalloc, strm->mem);
-        return rv;
-      }
-
-      sfrc->fr.stream = nfrc->fr.stream;
-      sfrc->fr.stream.offset += nmerged;
-      sfrc->fr.stream.datacnt = bcnt;
-      ngtcp2_vec_copy(sfrc->fr.stream.data, nfrc->fr.stream.data, bcnt);
-
+    rv = ngtcp2_ksl_insert(strm->tx.streamfrq, NULL, &nfr->offset, nfrc);
+    if (rv != 0) {
       ngtcp2_frame_chain_objalloc_del(nfrc, strm->frc_objalloc, strm->mem);
-
-      rv = ngtcp2_ksl_insert(strm->tx.streamfrq, NULL, &sfrc->fr.stream.offset,
-                             sfrc);
-      if (rv != 0) {
-        ngtcp2_frame_chain_objalloc_del(sfrc, strm->frc_objalloc, strm->mem);
-        ngtcp2_frame_chain_objalloc_del(frc, strm->frc_objalloc, strm->mem);
-        return rv;
-      }
+      ngtcp2_frame_chain_objalloc_del(frc, strm->frc_objalloc, strm->mem);
+      return rv;
     }
 
     break;
   }
 
-  if (acnt == fr->datacnt) {
-    if (acnt > 0) {
-      fr->data[acnt - 1] = a[acnt - 1];
+  if (datacnt == fr->datacnt) {
+    if (datacnt > 0) {
+      fr->data[datacnt - 1] = data[datacnt - 1];
     }
 
     *pfrc = frc;
@@ -582,10 +533,10 @@ int ngtcp2_strm_streamfrq_pop(ngtcp2_strm *strm, ngtcp2_frame_chain **pfrc,
     return 0;
   }
 
-  assert(acnt > fr->datacnt);
+  assert(datacnt > fr->datacnt);
 
   rv = ngtcp2_frame_chain_stream_datacnt_objalloc_new(
-    &nfrc, acnt, strm->frc_objalloc, strm->mem);
+    &nfrc, datacnt, strm->frc_objalloc, strm->mem);
   if (rv != 0) {
     ngtcp2_frame_chain_objalloc_del(frc, strm->frc_objalloc, strm->mem);
     return rv;
@@ -597,8 +548,8 @@ int ngtcp2_strm_streamfrq_pop(ngtcp2_strm *strm, ngtcp2_frame_chain **pfrc,
   nfr->fin = fr->fin;
   nfr->stream_id = fr->stream_id;
   nfr->offset = fr->offset;
-  nfr->datacnt = acnt;
-  ngtcp2_vec_copy(nfr->data, a, acnt);
+  nfr->datacnt = datacnt;
+  ngtcp2_vec_copy(nfr->data, data, datacnt);
 
   ngtcp2_frame_chain_objalloc_del(frc, strm->frc_objalloc, strm->mem);
 


### PR DESCRIPTION
Now that we can freely change stream.datacnt in ngtcp2_frame_chain, lets optimize the code where we do some workaround for this previous limitation.