### PR TITLE
Deprecate quictls

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -60,6 +60,7 @@ directory require at least one of the following TLS backends:
 
 - `quictls
   <https://github.com/quictls/openssl/tree/OpenSSL_1_1_1w+quic>`_
+  (deprecated)
 - GnuTLS >= 3.7.5
 - BoringSSL (commit 7d88bb1bf3372bda1134ad8bf624b25b88e0db86);
   or aws-lc >= 1.39.0
@@ -273,7 +274,7 @@ The header file exists under crypto/includes/ngtcp2 directory.
 Each library file is built for a particular TLS backend.  The
 available crypto helper libraries are:
 
-- libngtcp2_crypto_quictls: Use quictls as TLS backend
+- libngtcp2_crypto_quictls: Use quictls as TLS backend (deprecated)
 - libngtcp2_crypto_libressl: Use libressl as TLS backend
 - libngtcp2_crypto_gnutls: Use GnuTLS as TLS backend
 - libngtcp2_crypto_boringssl: Use BoringSSL and aws-lc as TLS backend

--- a/doc/source/programmers-guide.rst
+++ b/doc/source/programmers-guide.rst
@@ -18,7 +18,7 @@ to build QUIC application you have to choose one of them.  Here is the
 list of TLS stacks which are supposed to provide such interface and
 for which we provide crypto helper libraries:
 
-* `quictls <https://github.com/quictls/openssl>`_
+* `quictls <https://github.com/quictls/openssl>`_ (deprecated)
 * GnuTLS
 * BoringSSL
 * aws-lc


### PR DESCRIPTION
quictls repository (https://github.com/quictls/openssl) has been archived.  The development of its successor,
https://github.com/quictls/quictls, has stagnated since late last year.  We cannot expect new release from this project any time soon. Because now we have several alternatives (e.g., wolfSSL, boringssl, aws-lc, libressl, and OpenSSL), we decided to deprecate the use of quictls.  The code under crypto/quictls are shared by libressl, so they are not removed for the time being.  This commit just declare the deprecation of quictls in documentation wise.