### PR TITLE
Rename in6_addr to s6_addr

### DIFF
--- a/lib/includes/ngtcp2/ngtcp2.h
+++ b/lib/includes/ngtcp2/ngtcp2.h
@@ -1281,7 +1281,7 @@ typedef struct ngtcp2_sockaddr_in {
 } ngtcp2_sockaddr_in;
 
 typedef struct ngtcp2_in6_addr {
-  uint8_t in6_addr[16];
+  uint8_t s6_addr[16];
 } ngtcp2_in6_addr;
 
 typedef struct ngtcp2_sockaddr_in6 {

--- a/tests/ngtcp2_log_test.c
+++ b/tests/ngtcp2_log_test.c
@@ -1061,6 +1061,10 @@ void test_ngtcp2_log_fr(void) {
   assert_null(ld.expected[ld.idx]);
 }
 
+#if defined(NGTCP2_USE_GENERIC_SOCKADDR) && defined(s6_addr)
+#  undef s6_addr
+#endif /* defined(NGTCP2_USE_GENERIC_SOCKADDR) && defined(s6_addr) */
+
 void test_ngtcp2_log_remote_tp(void) {
   log_data ld;
   ngtcp2_log log;
@@ -1174,13 +1178,8 @@ void test_ngtcp2_log_remote_tp(void) {
               .sin6_family = NGTCP2_AF_INET6,
               .sin6_addr =
                 {
-#ifdef NGTCP2_USE_GENERIC_SOCKADDR
-                  .in6_addr =
-#else  /* !defined(NGTCP2_USE_GENERIC_SOCKADDR) */
-                  .s6_addr =
-#endif /* !defined(NGTCP2_USE_GENERIC_SOCKADDR) */
-                    {0xde, 0xad, 0xbe, 0xef, 0xba, 0xad, 0xf0, 0x0d, 0xba, 0xad,
-                     0xca, 0xce, 0xbe, 0xef, 0xca, 0xfe},
+                  .s6_addr = {0xde, 0xad, 0xbe, 0xef, 0xba, 0xad, 0xf0, 0x0d,
+                              0xba, 0xad, 0xca, 0xce, 0xbe, 0xef, 0xca, 0xfe},
                 },
               .sin6_port = ngtcp2_htons(63111),
             },


### PR DESCRIPTION
This only affects the build with NGTCP2_USE_GENERIC_SOCKADDR.  s6_addr is widely used standard name.  Using different name causes headaches when dealing with this field.  This is still most likely binary compatible, but when building with newer ngtcp2, the application source code needs to be changed if it touches the field directly. Most of the packaged ngtcp2 are built without
NGTCP2_USE_GENERIC_SOCKADDR, so I guess the impact is minimal.