### PR TITLE
Migrate to new callbacks

### DIFF
--- a/examples/gtlssimpleclient.c
+++ b/examples/gtlssimpleclient.c
@@ -244,8 +244,8 @@ static void rand_cb(uint8_t *dest, size_t destlen,
 }
 
 static int get_new_connection_id_cb(ngtcp2_conn *conn, ngtcp2_cid *cid,
-                                    uint8_t *token, size_t cidlen,
-                                    void *user_data) {
+                                    ngtcp2_stateless_reset_token *token,
+                                    size_t cidlen, void *user_data) {
   (void)conn;
   (void)user_data;
 
@@ -255,8 +255,7 @@ static int get_new_connection_id_cb(ngtcp2_conn *conn, ngtcp2_cid *cid,
 
   cid->datalen = cidlen;
 
-  if (gnutls_rnd(GNUTLS_RND_RANDOM, token, NGTCP2_STATELESS_RESET_TOKENLEN) !=
-      0) {
+  if (gnutls_rnd(GNUTLS_RND_RANDOM, token->data, sizeof(token->data)) != 0) {
     return NGTCP2_ERR_CALLBACK_FAILURE;
   }
 
@@ -332,12 +331,12 @@ static int client_quic_init(struct client *c,
     .recv_retry = ngtcp2_crypto_recv_retry_cb,
     .extend_max_local_streams_bidi = extend_max_local_streams_bidi,
     .rand = rand_cb,
-    .get_new_connection_id = get_new_connection_id_cb,
     .update_key = ngtcp2_crypto_update_key_cb,
     .delete_crypto_aead_ctx = ngtcp2_crypto_delete_crypto_aead_ctx_cb,
     .delete_crypto_cipher_ctx = ngtcp2_crypto_delete_crypto_cipher_ctx_cb,
     .get_path_challenge_data = ngtcp2_crypto_get_path_challenge_data_cb,
     .version_negotiation = ngtcp2_crypto_version_negotiation_cb,
+    .get_new_connection_id2 = get_new_connection_id_cb,
   };
   ngtcp2_cid dcid, scid;
   ngtcp2_settings settings;

--- a/examples/h09client.cc
+++ b/examples/h09client.cc
@@ -435,16 +435,17 @@ void rand(uint8_t *dest, size_t destlen, const ngtcp2_rand_ctx *rand_ctx) {
 } // namespace
 
 namespace {
-int get_new_connection_id(ngtcp2_conn *conn, ngtcp2_cid *cid, uint8_t *token,
-                          size_t cidlen, void *user_data) {
+int get_new_connection_id(ngtcp2_conn *conn, ngtcp2_cid *cid,
+                          ngtcp2_stateless_reset_token *token, size_t cidlen,
+                          void *user_data) {
   if (util::generate_secure_random({cid->data, cidlen}) != 0) {
     return NGTCP2_ERR_CALLBACK_FAILURE;
   }
 
   cid->datalen = cidlen;
   if (ngtcp2_crypto_generate_stateless_reset_token(
-        token, config.static_secret.data(), config.static_secret.size(), cid) !=
-      0) {
+        token->data, config.static_secret.data(), config.static_secret.size(),
+        cid) != 0) {
     return NGTCP2_ERR_CALLBACK_FAILURE;
   }
 
@@ -622,7 +623,6 @@ int Client::init(int fd, const Address &local_addr, const Address &remote_addr,
     .recv_retry = ngtcp2_crypto_recv_retry_cb,
     .extend_max_local_streams_bidi = extend_max_local_streams_bidi,
     .rand = rand,
-    .get_new_connection_id = get_new_connection_id,
     .update_key = ::update_key,
     .path_validation = path_validation,
     .select_preferred_addr = ::select_preferred_address,
@@ -634,6 +634,7 @@ int Client::init(int fd, const Address &local_addr, const Address &remote_addr,
     .get_path_challenge_data = ngtcp2_crypto_get_path_challenge_data_cb,
     .version_negotiation = ngtcp2_crypto_version_negotiation_cb,
     .tls_early_data_rejected = ::early_data_rejected,
+    .get_new_connection_id2 = get_new_connection_id,
   };
 
   ngtcp2_cid scid, dcid;

--- a/examples/h09server.cc
+++ b/examples/h09server.cc
@@ -522,16 +522,17 @@ void rand(uint8_t *dest, size_t destlen, const ngtcp2_rand_ctx *rand_ctx) {
 } // namespace
 
 namespace {
-int get_new_connection_id(ngtcp2_conn *conn, ngtcp2_cid *cid, uint8_t *token,
-                          size_t cidlen, void *user_data) {
+int get_new_connection_id(ngtcp2_conn *conn, ngtcp2_cid *cid,
+                          ngtcp2_stateless_reset_token *token, size_t cidlen,
+                          void *user_data) {
   if (util::generate_secure_random({cid->data, cidlen}) != 0) {
     return NGTCP2_ERR_CALLBACK_FAILURE;
   }
 
   cid->datalen = cidlen;
   if (ngtcp2_crypto_generate_stateless_reset_token(
-        token, config.static_secret.data(), config.static_secret.size(), cid) !=
-      0) {
+        token->data, config.static_secret.data(), config.static_secret.size(),
+        cid) != 0) {
     return NGTCP2_ERR_CALLBACK_FAILURE;
   }
 
@@ -660,7 +661,6 @@ int Handler::init(const Endpoint &ep, const Address &local_addr,
     .stream_open = stream_open,
     .stream_close = stream_close,
     .rand = rand,
-    .get_new_connection_id = get_new_connection_id,
     .remove_connection_id = remove_connection_id,
     .update_key = ::update_key,
     .path_validation = path_validation,
@@ -669,6 +669,7 @@ int Handler::init(const Endpoint &ep, const Address &local_addr,
     .delete_crypto_cipher_ctx = ngtcp2_crypto_delete_crypto_cipher_ctx_cb,
     .get_path_challenge_data = ngtcp2_crypto_get_path_challenge_data_cb,
     .version_negotiation = ngtcp2_crypto_version_negotiation_cb,
+    .get_new_connection_id2 = get_new_connection_id,
   };
 
   scid_.datalen = NGTCP2_SV_SCIDLEN;

--- a/examples/sim.cc
+++ b/examples/sim.cc
@@ -63,15 +63,16 @@ void rand_bytes(uint8_t *dest, size_t destlen,
   assert(0 == rv);
 }
 
-int get_new_connection_id(ngtcp2_conn *conn, ngtcp2_cid *cid, uint8_t *token,
-                          size_t cidlen, void *user_data) {
+int get_new_connection_id(ngtcp2_conn *conn, ngtcp2_cid *cid,
+                          ngtcp2_stateless_reset_token *token, size_t cidlen,
+                          void *user_data) {
   if (generate_secure_random({cid->data, cidlen}) != 0) {
     return NGTCP2_ERR_CALLBACK_FAILURE;
   }
 
   cid->datalen = cidlen;
   if (ngtcp2_crypto_generate_stateless_reset_token(
-        token, SERVER_SECRET, sizeof(SERVER_SECRET) - 1, cid) != 0) {
+        token->data, SERVER_SECRET, sizeof(SERVER_SECRET) - 1, cid) != 0) {
     return NGTCP2_ERR_CALLBACK_FAILURE;
   }
 
@@ -124,12 +125,12 @@ ngtcp2_callbacks default_client_callbacks() {
     .recv_stream_data = recv_stream_data,
     .recv_retry = ngtcp2_crypto_recv_retry_cb,
     .rand = rand_bytes,
-    .get_new_connection_id = get_new_connection_id,
     .update_key = ngtcp2_crypto_update_key_cb,
     .delete_crypto_aead_ctx = ngtcp2_crypto_delete_crypto_aead_ctx_cb,
     .delete_crypto_cipher_ctx = ngtcp2_crypto_delete_crypto_cipher_ctx_cb,
     .get_path_challenge_data = ngtcp2_crypto_get_path_challenge_data_cb,
     .version_negotiation = ngtcp2_crypto_version_negotiation_cb,
+    .get_new_connection_id2 = get_new_connection_id,
   };
 }
 
@@ -142,12 +143,12 @@ ngtcp2_callbacks default_server_callbacks() {
     .hp_mask = ngtcp2_crypto_hp_mask_cb,
     .recv_stream_data = recv_stream_data,
     .rand = rand_bytes,
-    .get_new_connection_id = get_new_connection_id,
     .update_key = ngtcp2_crypto_update_key_cb,
     .delete_crypto_aead_ctx = ngtcp2_crypto_delete_crypto_aead_ctx_cb,
     .delete_crypto_cipher_ctx = ngtcp2_crypto_delete_crypto_cipher_ctx_cb,
     .get_path_challenge_data = ngtcp2_crypto_get_path_challenge_data_cb,
     .version_negotiation = ngtcp2_crypto_version_negotiation_cb,
+    .get_new_connection_id2 = get_new_connection_id,
   };
 }
 

--- a/examples/simpleclient.c
+++ b/examples/simpleclient.c
@@ -206,8 +206,8 @@ static void rand_cb(uint8_t *dest, size_t destlen,
 }
 
 static int get_new_connection_id_cb(ngtcp2_conn *conn, ngtcp2_cid *cid,
-                                    uint8_t *token, size_t cidlen,
-                                    void *user_data) {
+                                    ngtcp2_stateless_reset_token *token,
+                                    size_t cidlen, void *user_data) {
   (void)conn;
   (void)user_data;
 
@@ -217,7 +217,7 @@ static int get_new_connection_id_cb(ngtcp2_conn *conn, ngtcp2_cid *cid,
 
   cid->datalen = cidlen;
 
-  if (RAND_bytes(token, NGTCP2_STATELESS_RESET_TOKENLEN) != 1) {
+  if (RAND_bytes(token->data, sizeof(token->data)) != 1) {
     return NGTCP2_ERR_CALLBACK_FAILURE;
   }
 
@@ -293,12 +293,12 @@ static int client_quic_init(struct client *c,
     .recv_retry = ngtcp2_crypto_recv_retry_cb,
     .extend_max_local_streams_bidi = extend_max_local_streams_bidi,
     .rand = rand_cb,
-    .get_new_connection_id = get_new_connection_id_cb,
     .update_key = ngtcp2_crypto_update_key_cb,
     .delete_crypto_aead_ctx = ngtcp2_crypto_delete_crypto_aead_ctx_cb,
     .delete_crypto_cipher_ctx = ngtcp2_crypto_delete_crypto_cipher_ctx_cb,
     .get_path_challenge_data = ngtcp2_crypto_get_path_challenge_data_cb,
     .version_negotiation = ngtcp2_crypto_version_negotiation_cb,
+    .get_new_connection_id2 = get_new_connection_id_cb,
   };
   ngtcp2_cid dcid, scid;
   ngtcp2_settings settings;

--- a/tests/ngtcp2_conn_test.c
+++ b/tests/ngtcp2_conn_test.c
@@ -223,13 +223,16 @@ static int null_hp_mask(uint8_t *dest, const ngtcp2_crypto_cipher *hp,
 }
 
 static int get_new_connection_id(ngtcp2_conn *conn, ngtcp2_cid *cid,
-                                 uint8_t *token, size_t cidlen,
-                                 void *user_data) {
+                                 ngtcp2_stateless_reset_token *token,
+                                 size_t cidlen, void *user_data) {
   (void)user_data;
-  memset(cid->data, 0, cidlen);
-  cid->data[0] = (uint8_t)(conn->scid.last_seq + 1);
-  cid->datalen = cidlen;
-  memset(token, 0, NGTCP2_STATELESS_RESET_TOKENLEN);
+
+  *cid = (ngtcp2_cid){
+    .datalen = cidlen,
+    .data = {(uint8_t)(conn->scid.last_seq + 1)},
+  };
+  *token = (ngtcp2_stateless_reset_token){0};
+
   return 0;
 }
 
@@ -870,12 +873,12 @@ static void server_default_callbacks(ngtcp2_callbacks *cb) {
     .encrypt = null_encrypt,
     .hp_mask = null_hp_mask,
     .rand = genrand,
-    .get_new_connection_id = get_new_connection_id,
     .update_key = update_key,
     .delete_crypto_aead_ctx = delete_crypto_aead_ctx,
     .delete_crypto_cipher_ctx = delete_crypto_cipher_ctx,
     .get_path_challenge_data = get_path_challenge_data,
     .version_negotiation = version_negotiation,
+    .get_new_connection_id2 = get_new_connection_id,
   };
 }
 
@@ -946,12 +949,12 @@ static void client_default_callbacks(ngtcp2_callbacks *cb) {
     .hp_mask = null_hp_mask,
     .recv_retry = recv_retry,
     .rand = genrand,
-    .get_new_connection_id = get_new_connection_id,
     .update_key = update_key,
     .delete_crypto_aead_ctx = delete_crypto_aead_ctx,
     .delete_crypto_cipher_ctx = delete_crypto_cipher_ctx,
     .get_path_challenge_data = get_path_challenge_data,
     .version_negotiation = version_negotiation,
+    .get_new_connection_id2 = get_new_connection_id,
   };
 }
 


### PR DESCRIPTION
Migrate to new callbacks that use ngtcp2_stateless_reset_token.