### PR TITLE
Remove ngtcp2_datagram.rdata

### DIFF
--- a/lib/ngtcp2_pkt.h
+++ b/lib/ngtcp2_pkt.h
@@ -340,13 +340,9 @@ typedef struct ngtcp2_datagram {
   uint64_t dgram_id;
   /* datacnt is the number of elements that data contains. */
   size_t datacnt;
-  /* data is a pointer to ngtcp2_vec array that stores data. */
+  /* data is a pointer to ngtcp2_vec array that stores data.  If
+     datacnt == 0, this field may be NULL.*/
   ngtcp2_vec *data;
-  /* rdata is conveniently embedded to ngtcp2_datagram, so that data
-     field can just point to the address of this field to store a
-     single vector which is the case when DATAGRAM is received from a
-     remote endpoint. */
-  ngtcp2_vec rdata[1];
 } ngtcp2_datagram;
 
 typedef union ngtcp2_frame {
@@ -457,7 +453,7 @@ ngtcp2_ssize ngtcp2_pkt_encode_hd_short(uint8_t *out, size_t outlen,
  */
 typedef struct ngtcp2_frame_decoder {
   union {
-    ngtcp2_vec stream_data;
+    ngtcp2_vec data;
     ngtcp2_ack_range ack_ranges[NGTCP2_MAX_ACK_RANGES];
   } buf;
 } ngtcp2_frame_decoder;

--- a/tests/ngtcp2_conn_test.c
+++ b/tests/ngtcp2_conn_test.c
@@ -9105,13 +9105,12 @@ void test_ngtcp2_conn_recv_datagram(void) {
   fr.datagram = (ngtcp2_datagram){
     .type = NGTCP2_FRAME_DATAGRAM,
     .datacnt = 1,
-    .rdata[0] =
-      {
-        .base = null_data,
-        .len = 1111,
-      },
+    .data = &datav,
   };
-  fr.datagram.data = fr.datagram.rdata;
+  datav = (ngtcp2_vec){
+    .base = null_data,
+    .len = 1111,
+  };
 
   pktlen = ngtcp2_tpe_write_1rtt(&tpe, buf, sizeof(buf), &fr, 1);
 
@@ -9139,13 +9138,12 @@ void test_ngtcp2_conn_recv_datagram(void) {
   fr.datagram = (ngtcp2_datagram){
     .type = NGTCP2_FRAME_DATAGRAM,
     .datacnt = 1,
-    .rdata[0] =
-      {
-        .base = null_data,
-        .len = 1111,
-      },
+    .data = &datav,
   };
-  fr.datagram.data = fr.datagram.rdata;
+  datav = (ngtcp2_vec){
+    .base = null_data,
+    .len = 1111,
+  };
 
   pktlen = ngtcp2_tpe_write_1rtt(&tpe, buf, sizeof(buf), &fr, 1);
 
@@ -9190,13 +9188,12 @@ void test_ngtcp2_conn_recv_datagram(void) {
   fr.datagram = (ngtcp2_datagram){
     .type = NGTCP2_FRAME_DATAGRAM,
     .datacnt = 1,
-    .rdata[0] =
-      {
-        .base = null_data,
-        .len = 1111,
-      },
+    .data = &datav,
   };
-  fr.datagram.data = fr.datagram.rdata;
+  datav = (ngtcp2_vec){
+    .base = null_data,
+    .len = 1111,
+  };
 
   tpe.early.ckm = conn->early.ckm;
 

--- a/tests/ngtcp2_pkt_test.c
+++ b/tests/ngtcp2_pkt_test.c
@@ -1717,6 +1717,7 @@ void test_ngtcp2_pkt_encode_handshake_done_frame(void) {
 void test_ngtcp2_pkt_encode_datagram_frame(void) {
   const uint8_t data[] = "0123456789abcdef3";
   uint8_t buf[256];
+  ngtcp2_vec datav, ndatav;
   ngtcp2_datagram fr, nfr;
   ngtcp2_ssize rv;
   size_t framelen;
@@ -1725,13 +1726,12 @@ void test_ngtcp2_pkt_encode_datagram_frame(void) {
   fr = (ngtcp2_datagram){
     .type = NGTCP2_FRAME_DATAGRAM_LEN,
     .datacnt = 1,
-    .rdata[0] =
-      {
-        .len = ngtcp2_strlen_lit(data),
-        .base = (uint8_t *)data,
-      },
+    .data = &datav,
   };
-  fr.data = fr.rdata;
+  datav = (ngtcp2_vec){
+    .len = ngtcp2_strlen_lit(data),
+    .base = (uint8_t *)data,
+  };
 
   framelen = 1 + 1 + 17;
 
@@ -1739,6 +1739,7 @@ void test_ngtcp2_pkt_encode_datagram_frame(void) {
 
   assert_ptrdiff((ngtcp2_ssize)framelen, ==, rv);
 
+  nfr.data = &ndatav;
   rv = ngtcp2_pkt_decode_datagram_frame(&nfr, buf, framelen);
 
   assert_ptrdiff((ngtcp2_ssize)framelen, ==, rv);
@@ -1749,6 +1750,7 @@ void test_ngtcp2_pkt_encode_datagram_frame(void) {
 
   /* Fail if a frame is truncated. */
   for (i = 1; i < framelen; ++i) {
+    nfr.data = &ndatav;
     rv = ngtcp2_pkt_decode_datagram_frame(&nfr, buf, i);
 
     assert_ptrdiff(NGTCP2_ERR_FRAME_ENCODING, ==, rv);
@@ -1760,13 +1762,12 @@ void test_ngtcp2_pkt_encode_datagram_frame(void) {
   fr = (ngtcp2_datagram){
     .type = NGTCP2_FRAME_DATAGRAM,
     .datacnt = 1,
-    .rdata[0] =
-      {
-        .len = ngtcp2_strlen_lit(data),
-        .base = (uint8_t *)data,
-      },
+    .data = &datav,
   };
-  fr.data = fr.rdata;
+  datav = (ngtcp2_vec){
+    .len = ngtcp2_strlen_lit(data),
+    .base = (uint8_t *)data,
+  };
 
   framelen = 1 + 17;
 
@@ -1774,6 +1775,7 @@ void test_ngtcp2_pkt_encode_datagram_frame(void) {
 
   assert_ptrdiff((ngtcp2_ssize)framelen, ==, rv);
 
+  nfr.data = &ndatav;
   rv = ngtcp2_pkt_decode_datagram_frame(&nfr, buf, framelen);
 
   assert_ptrdiff((ngtcp2_ssize)framelen, ==, rv);
@@ -1784,6 +1786,7 @@ void test_ngtcp2_pkt_encode_datagram_frame(void) {
 
   /* Does not fail if a frame is truncated. */
   for (i = 1; i < framelen; ++i) {
+    nfr.data = &ndatav;
     rv = ngtcp2_pkt_decode_datagram_frame(&nfr, buf, i);
 
     assert_ptrdiff((ngtcp2_ssize)i, ==, rv);
@@ -1802,16 +1805,16 @@ void test_ngtcp2_pkt_encode_datagram_frame(void) {
 
   assert_ptrdiff((ngtcp2_ssize)framelen, ==, rv);
 
+  nfr.data = &ndatav;
   rv = ngtcp2_pkt_decode_datagram_frame(&nfr, buf, framelen);
 
   assert_ptrdiff((ngtcp2_ssize)framelen, ==, rv);
   assert_uint64(fr.type, ==, nfr.type);
   assert_size(fr.datacnt, ==, nfr.datacnt);
-  assert_null(nfr.data);
-  ;
 
   /* Fail if a frame is truncated. */
   for (i = 1; i < framelen; ++i) {
+    nfr.data = &ndatav;
     rv = ngtcp2_pkt_decode_datagram_frame(&nfr, buf, i);
 
     assert_ptrdiff(NGTCP2_ERR_FRAME_ENCODING, ==, rv);
@@ -1830,13 +1833,12 @@ void test_ngtcp2_pkt_encode_datagram_frame(void) {
 
   assert_ptrdiff((ngtcp2_ssize)framelen, ==, rv);
 
+  nfr.data = &ndatav;
   rv = ngtcp2_pkt_decode_datagram_frame(&nfr, buf, framelen);
 
   assert_ptrdiff((ngtcp2_ssize)framelen, ==, rv);
   assert_uint64(fr.type, ==, nfr.type);
   assert_size(fr.datacnt, ==, nfr.datacnt);
-  assert_null(nfr.data);
-  ;
 }
 
 void test_ngtcp2_pkt_adjust_pkt_num(void) {

--- a/tests/ngtcp2_qlog_test.c
+++ b/tests/ngtcp2_qlog_test.c
@@ -557,9 +557,11 @@ void test_ngtcp2_qlog_write_frame(void) {
     fr.datagram = (ngtcp2_datagram){
       .type = NGTCP2_FRAME_DATAGRAM,
       .datacnt = 1,
-      .rdata[0].len = 1301458,
+      .data = &datav,
     };
-    fr.datagram.data = fr.datagram.rdata;
+    datav = (ngtcp2_vec){
+      .len = 1301458,
+    };
 
     ngtcp2_qlog_write_frame(&qlog, &fr);
     *qlog.buf.last = '\0';


### PR DESCRIPTION
Remove ngtcp2_datagram.rdata.  Share ngtcp2_vec in ngtcp2_frame_decoder with ngtcp2_stream.