### PR TITLE
ksl: Remove dead code

### DIFF
--- a/lib/ngtcp2_ksl.c
+++ b/lib/ngtcp2_ksl.c
@@ -361,10 +361,6 @@ int ngtcp2_ksl_insert(ngtcp2_ksl *ksl, ngtcp2_ksl_it *it,
 
       if (ksl->compar(ngtcp2_ksl_blk_nth_key(blk, i), key)) {
         node = &blk->nodes[i + 1];
-
-        if (ksl->compar(ngtcp2_ksl_blk_nth_key(blk, i + 1), key)) {
-          ksl_set_nth_key(ksl, blk, i + 1, key);
-        }
       }
     }
 


### PR DESCRIPTION
In this context, the key larger than the maximum key in the node is already handled.  This is effectively unreachable.