### PR TITLE
Reclaim extra packet for Initial on PTO

### DIFF
--- a/lib/ngtcp2_conn.c
+++ b/lib/ngtcp2_conn.c
@@ -2605,7 +2605,8 @@ conn_write_handshake_pkt(ngtcp2_conn *conn, ngtcp2_pkt_info *pi, uint8_t *dest,
 
     if (!(rtb_entry_flags & NGTCP2_RTB_ENTRY_FLAG_ACK_ELICITING) &&
         pktns->rtb.num_retransmittable && pktns->rtb.probe_pkt_left) {
-      num_reclaimed = ngtcp2_rtb_reclaim_on_pto(&pktns->rtb, conn, pktns, 1);
+      num_reclaimed = ngtcp2_rtb_reclaim_on_pto(
+        &pktns->rtb, conn, pktns, type == NGTCP2_PKT_INITIAL ? 2 : 1);
       if (num_reclaimed < 0) {
         ngtcp2_frame_chain_list_objalloc_del(frq, &conn->frc_objalloc,
                                              conn->mem);


### PR DESCRIPTION
Reclaim extra packet for Initial on PTO to resend 2 complete Initial packets.