### PR TITLE
ksl: Adjust NGTCP2_KSL_DEGR

### DIFF
--- a/lib/ngtcp2_ksl.c
+++ b/lib/ngtcp2_ksl.c
@@ -409,7 +409,7 @@ static ngtcp2_ksl_blk *ksl_merge_node(ngtcp2_ksl *ksl, ngtcp2_ksl_blk *blk,
   lblk = lnode->blk;
   rblk = blk->nodes[i + 1].blk;
 
-  assert(lblk->n + rblk->n < NGTCP2_KSL_MAX_NBLK);
+  assert(lblk->n + rblk->n <= NGTCP2_KSL_MAX_NBLK);
 
   memcpy(lblk->nodes + lblk->n, rblk->nodes, rblk->n * sizeof(ngtcp2_ksl_node));
 

--- a/lib/ngtcp2_ksl.h
+++ b/lib/ngtcp2_ksl.h
@@ -38,10 +38,10 @@
 #define NGTCP2_KSL_DEGR 16
 /* NGTCP2_KSL_MAX_NBLK is the maximum number of nodes which a single
    block can contain. */
-#define NGTCP2_KSL_MAX_NBLK (2 * NGTCP2_KSL_DEGR - 1)
+#define NGTCP2_KSL_MAX_NBLK (2 * NGTCP2_KSL_DEGR)
 /* NGTCP2_KSL_MIN_NBLK is the minimum number of nodes which a single
    block other than root must contain. */
-#define NGTCP2_KSL_MIN_NBLK (NGTCP2_KSL_DEGR - 1)
+#define NGTCP2_KSL_MIN_NBLK NGTCP2_KSL_DEGR
 
 /*
  * ngtcp2_ksl_key represents key in ngtcp2_ksl.

--- a/tests/ngtcp2_ksl_test.c
+++ b/tests/ngtcp2_ksl_test.c
@@ -310,22 +310,19 @@ void test_ngtcp2_ksl_range(void) {
   ngtcp2_ksl_init(&ksl, ngtcp2_ksl_range_compar, ngtcp2_ksl_range_search,
                   sizeof(ngtcp2_range), mem);
 
-  for (i = 0; i < 32; ++i) {
+  for (i = 0; i < 33; ++i) {
     ngtcp2_range_init(&r, i, i + 1);
     assert_int(0, ==, ngtcp2_ksl_insert(&ksl, NULL, &r, NULL));
   }
 
-  /* Removing these 3 nodes kicks merging 2 nodes under head */
+  /* Removing these 2 nodes kicks merging 2 nodes under head */
   ngtcp2_range_init(&r, 13, 14);
   assert_int(0, ==, ngtcp2_ksl_remove(&ksl, NULL, &r));
 
   ngtcp2_range_init(&r, 14, 15);
   assert_int(0, ==, ngtcp2_ksl_remove(&ksl, NULL, &r));
 
-  ngtcp2_range_init(&r, 15, 16);
-  assert_int(0, ==, ngtcp2_ksl_remove(&ksl, NULL, &r));
-
-  assert_size(29, ==, ksl.head->n);
+  assert_size(31, ==, ksl.head->n);
 
   ngtcp2_ksl_free(&ksl);
 
@@ -333,24 +330,18 @@ void test_ngtcp2_ksl_range(void) {
   ngtcp2_ksl_init(&ksl, ngtcp2_ksl_range_compar, ngtcp2_ksl_range_search,
                   sizeof(ngtcp2_range), mem);
 
-  for (i = 0; i < 32 + 18; ++i) {
+  for (i = 0; i < 33 + 18; ++i) {
     ngtcp2_range_init(&r, i, i + 1);
     assert_int(0, ==, ngtcp2_ksl_insert(&ksl, NULL, &r, NULL));
   }
 
-  /* Removing these 3 nodes kicks merging 2 nodes */
+  /* Removing this node kicks merging 2 nodes */
   ngtcp2_range_init(&r, 13, 14);
   assert_int(0, ==, ngtcp2_ksl_remove(&ksl, NULL, &r));
 
-  ngtcp2_range_init(&r, 14, 15);
-  assert_int(0, ==, ngtcp2_ksl_remove(&ksl, NULL, &r));
-
-  ngtcp2_range_init(&r, 15, 16);
-  assert_int(0, ==, ngtcp2_ksl_remove(&ksl, NULL, &r));
-
   assert_size(2, ==, ksl.head->n);
-  assert_size(29, ==, ksl.head->nodes[0].blk->n);
-  assert_size(18, ==, ksl.head->nodes[1].blk->n);
+  assert_size(31, ==, ksl.head->nodes[0].blk->n);
+  assert_size(19, ==, ksl.head->nodes[1].blk->n);
 
   ngtcp2_ksl_free(&ksl);
 
@@ -363,15 +354,13 @@ void test_ngtcp2_ksl_range(void) {
     assert_int(0, ==, ngtcp2_ksl_insert(&ksl, NULL, &r, NULL));
   }
 
-  ngtcp2_range_init(&r, 1501, 1502);
-  assert_int(0, ==, ngtcp2_ksl_remove(&ksl, NULL, &r));
-  ngtcp2_range_init(&r, 1401, 1402);
+  ngtcp2_range_init(&r, 3101, 3102);
   assert_int(0, ==, ngtcp2_ksl_remove(&ksl, NULL, &r));
 
   r =
     *(ngtcp2_range *)(void *)ngtcp2_ksl_blk_nth_key(ksl.head->nodes[1].blk, 0);
 
-  assert_uint64(1701, ==, r.begin);
+  assert_uint64(1601, ==, r.begin);
 
   ngtcp2_ksl_free(&ksl);
 
@@ -379,21 +368,23 @@ void test_ngtcp2_ksl_range(void) {
   ngtcp2_ksl_init(&ksl, ngtcp2_ksl_range_compar, ngtcp2_ksl_range_search,
                   sizeof(ngtcp2_range), mem);
 
-  for (i = 0; i < 32; ++i) {
+  for (i = 0; i < 49; ++i) {
     ngtcp2_range_init(&r, i, i + 1);
     assert_int(0, ==, ngtcp2_ksl_insert(&ksl, NULL, &r, NULL));
   }
 
-  ngtcp2_range_init(&r, 17, 18);
+  ngtcp2_range_init(&r, 15, 16);
   assert_int(0, ==, ngtcp2_ksl_remove(&ksl, NULL, &r));
-  ngtcp2_range_init(&r, 16, 17);
+  ngtcp2_range_init(&r, 48, 49);
+  assert_int(0, ==, ngtcp2_ksl_remove(&ksl, NULL, &r));
+  ngtcp2_range_init(&r, 47, 48);
   assert_int(0, ==, ngtcp2_ksl_remove(&ksl, NULL, &r));
 
   node = &ksl.head->nodes[0];
   r = *(ngtcp2_range *)(void *)ngtcp2_ksl_blk_nth_key(node->blk,
                                                       node->blk->n - 1);
 
-  assert_uint64(14, ==, r.begin);
+  assert_uint64(23, ==, r.begin);
 
   ngtcp2_ksl_free(&ksl);
 }


### PR DESCRIPTION
Adjust NGTCP2_KSL_DEGR to match the number of nodes per block with B-tree.  The previous value is borrowed from B-tree, and B-tree has one-less keys than nodes.  No need to adjust the number of keys because our data structure has the same number of keys and data.