### PR TITLE
Rewrite fallback ntoh/hton functions for win32

### DIFF
--- a/lib/ngtcp2_net.h
+++ b/lib/ngtcp2_net.h
@@ -94,39 +94,19 @@
 #  endif /* !defined(_MSC_VER) */
 
 STIN uint32_t ngtcp2_htonl(uint32_t hostlong) {
-  uint32_t res;
-  unsigned char *p = (unsigned char *)&res;
-  *p++ = (unsigned char)(hostlong >> 24);
-  *p++ = (hostlong >> 16) & 0xFFU;
-  *p++ = (hostlong >> 8) & 0xFFU;
-  *p = hostlong & 0xFFU;
-  return res;
+  return _byteswap_ulong(hostlong);
 }
 
 STIN uint16_t ngtcp2_htons(uint16_t hostshort) {
-  uint16_t res;
-  unsigned char *p = (unsigned char *)&res;
-  *p++ = (unsigned char)(hostshort >> 8);
-  *p = hostshort & 0xFFU;
-  return res;
+  return _byteswap_ushort(hostshort);
 }
 
 STIN uint32_t ngtcp2_ntohl(uint32_t netlong) {
-  uint32_t res;
-  unsigned char *p = (unsigned char *)&netlong;
-  res = (uint32_t)(*p++ << 24);
-  res += (uint32_t)(*p++ << 16);
-  res += (uint32_t)(*p++ << 8);
-  res += *p;
-  return res;
+  return _byteswap_ulong(netlong);
 }
 
 STIN uint16_t ngtcp2_ntohs(uint16_t netshort) {
-  uint16_t res;
-  unsigned char *p = (unsigned char *)&netshort;
-  res = (uint16_t)(*p++ << 8);
-  res += *p;
-  return res;
+  return _byteswap_ushort(netshort);
 }
 
 #else /* !defined(WIN32) */


### PR DESCRIPTION
Because we assume win32 build is little endian only, we always do byteswap.