### PR TITLE
Introduce struct ngtcp2_path_challenge_data

### DIFF
--- a/crypto/boringssl/boringssl.c
+++ b/crypto/boringssl/boringssl.c
@@ -568,6 +568,19 @@ int ngtcp2_crypto_get_path_challenge_data_cb(ngtcp2_conn *conn, uint8_t *data,
   return 0;
 }
 
+int ngtcp2_crypto_get_path_challenge_data2_cb(ngtcp2_conn *conn,
+                                              ngtcp2_path_challenge_data *data,
+                                              void *user_data) {
+  (void)conn;
+  (void)user_data;
+
+  if (RAND_bytes(data->data, NGTCP2_PATH_CHALLENGE_DATALEN) != 1) {
+    return NGTCP2_ERR_CALLBACK_FAILURE;
+  }
+
+  return 0;
+}
+
 int ngtcp2_crypto_random(uint8_t *data, size_t datalen) {
   if (RAND_bytes(data, datalen) != 1) {
     return -1;

--- a/crypto/gnutls/gnutls.c
+++ b/crypto/gnutls/gnutls.c
@@ -543,6 +543,20 @@ int ngtcp2_crypto_get_path_challenge_data_cb(ngtcp2_conn *conn, uint8_t *data,
   return 0;
 }
 
+int ngtcp2_crypto_get_path_challenge_data2_cb(ngtcp2_conn *conn,
+                                              ngtcp2_path_challenge_data *data,
+                                              void *user_data) {
+  (void)conn;
+  (void)user_data;
+
+  if (gnutls_rnd(GNUTLS_RND_RANDOM, data->data,
+                 NGTCP2_PATH_CHALLENGE_DATALEN) != 0) {
+    return NGTCP2_ERR_CALLBACK_FAILURE;
+  }
+
+  return 0;
+}
+
 int ngtcp2_crypto_random(uint8_t *data, size_t datalen) {
   if (gnutls_rnd(GNUTLS_RND_RANDOM, data, datalen) != 0) {
     return -1;

--- a/crypto/includes/ngtcp2/ngtcp2_crypto.h
+++ b/crypto/includes/ngtcp2/ngtcp2_crypto.h
@@ -978,10 +978,28 @@ NGTCP2_EXTERN void ngtcp2_crypto_delete_crypto_cipher_ctx_cb(
  *
  * This function can be directly passed to
  * :member:`ngtcp2_callbacks.get_path_challenge_data` field.
+ *
+ * Deprecated since v1.22.0.  Use
+ * `ngtcp2_crypto_get_path_challenge_data2_cb` instead.
  */
 NGTCP2_EXTERN int ngtcp2_crypto_get_path_challenge_data_cb(ngtcp2_conn *conn,
                                                            uint8_t *data,
                                                            void *user_data);
+
+/**
+ * @function
+ *
+ * `ngtcp2_crypto_get_path_challenge_data2_cb` writes unpredictable
+ * sequence of :macro:`NGTCP2_PATH_CHALLENGE_DATALEN` bytes to |data|
+ * which is sent with PATH_CHALLENGE frame.
+ *
+ * This function can be directly passed to
+ * :member:`ngtcp2_callbacks.get_path_challenge_data2` field.
+ *
+ * This function has been available since v1.22.0.
+ */
+NGTCP2_EXTERN int ngtcp2_crypto_get_path_challenge_data2_cb(
+  ngtcp2_conn *conn, ngtcp2_path_challenge_data *data, void *user_data);
 
 /**
  * @function

--- a/crypto/ossl/ossl.c
+++ b/crypto/ossl/ossl.c
@@ -983,6 +983,19 @@ int ngtcp2_crypto_get_path_challenge_data_cb(ngtcp2_conn *conn, uint8_t *data,
   return 0;
 }
 
+int ngtcp2_crypto_get_path_challenge_data2_cb(ngtcp2_conn *conn,
+                                              ngtcp2_path_challenge_data *data,
+                                              void *user_data) {
+  (void)conn;
+  (void)user_data;
+
+  if (RAND_bytes(data->data, NGTCP2_PATH_CHALLENGE_DATALEN) != 1) {
+    return NGTCP2_ERR_CALLBACK_FAILURE;
+  }
+
+  return 0;
+}
+
 int ngtcp2_crypto_random(uint8_t *data, size_t datalen) {
   if (RAND_bytes(data, (int)datalen) != 1) {
     return -1;

--- a/crypto/picotls/picotls.c
+++ b/crypto/picotls/picotls.c
@@ -493,6 +493,17 @@ int ngtcp2_crypto_get_path_challenge_data_cb(ngtcp2_conn *conn, uint8_t *data,
   return 0;
 }
 
+int ngtcp2_crypto_get_path_challenge_data2_cb(ngtcp2_conn *conn,
+                                              ngtcp2_path_challenge_data *data,
+                                              void *user_data) {
+  (void)conn;
+  (void)user_data;
+
+  ptls_openssl_random_bytes(data->data, NGTCP2_PATH_CHALLENGE_DATALEN);
+
+  return 0;
+}
+
 int ngtcp2_crypto_random(uint8_t *data, size_t datalen) {
   ptls_openssl_random_bytes(data, datalen);
 

--- a/crypto/quictls/quictls.c
+++ b/crypto/quictls/quictls.c
@@ -922,6 +922,19 @@ int ngtcp2_crypto_get_path_challenge_data_cb(ngtcp2_conn *conn, uint8_t *data,
   return 0;
 }
 
+int ngtcp2_crypto_get_path_challenge_data2_cb(ngtcp2_conn *conn,
+                                              ngtcp2_path_challenge_data *data,
+                                              void *user_data) {
+  (void)conn;
+  (void)user_data;
+
+  if (RAND_bytes(data->data, NGTCP2_PATH_CHALLENGE_DATALEN) != 1) {
+    return NGTCP2_ERR_CALLBACK_FAILURE;
+  }
+
+  return 0;
+}
+
 int ngtcp2_crypto_random(uint8_t *data, size_t datalen) {
   if (RAND_bytes(data, (int)datalen) != 1) {
     return -1;

--- a/crypto/wolfssl/wolfssl.c
+++ b/crypto/wolfssl/wolfssl.c
@@ -444,6 +444,19 @@ int ngtcp2_crypto_get_path_challenge_data_cb(ngtcp2_conn *conn, uint8_t *data,
   return 0;
 }
 
+int ngtcp2_crypto_get_path_challenge_data2_cb(ngtcp2_conn *conn,
+                                              ngtcp2_path_challenge_data *data,
+                                              void *user_data) {
+  (void)conn;
+  (void)user_data;
+
+  DEBUG_MSG("WOLFSSL: get path challenge data\n");
+  if (wolfSSL_RAND_bytes(data->data, NGTCP2_PATH_CHALLENGE_DATALEN) != 1) {
+    return NGTCP2_ERR_CALLBACK_FAILURE;
+  }
+  return 0;
+}
+
 int ngtcp2_crypto_random(uint8_t *data, size_t datalen) {
   DEBUG_MSG("WOLFSSL: get random\n");
   if (wolfSSL_RAND_bytes(data, (int)datalen) != 1) {

--- a/doc/source/programmers-guide.rst
+++ b/doc/source/programmers-guide.rst
@@ -67,9 +67,9 @@ callback functions must be set:
   <ngtcp2_callbacks.delete_crypto_cipher_ctx>`:
   `ngtcp2_crypto_delete_crypto_cipher_ctx_cb()` can be passed
   directly.
-* :member:`get_path_challenge_data
-  <ngtcp2_callbacks.get_path_challenge_data>`:
-  `ngtcp2_crypto_get_path_challenge_data_cb()` can be passed directly.
+* :member:`get_path_challenge_data2
+  <ngtcp2_callbacks.get_path_challenge_data2>`:
+  `ngtcp2_crypto_get_path_challenge_data2_cb()` can be passed directly.
 * :member:`version_negotiation
   <ngtcp2_callbacks.version_negotiation>`:
   `ngtcp2_crypto_version_negotiation_cb()` can be passed directly.
@@ -99,9 +99,9 @@ For server application, the following callback functions must be set:
   <ngtcp2_callbacks.delete_crypto_cipher_ctx>`:
   `ngtcp2_crypto_delete_crypto_cipher_ctx_cb()` can be passed
   directly.
-* :member:`get_path_challenge_data
-  <ngtcp2_callbacks.get_path_challenge_data>`:
-  `ngtcp2_crypto_get_path_challenge_data_cb()` can be passed directly.
+* :member:`get_path_challenge_data2
+  <ngtcp2_callbacks.get_path_challenge_data2>`:
+  `ngtcp2_crypto_get_path_challenge_data2_cb()` can be passed directly.
 * :member:`version_negotiation
   <ngtcp2_callbacks.version_negotiation>`:
   `ngtcp2_crypto_version_negotiation_cb()` can be passed directly.

--- a/examples/client.cc
+++ b/examples/client.cc
@@ -695,12 +695,12 @@ int Client::init(int fd, const Address &local_addr, const Address &remote_addr,
     .recv_new_token = ::recv_new_token,
     .delete_crypto_aead_ctx = ngtcp2_crypto_delete_crypto_aead_ctx_cb,
     .delete_crypto_cipher_ctx = ngtcp2_crypto_delete_crypto_cipher_ctx_cb,
-    .get_path_challenge_data = ngtcp2_crypto_get_path_challenge_data_cb,
     .stream_stop_sending = stream_stop_sending,
     .version_negotiation = ngtcp2_crypto_version_negotiation_cb,
     .recv_rx_key = ::recv_rx_key,
     .tls_early_data_rejected = ::early_data_rejected,
     .get_new_connection_id2 = get_new_connection_id,
+    .get_path_challenge_data2 = ngtcp2_crypto_get_path_challenge_data2_cb,
   };
 
   ngtcp2_cid scid, dcid;

--- a/examples/gtlssimpleclient.c
+++ b/examples/gtlssimpleclient.c
@@ -334,9 +334,9 @@ static int client_quic_init(struct client *c,
     .update_key = ngtcp2_crypto_update_key_cb,
     .delete_crypto_aead_ctx = ngtcp2_crypto_delete_crypto_aead_ctx_cb,
     .delete_crypto_cipher_ctx = ngtcp2_crypto_delete_crypto_cipher_ctx_cb,
-    .get_path_challenge_data = ngtcp2_crypto_get_path_challenge_data_cb,
     .version_negotiation = ngtcp2_crypto_version_negotiation_cb,
     .get_new_connection_id2 = get_new_connection_id_cb,
+    .get_path_challenge_data2 = ngtcp2_crypto_get_path_challenge_data2_cb,
   };
   ngtcp2_cid dcid, scid;
   ngtcp2_settings settings;

--- a/examples/h09client.cc
+++ b/examples/h09client.cc
@@ -631,10 +631,10 @@ int Client::init(int fd, const Address &local_addr, const Address &remote_addr,
     .recv_new_token = ::recv_new_token,
     .delete_crypto_aead_ctx = ngtcp2_crypto_delete_crypto_aead_ctx_cb,
     .delete_crypto_cipher_ctx = ngtcp2_crypto_delete_crypto_cipher_ctx_cb,
-    .get_path_challenge_data = ngtcp2_crypto_get_path_challenge_data_cb,
     .version_negotiation = ngtcp2_crypto_version_negotiation_cb,
     .tls_early_data_rejected = ::early_data_rejected,
     .get_new_connection_id2 = get_new_connection_id,
+    .get_path_challenge_data2 = ngtcp2_crypto_get_path_challenge_data2_cb,
   };
 
   ngtcp2_cid scid, dcid;

--- a/examples/h09server.cc
+++ b/examples/h09server.cc
@@ -667,9 +667,9 @@ int Handler::init(const Endpoint &ep, const Address &local_addr,
     .extend_max_stream_data = ::extend_max_stream_data,
     .delete_crypto_aead_ctx = ngtcp2_crypto_delete_crypto_aead_ctx_cb,
     .delete_crypto_cipher_ctx = ngtcp2_crypto_delete_crypto_cipher_ctx_cb,
-    .get_path_challenge_data = ngtcp2_crypto_get_path_challenge_data_cb,
     .version_negotiation = ngtcp2_crypto_version_negotiation_cb,
     .get_new_connection_id2 = get_new_connection_id,
+    .get_path_challenge_data2 = ngtcp2_crypto_get_path_challenge_data2_cb,
   };
 
   scid_.datalen = NGTCP2_SV_SCIDLEN;

--- a/examples/server.cc
+++ b/examples/server.cc
@@ -1393,11 +1393,11 @@ int Handler::init(const Endpoint &ep, const Address &local_addr,
     .extend_max_stream_data = ::extend_max_stream_data,
     .delete_crypto_aead_ctx = ngtcp2_crypto_delete_crypto_aead_ctx_cb,
     .delete_crypto_cipher_ctx = ngtcp2_crypto_delete_crypto_cipher_ctx_cb,
-    .get_path_challenge_data = ngtcp2_crypto_get_path_challenge_data_cb,
     .stream_stop_sending = stream_stop_sending,
     .version_negotiation = ngtcp2_crypto_version_negotiation_cb,
     .recv_tx_key = ::recv_tx_key,
     .get_new_connection_id2 = get_new_connection_id,
+    .get_path_challenge_data2 = ngtcp2_crypto_get_path_challenge_data2_cb,
   };
 
   scid_.datalen = NGTCP2_SV_SCIDLEN;

--- a/examples/sim.cc
+++ b/examples/sim.cc
@@ -128,9 +128,9 @@ ngtcp2_callbacks default_client_callbacks() {
     .update_key = ngtcp2_crypto_update_key_cb,
     .delete_crypto_aead_ctx = ngtcp2_crypto_delete_crypto_aead_ctx_cb,
     .delete_crypto_cipher_ctx = ngtcp2_crypto_delete_crypto_cipher_ctx_cb,
-    .get_path_challenge_data = ngtcp2_crypto_get_path_challenge_data_cb,
     .version_negotiation = ngtcp2_crypto_version_negotiation_cb,
     .get_new_connection_id2 = get_new_connection_id,
+    .get_path_challenge_data2 = ngtcp2_crypto_get_path_challenge_data2_cb,
   };
 }
 
@@ -146,9 +146,9 @@ ngtcp2_callbacks default_server_callbacks() {
     .update_key = ngtcp2_crypto_update_key_cb,
     .delete_crypto_aead_ctx = ngtcp2_crypto_delete_crypto_aead_ctx_cb,
     .delete_crypto_cipher_ctx = ngtcp2_crypto_delete_crypto_cipher_ctx_cb,
-    .get_path_challenge_data = ngtcp2_crypto_get_path_challenge_data_cb,
     .version_negotiation = ngtcp2_crypto_version_negotiation_cb,
     .get_new_connection_id2 = get_new_connection_id,
+    .get_path_challenge_data2 = ngtcp2_crypto_get_path_challenge_data2_cb,
   };
 }
 

--- a/examples/simpleclient.c
+++ b/examples/simpleclient.c
@@ -296,9 +296,9 @@ static int client_quic_init(struct client *c,
     .update_key = ngtcp2_crypto_update_key_cb,
     .delete_crypto_aead_ctx = ngtcp2_crypto_delete_crypto_aead_ctx_cb,
     .delete_crypto_cipher_ctx = ngtcp2_crypto_delete_crypto_cipher_ctx_cb,
-    .get_path_challenge_data = ngtcp2_crypto_get_path_challenge_data_cb,
     .version_negotiation = ngtcp2_crypto_version_negotiation_cb,
     .get_new_connection_id2 = get_new_connection_id_cb,
+    .get_path_challenge_data2 = ngtcp2_crypto_get_path_challenge_data2_cb,
   };
   ngtcp2_cid dcid, scid;
   ngtcp2_settings settings;

--- a/fuzz/read_write_handshake_pkt.cc
+++ b/fuzz/read_write_handshake_pkt.cc
@@ -241,8 +241,10 @@ void delete_crypto_cipher_ctx(ngtcp2_conn *conn,
 } // namespace
 
 namespace {
-int get_path_challenge_data(ngtcp2_conn *conn, uint8_t *data, void *user_data) {
-  memset(data, 0, NGTCP2_PATH_CHALLENGE_DATALEN);
+int get_path_challenge_data2(ngtcp2_conn *conn,
+                             ngtcp2_path_challenge_data *data,
+                             void *user_data) {
+  *data = {};
 
   return 0;
 }
@@ -313,9 +315,9 @@ ngtcp2_conn *setup_conn(TLSState *state) {
     .update_key = update_key,
     .delete_crypto_aead_ctx = delete_crypto_aead_ctx,
     .delete_crypto_cipher_ctx = delete_crypto_cipher_ctx,
-    .get_path_challenge_data = get_path_challenge_data,
     .version_negotiation = version_negotiation,
     .get_new_connection_id2 = get_new_connection_id2,
+    .get_path_challenge_data2 = get_path_challenge_data2,
   };
 
   ngtcp2_path_storage ps;

--- a/fuzz/read_write_pkt.cc
+++ b/fuzz/read_write_pkt.cc
@@ -517,6 +517,22 @@ int dcid_status2(ngtcp2_conn *conn, ngtcp2_connection_id_status_type type,
 } // namespace
 
 namespace {
+int get_path_challenge_data2(ngtcp2_conn *conn,
+                             ngtcp2_path_challenge_data *data,
+                             void *user_data) {
+  auto fuzzed_data_provider = static_cast<FuzzedDataProvider *>(user_data);
+
+  if (fuzzed_data_provider->ConsumeBool()) {
+    return NGTCP2_ERR_CALLBACK_FAILURE;
+  }
+
+  *data = {};
+
+  return 0;
+}
+} // namespace
+
+namespace {
 void init_path(ngtcp2_path_storage *ps) {
   addrinfo *local, *remote,
     hints{
@@ -618,6 +634,7 @@ ngtcp2_conn *setup_conn(FuzzedDataProvider &fuzzed_data_provider,
     .recv_stateless_reset2 = recv_stateless_reset2,
     .get_new_connection_id2 = get_new_connection_id2,
     .dcid_status2 = dcid_status2,
+    .get_path_challenge_data2 = get_path_challenge_data2,
   };
 
   if (fuzzed_data_provider.ConsumeBool()) {
@@ -630,6 +647,10 @@ ngtcp2_conn *setup_conn(FuzzedDataProvider &fuzzed_data_provider,
 
   if (fuzzed_data_provider.ConsumeBool()) {
     cb.dcid_status2 = nullptr;
+  }
+
+  if (fuzzed_data_provider.ConsumeBool()) {
+    cb.get_path_challenge_data2 = nullptr;
   }
 
   ngtcp2_cid dcid, scid, odcid;

--- a/lib/includes/ngtcp2/ngtcp2.h
+++ b/lib/includes/ngtcp2/ngtcp2.h
@@ -3370,6 +3370,9 @@ typedef int (*ngtcp2_lost_datagram)(ngtcp2_conn *conn, uint64_t dgram_id,
  * The callback function must return 0 if it succeeds.  Returning
  * :macro:`NGTCP2_ERR_CALLBACK_FAILURE` makes the library call return
  * immediately.
+ *
+ * Deprecated since v1.22.0.  Use
+ * :type:`ngtcp2_get_path_challenge_data2` instead.
  */
 typedef int (*ngtcp2_get_path_challenge_data)(ngtcp2_conn *conn, uint8_t *data,
                                               void *user_data);
@@ -3499,6 +3502,36 @@ typedef int (*ngtcp2_connection_id_status2)(
   ngtcp2_conn *conn, ngtcp2_connection_id_status_type type, uint64_t seq,
   const ngtcp2_cid *cid, const ngtcp2_stateless_reset_token *token,
   void *user_data);
+
+/**
+ * @struct
+ *
+ * :type:`ngtcp2_path_challenge_data` stores path challenge data.
+ *
+ * This type has been available since v1.22.0.
+ */
+typedef struct ngtcp2_path_challenge_data {
+  uint8_t data[NGTCP2_PATH_CHALLENGE_DATALEN];
+} ngtcp2_path_challenge_data;
+
+/**
+ * @functypedef
+ *
+ * :type:`ngtcp2_get_path_challenge_data2` is a callback function to
+ * ask an application for new data that is sent in PATH_CHALLENGE
+ * frame.  Application must generate new unpredictable, exactly
+ * :macro:`NGTCP2_PATH_CHALLENGE_DATALEN` bytes of random data, and
+ * store them into |data|.
+ *
+ * The callback function must return 0 if it succeeds.  Returning
+ * :macro:`NGTCP2_ERR_CALLBACK_FAILURE` makes the library call return
+ * immediately.
+ *
+ * This type has been available since v1.22.0.
+ */
+typedef int (*ngtcp2_get_path_challenge_data2)(ngtcp2_conn *conn,
+                                               ngtcp2_path_challenge_data *data,
+                                               void *user_data);
 
 #define NGTCP2_CALLBACKS_V1 1
 #define NGTCP2_CALLBACKS_V2 2
@@ -3747,6 +3780,9 @@ typedef struct ngtcp2_callbacks {
    * :member:`get_path_challenge_data` is a callback function which is
    * invoked when the library needs new data sent along with
    * PATH_CHALLENGE frame.  This callback must be specified.
+   *
+   * Deprecated since v1.22.0.  Use :member:`get_path_challenge_data2`
+   * instead.
    */
   ngtcp2_get_path_challenge_data get_path_challenge_data;
   /**
@@ -3812,6 +3848,13 @@ typedef struct ngtcp2_callbacks {
    * v1.22.0.
    */
   ngtcp2_connection_id_status2 dcid_status2;
+  /**
+   * :member:`get_path_challenge_data2` is a callback function which
+   * is invoked when the library needs new data sent along with
+   * PATH_CHALLENGE frame.  This callback must be specified.  This
+   * field is available since v1.22.0.
+   */
+  ngtcp2_get_path_challenge_data2 get_path_challenge_data2;
 } ngtcp2_callbacks;
 
 /**

--- a/lib/ngtcp2_conn.h
+++ b/lib/ngtcp2_conn.h
@@ -114,12 +114,12 @@ typedef enum {
 
 typedef struct ngtcp2_path_challenge_entry {
   ngtcp2_path_storage ps;
-  uint8_t data[NGTCP2_PATH_CHALLENGE_DATALEN];
+  ngtcp2_path_challenge_data data;
 } ngtcp2_path_challenge_entry;
 
 void ngtcp2_path_challenge_entry_init(ngtcp2_path_challenge_entry *pcent,
                                       const ngtcp2_path *path,
-                                      const uint8_t *data);
+                                      const ngtcp2_path_challenge_data *data);
 
 /* NGTCP2_CONN_FLAG_NONE indicates that no flag is set. */
 #define NGTCP2_CONN_FLAG_NONE 0x00U

--- a/lib/ngtcp2_log.c
+++ b/lib/ngtcp2_log.c
@@ -356,25 +356,25 @@ static void log_fr_stop_sending(ngtcp2_log *log, const ngtcp2_pkt_hd *hd,
 static void log_fr_path_challenge(ngtcp2_log *log, const ngtcp2_pkt_hd *hd,
                                   const ngtcp2_path_challenge *fr,
                                   const char *dir) {
-  char buf[sizeof(fr->data) * 2 + 1];
+  char buf[sizeof(fr->data.data) * 2 + 1];
 
-  ngtcp2_log_infof_raw(log, NGTCP2_LOG_EVENT_FRM,
-                       NGTCP2_LOG_PKT " PATH_CHALLENGE(0x%02" PRIx64
-                                      ") data=0x%s",
-                       NGTCP2_LOG_PKT_HD_FIELDS(dir), fr->type,
-                       ngtcp2_encode_hex_cstr(buf, fr->data, sizeof(fr->data)));
+  ngtcp2_log_infof_raw(
+    log, NGTCP2_LOG_EVENT_FRM,
+    NGTCP2_LOG_PKT " PATH_CHALLENGE(0x%02" PRIx64 ") data=0x%s",
+    NGTCP2_LOG_PKT_HD_FIELDS(dir), fr->type,
+    ngtcp2_encode_hex_cstr(buf, fr->data.data, sizeof(fr->data.data)));
 }
 
 static void log_fr_path_response(ngtcp2_log *log, const ngtcp2_pkt_hd *hd,
                                  const ngtcp2_path_response *fr,
                                  const char *dir) {
-  char buf[sizeof(fr->data) * 2 + 1];
+  char buf[sizeof(fr->data.data) * 2 + 1];
 
-  ngtcp2_log_infof_raw(log, NGTCP2_LOG_EVENT_FRM,
-                       NGTCP2_LOG_PKT " PATH_RESPONSE(0x%02" PRIx64
-                                      ") data=0x%s",
-                       NGTCP2_LOG_PKT_HD_FIELDS(dir), fr->type,
-                       ngtcp2_encode_hex_cstr(buf, fr->data, sizeof(fr->data)));
+  ngtcp2_log_infof_raw(
+    log, NGTCP2_LOG_EVENT_FRM,
+    NGTCP2_LOG_PKT " PATH_RESPONSE(0x%02" PRIx64 ") data=0x%s",
+    NGTCP2_LOG_PKT_HD_FIELDS(dir), fr->type,
+    ngtcp2_encode_hex_cstr(buf, fr->data.data, sizeof(fr->data.data)));
 }
 
 static void log_fr_crypto(ngtcp2_log *log, const ngtcp2_pkt_hd *hd,

--- a/lib/ngtcp2_pkt.c
+++ b/lib/ngtcp2_pkt.c
@@ -1267,7 +1267,7 @@ ngtcp2_ssize ngtcp2_pkt_decode_path_challenge_frame(ngtcp2_path_challenge *dest,
   p = payload + 1;
 
   dest->type = NGTCP2_FRAME_PATH_CHALLENGE;
-  ngtcp2_cpymem(dest->data, p, sizeof(dest->data));
+  ngtcp2_cpymem(dest->data.data, p, sizeof(dest->data.data));
   p += sizeof(dest->data);
 
   assert((size_t)(p - payload) == len);
@@ -1288,7 +1288,7 @@ ngtcp2_ssize ngtcp2_pkt_decode_path_response_frame(ngtcp2_path_response *dest,
   p = payload + 1;
 
   dest->type = NGTCP2_FRAME_PATH_RESPONSE;
-  ngtcp2_cpymem(dest->data, p, sizeof(dest->data));
+  ngtcp2_cpymem(dest->data.data, p, sizeof(dest->data.data));
   p += sizeof(dest->data);
 
   assert((size_t)(p - payload) == len);
@@ -1938,7 +1938,7 @@ ngtcp2_pkt_encode_path_challenge_frame(uint8_t *out, size_t outlen,
   p = out;
 
   *p++ = NGTCP2_FRAME_PATH_CHALLENGE;
-  p = ngtcp2_cpymem(p, fr->data, sizeof(fr->data));
+  p = ngtcp2_cpymem(p, fr->data.data, sizeof(fr->data.data));
 
   assert((size_t)(p - out) == len);
 
@@ -1958,7 +1958,7 @@ ngtcp2_pkt_encode_path_response_frame(uint8_t *out, size_t outlen,
   p = out;
 
   *p++ = NGTCP2_FRAME_PATH_RESPONSE;
-  p = ngtcp2_cpymem(p, fr->data, sizeof(fr->data));
+  p = ngtcp2_cpymem(p, fr->data.data, sizeof(fr->data.data));
 
   assert((size_t)(p - out) == len);
 

--- a/lib/ngtcp2_pkt.h
+++ b/lib/ngtcp2_pkt.h
@@ -311,12 +311,12 @@ typedef struct ngtcp2_stop_sending {
 
 typedef struct ngtcp2_path_challenge {
   uint64_t type;
-  uint8_t data[NGTCP2_PATH_CHALLENGE_DATALEN];
+  ngtcp2_path_challenge_data data;
 } ngtcp2_path_challenge;
 
 typedef struct ngtcp2_path_response {
   uint64_t type;
-  uint8_t data[NGTCP2_PATH_CHALLENGE_DATALEN];
+  ngtcp2_path_challenge_data data;
 } ngtcp2_path_response;
 
 typedef struct ngtcp2_new_token {

--- a/lib/ngtcp2_pv.h
+++ b/lib/ngtcp2_pv.h
@@ -57,10 +57,11 @@ typedef struct ngtcp2_pv_entry {
   /* flags is zero or more of NGTCP2_PV_ENTRY_FLAG_*. */
   uint8_t flags;
   /* data is a byte string included in PATH_CHALLENGE. */
-  uint8_t data[NGTCP2_PATH_CHALLENGE_DATALEN];
+  ngtcp2_path_challenge_data data;
 } ngtcp2_pv_entry;
 
-void ngtcp2_pv_entry_init(ngtcp2_pv_entry *pvent, const uint8_t *data,
+void ngtcp2_pv_entry_init(ngtcp2_pv_entry *pvent,
+                          const ngtcp2_path_challenge_data *data,
                           ngtcp2_tstamp expiry, uint8_t flags);
 
 /* NGTCP2_PV_FLAG_NONE indicates no flag is set. */
@@ -141,7 +142,7 @@ void ngtcp2_pv_del(ngtcp2_pv *pv);
  * ngtcp2_pv_add_entry adds new entry with |data|.  |expiry| is the
  * expiry time of the entry.
  */
-void ngtcp2_pv_add_entry(ngtcp2_pv *pv, const uint8_t *data,
+void ngtcp2_pv_add_entry(ngtcp2_pv *pv, const ngtcp2_path_challenge_data *data,
                          ngtcp2_tstamp expiry, uint8_t flags, ngtcp2_tstamp ts);
 
 /*
@@ -164,7 +165,8 @@ int ngtcp2_pv_full(ngtcp2_pv *pv);
  * NGTCP2_ERR_INVALID_ARGUMENT
  *     |pv| does not have an entry which has |data| and |path|
  */
-int ngtcp2_pv_validate(ngtcp2_pv *pv, uint8_t *pflags, const uint8_t *data);
+int ngtcp2_pv_validate(ngtcp2_pv *pv, uint8_t *pflags,
+                       const ngtcp2_path_challenge_data *data);
 
 /*
  * ngtcp2_pv_handle_entry_expiry checks expiry of existing entries.

--- a/lib/ngtcp2_qlog.c
+++ b/lib/ngtcp2_qlog.c
@@ -577,7 +577,7 @@ static uint8_t *write_path_challenge_frame(uint8_t *p,
 #define NGTCP2_QLOG_PATH_CHALLENGE_FRAME_OVERHEAD 57
 
   p = write_verbatim(p, "{\"frame_type\":\"path_challenge\",");
-  p = write_pair_hex(p, "data", fr->data, sizeof(fr->data));
+  p = write_pair_hex(p, "data", fr->data.data, sizeof(fr->data.data));
   *p++ = '}';
 
   return p;
@@ -591,7 +591,7 @@ static uint8_t *write_path_response_frame(uint8_t *p,
 #define NGTCP2_QLOG_PATH_RESPONSE_FRAME_OVERHEAD 56
 
   p = write_verbatim(p, "{\"frame_type\":\"path_response\",");
-  p = write_pair_hex(p, "data", fr->data, sizeof(fr->data));
+  p = write_pair_hex(p, "data", fr->data.data, sizeof(fr->data.data));
   *p++ = '}';
 
   return p;

--- a/tests/ngtcp2_callbacks_test.c
+++ b/tests/ngtcp2_callbacks_test.c
@@ -522,6 +522,16 @@ static int dcid_status2(ngtcp2_conn *conn,
   return 0;
 }
 
+static int get_path_challenge_data2(ngtcp2_conn *conn,
+                                    ngtcp2_path_challenge_data *data,
+                                    void *user_data) {
+  (void)conn;
+  (void)data;
+  (void)user_data;
+
+  return 0;
+}
+
 void test_ngtcp2_callbacks_convert_to_latest(void) {
   ngtcp2_callbacks srcbuf = {
     .client_initial = client_initial,
@@ -635,6 +645,7 @@ void test_ngtcp2_callbacks_convert_to_latest(void) {
   assert_null(dest->recv_stateless_reset2);
   assert_null(dest->get_new_connection_id2);
   assert_null(dest->dcid_status2);
+  assert_null(dest->get_path_challenge_data2);
 }
 
 void test_ngtcp2_callbacks_convert_to_old(void) {
@@ -683,6 +694,7 @@ void test_ngtcp2_callbacks_convert_to_old(void) {
     .recv_stateless_reset2 = recv_stateless_reset2,
     .get_new_connection_id2 = get_new_connection_id2,
     .dcid_status2 = dcid_status2,
+    .get_path_challenge_data2 = get_path_challenge_data2,
   };
   ngtcp2_callbacks *dest, destbuf;
   size_t v2len;
@@ -751,4 +763,5 @@ void test_ngtcp2_callbacks_convert_to_old(void) {
   assert_null(destbuf.recv_stateless_reset2);
   assert_null(destbuf.get_new_connection_id2);
   assert_null(destbuf.dcid_status2);
+  assert_null(destbuf.get_path_challenge_data2);
 }

--- a/tests/ngtcp2_log_test.c
+++ b/tests/ngtcp2_log_test.c
@@ -918,7 +918,10 @@ void test_ngtcp2_log_fr(void) {
       .path_challenge =
         {
           .type = NGTCP2_FRAME_PATH_CHALLENGE,
-          .data = {0xDE, 0xAD, 0xBE, 0xEF, 0xBA, 0xAD, 0xCA, 0xCE},
+          .data =
+            {
+              .data = {0xDE, 0xAD, 0xBE, 0xEF, 0xBA, 0xAD, 0xCA, 0xCE},
+            },
         },
     });
 
@@ -941,7 +944,10 @@ void test_ngtcp2_log_fr(void) {
       .path_response =
         {
           .type = NGTCP2_FRAME_PATH_RESPONSE,
-          .data = {0xDE, 0xAD, 0xBE, 0xEF, 0xBA, 0xAD, 0xF0, 0x0D},
+          .data =
+            {
+              .data = {0xDE, 0xAD, 0xBE, 0xEF, 0xBA, 0xAD, 0xF0, 0x0D},
+            },
         },
     });
 

--- a/tests/ngtcp2_pkt_test.c
+++ b/tests/ngtcp2_pkt_test.c
@@ -1533,10 +1533,13 @@ void test_ngtcp2_pkt_encode_path_challenge_frame(void) {
   size_t framelen = 1 + 8;
   size_t i;
 
-  fr.type = NGTCP2_FRAME_PATH_CHALLENGE;
-  for (i = 0; i < sizeof(fr.data); ++i) {
-    fr.data[i] = (uint8_t)(i + 1);
-  }
+  fr = (ngtcp2_path_challenge){
+    .type = NGTCP2_FRAME_PATH_CHALLENGE,
+    .data =
+      {
+        .data = {0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08},
+      },
+  };
 
   rv = ngtcp2_pkt_encode_path_challenge_frame(buf, sizeof(buf), &fr);
 
@@ -1546,7 +1549,7 @@ void test_ngtcp2_pkt_encode_path_challenge_frame(void) {
 
   assert_ptrdiff((ngtcp2_ssize)framelen, ==, rv);
   assert_uint64(fr.type, ==, nfr.type);
-  assert_memory_equal(sizeof(fr.data), fr.data, nfr.data);
+  assert_memory_equal(sizeof(fr.data.data), fr.data.data, nfr.data.data);
 
   /* Fail if a frame is truncated. */
   for (i = 1; i < framelen; ++i) {
@@ -1563,10 +1566,13 @@ void test_ngtcp2_pkt_encode_path_response_frame(void) {
   size_t framelen = 1 + 8;
   size_t i;
 
-  fr.type = NGTCP2_FRAME_PATH_RESPONSE;
-  for (i = 0; i < sizeof(fr.data); ++i) {
-    fr.data[i] = (uint8_t)(i + 1);
-  }
+  fr = (ngtcp2_path_response){
+    .type = NGTCP2_FRAME_PATH_RESPONSE,
+    .data =
+      {
+        .data = {0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08},
+      },
+  };
 
   rv = ngtcp2_pkt_encode_path_response_frame(buf, sizeof(buf), &fr);
 
@@ -1576,7 +1582,7 @@ void test_ngtcp2_pkt_encode_path_response_frame(void) {
 
   assert_ptrdiff((ngtcp2_ssize)framelen, ==, rv);
   assert_uint64(fr.type, ==, nfr.type);
-  assert_memory_equal(sizeof(fr.data), fr.data, nfr.data);
+  assert_memory_equal(sizeof(fr.data.data), fr.data.data, nfr.data.data);
 
   /* Fail if a frame is truncated. */
   for (i = 1; i < framelen; ++i) {

--- a/tests/ngtcp2_qlog_test.c
+++ b/tests/ngtcp2_qlog_test.c
@@ -478,9 +478,11 @@ void test_ngtcp2_qlog_write_frame(void) {
   {
     fr.path_challenge = (ngtcp2_path_challenge){
       .type = NGTCP2_FRAME_PATH_CHALLENGE,
+      .data =
+        {
+          .data = {0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88},
+        },
     };
-    memcpy(fr.path_challenge.data, "\x11\x22\x33\x44\x55\x66\x77\x88",
-           NGTCP2_PATH_CHALLENGE_DATALEN);
 
     ngtcp2_qlog_write_frame(&qlog, &fr);
     *qlog.buf.last = '\0';
@@ -495,9 +497,11 @@ void test_ngtcp2_qlog_write_frame(void) {
   {
     fr.path_response = (ngtcp2_path_response){
       .type = NGTCP2_FRAME_PATH_RESPONSE,
+      .data =
+        {
+          .data = {0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99},
+        },
     };
-    memcpy(fr.path_challenge.data, "\x22\x33\x44\x55\x66\x77\x88\x99",
-           NGTCP2_PATH_CHALLENGE_DATALEN);
 
     ngtcp2_qlog_write_frame(&qlog, &fr);
     *qlog.buf.last = '\0';


### PR DESCRIPTION
This commit introduces struct ngtcp2_path_challenge_data just like ngtcp2_stateless_reset_token in earlier commits.

This commit deprecates ngtcp2_get_path_challenge_data.  It adds ngtcp2_get_path_challenge_data2 as a replacement.

This commit deprecates ngtcp2_crypto_get_path_challenge_data_cb.  It adds ngtcp2_crypto_get_path_challenge_data2_cb as a replacement.