### PR TITLE
Revert "examples: Avoid strict aliasing violation"

### DIFF
--- a/examples/client.cc
+++ b/examples/client.cc
@@ -1049,7 +1049,7 @@ ngtcp2_ssize write_pkt(ngtcp2_conn *conn, ngtcp2_path *path,
 ngtcp2_ssize Client::write_pkt(ngtcp2_path *path, ngtcp2_pkt_info *pi,
                                uint8_t *dest, size_t destlen,
                                ngtcp2_tstamp ts) {
-  std::array<SharedVec, 16> vec;
+  std::array<nghttp3_vec, 16> vec;
 
   for (;;) {
     int64_t stream_id = -1;
@@ -1057,9 +1057,8 @@ ngtcp2_ssize Client::write_pkt(ngtcp2_path *path, ngtcp2_pkt_info *pi,
     nghttp3_ssize sveccnt = 0;
 
     if (httpconn_ && ngtcp2_conn_get_max_data_left(conn_)) {
-      sveccnt = nghttp3_conn_writev_stream(
-        httpconn_, &stream_id, &fin,
-        reinterpret_cast<nghttp3_vec *>(vec.data()), vec.size());
+      sveccnt = nghttp3_conn_writev_stream(httpconn_, &stream_id, &fin,
+                                           vec.data(), vec.size());
       if (sveccnt < 0) {
         std::cerr << "nghttp3_conn_writev_stream: "
                   << nghttp3_strerror(static_cast<int>(sveccnt)) << std::endl;
@@ -1072,6 +1071,7 @@ ngtcp2_ssize Client::write_pkt(ngtcp2_path *path, ngtcp2_pkt_info *pi,
     }
 
     ngtcp2_ssize ndatalen;
+    auto v = vec.data();
     auto vcnt = static_cast<size_t>(sveccnt);
 
     uint32_t flags = NGTCP2_WRITE_STREAM_FLAG_MORE;
@@ -1081,7 +1081,7 @@ ngtcp2_ssize Client::write_pkt(ngtcp2_path *path, ngtcp2_pkt_info *pi,
 
     auto nwrite = ngtcp2_conn_writev_stream(
       conn_, path, pi, dest, destlen, &ndatalen, flags, stream_id,
-      reinterpret_cast<const ngtcp2_vec *>(vec.data()), vcnt, ts);
+      reinterpret_cast<const ngtcp2_vec *>(v), vcnt, ts);
     if (nwrite < 0) {
       switch (nwrite) {
       case NGTCP2_ERR_STREAM_DATA_BLOCKED:

--- a/examples/server.cc
+++ b/examples/server.cc
@@ -1652,7 +1652,7 @@ ngtcp2_ssize write_pkt(ngtcp2_conn *conn, ngtcp2_path *path,
 ngtcp2_ssize Handler::write_pkt(ngtcp2_path *path, ngtcp2_pkt_info *pi,
                                 uint8_t *dest, size_t destlen,
                                 ngtcp2_tstamp ts) {
-  std::array<SharedVec, 16> vec;
+  std::array<nghttp3_vec, 16> vec;
 
   for (;;) {
     int64_t stream_id = -1;
@@ -1660,9 +1660,8 @@ ngtcp2_ssize Handler::write_pkt(ngtcp2_path *path, ngtcp2_pkt_info *pi,
     nghttp3_ssize sveccnt = 0;
 
     if (httpconn_ && ngtcp2_conn_get_max_data_left(conn_)) {
-      sveccnt = nghttp3_conn_writev_stream(
-        httpconn_, &stream_id, &fin,
-        reinterpret_cast<nghttp3_vec *>(vec.data()), vec.size());
+      sveccnt = nghttp3_conn_writev_stream(httpconn_, &stream_id, &fin,
+                                           vec.data(), vec.size());
       if (sveccnt < 0) {
         std::cerr << "nghttp3_conn_writev_stream: "
                   << nghttp3_strerror(static_cast<int>(sveccnt)) << std::endl;
@@ -1675,6 +1674,7 @@ ngtcp2_ssize Handler::write_pkt(ngtcp2_path *path, ngtcp2_pkt_info *pi,
     }
 
     ngtcp2_ssize ndatalen;
+    auto v = vec.data();
     auto vcnt = static_cast<size_t>(sveccnt);
 
     uint32_t flags =
@@ -1685,7 +1685,7 @@ ngtcp2_ssize Handler::write_pkt(ngtcp2_path *path, ngtcp2_pkt_info *pi,
 
     auto nwrite = ngtcp2_conn_writev_stream(
       conn_, path, pi, dest, destlen, &ndatalen, flags, stream_id,
-      reinterpret_cast<const ngtcp2_vec *>(vec.data()), vcnt, ts);
+      reinterpret_cast<const ngtcp2_vec *>(v), vcnt, ts);
     if (nwrite < 0) {
       switch (nwrite) {
       case NGTCP2_ERR_STREAM_DATA_BLOCKED:

--- a/examples/shared.h
+++ b/examples/shared.h
@@ -34,7 +34,6 @@
 #include <span>
 
 #include <ngtcp2/ngtcp2.h>
-#include <nghttp3/nghttp3.h>
 
 #include "network.h"
 
@@ -63,11 +62,6 @@ inline constexpr auto H3_ALPN_V1 = as_uint8_span(RAW_H3_ALPN);
 inline constexpr uint32_t TLS_ALERT_ECH_REQUIRED = 121;
 
 inline constexpr size_t MAX_RECV_PKTS = 64;
-
-union SharedVec {
-  ngtcp2_vec v2;
-  nghttp3_vec v3;
-};
 
 // msghdr_get_ecn gets ECN bits from |msg|.  |family| is the address
 // family from which packet is received.


### PR DESCRIPTION
Reverts ngtcp2/ngtcp2#1979