### PR TITLE
crypto: No need to disable padding for aes-ecb

### DIFF
--- a/crypto/ossl/ossl.c
+++ b/crypto/ossl/ossl.c
@@ -661,8 +661,6 @@ int ngtcp2_crypto_cipher_ctx_encrypt_init(ngtcp2_crypto_cipher_ctx *cipher_ctx,
     return -1;
   }
 
-  EVP_CIPHER_CTX_set_padding(actx, 0);
-
   cipher_ctx->native_handle = actx;
 
   return 0;

--- a/crypto/quictls/quictls.c
+++ b/crypto/quictls/quictls.c
@@ -508,8 +508,6 @@ int ngtcp2_crypto_cipher_ctx_encrypt_init(ngtcp2_crypto_cipher_ctx *cipher_ctx,
     return -1;
   }
 
-  EVP_CIPHER_CTX_set_padding(actx, 0);
-
   cipher_ctx->native_handle = actx;
 
   return 0;


### PR DESCRIPTION
We always feed 16 bytes to encrypt and never decrypt them.  That means no need to disable padding for openssl EVP.