### PR TITLE
Only reclaim 2 packets for client Initials

### DIFF
--- a/lib/ngtcp2_conn.c
+++ b/lib/ngtcp2_conn.c
@@ -2606,7 +2606,8 @@ conn_write_handshake_pkt(ngtcp2_conn *conn, ngtcp2_pkt_info *pi, uint8_t *dest,
     if (!(rtb_entry_flags & NGTCP2_RTB_ENTRY_FLAG_ACK_ELICITING) &&
         pktns->rtb.num_retransmittable && pktns->rtb.probe_pkt_left) {
       num_reclaimed = ngtcp2_rtb_reclaim_on_pto(
-        &pktns->rtb, conn, pktns, type == NGTCP2_PKT_INITIAL ? 2 : 1);
+        &pktns->rtb, conn, pktns,
+        !conn->server && type == NGTCP2_PKT_INITIAL ? 2 : 1);
       if (num_reclaimed < 0) {
         ngtcp2_frame_chain_list_objalloc_del(frq, &conn->frc_objalloc,
                                              conn->mem);


### PR DESCRIPTION
Server Initial is usually small, and we do not split it.