### PR TITLE
Revert "fix: prevent max_idle_timeout multiplication overflow in transport params decode"

### DIFF
--- a/lib/ngtcp2_transport_params.c
+++ b/lib/ngtcp2_transport_params.c
@@ -586,9 +586,6 @@ int ngtcp2_transport_params_decode_versioned(int transport_params_version,
       if (decode_varint_param(&params->max_idle_timeout, &p, end) != 0) {
         return NGTCP2_ERR_MALFORMED_TRANSPORT_PARAM;
       }
-      if (params->max_idle_timeout > UINT64_MAX / NGTCP2_MILLISECONDS) {
-        return NGTCP2_ERR_MALFORMED_TRANSPORT_PARAM;
-      }
       params->max_idle_timeout *= NGTCP2_MILLISECONDS;
       break;
     case NGTCP2_TRANSPORT_PARAM_MAX_UDP_PAYLOAD_SIZE:

--- a/tests/ngtcp2_transport_params_test.c
+++ b/tests/ngtcp2_transport_params_test.c
@@ -38,7 +38,6 @@ static const MunitTest tests[] = {
   munit_void_test(test_ngtcp2_transport_params_decode_new),
   munit_void_test(test_ngtcp2_transport_params_convert_to_latest),
   munit_void_test(test_ngtcp2_transport_params_convert_to_old),
-  munit_void_test(test_ngtcp2_transport_params_decode_max_idle_timeout_overflow),
   munit_test_end(),
 };
 
@@ -584,20 +583,3 @@ void test_ngtcp2_transport_params_convert_to_latest(void) {
 }
 
 void test_ngtcp2_transport_params_convert_to_old(void) {}
-
-void test_ngtcp2_transport_params_decode_max_idle_timeout_overflow(void) {
-  ngtcp2_transport_params params;
-  uint8_t buf[32];
-  uint8_t *p = buf;
-  int rv;
-
-  /* Encode max_idle_timeout transport param with value NGTCP2_MAX_VARINT,
-     which overflows when multiplied by NGTCP2_MILLISECONDS. */
-  p = ngtcp2_put_uvarint(p, NGTCP2_TRANSPORT_PARAM_MAX_IDLE_TIMEOUT);
-  p = ngtcp2_put_uvarint(p, ngtcp2_put_uvarintlen(NGTCP2_MAX_VARINT));
-  p = ngtcp2_put_uvarint(p, NGTCP2_MAX_VARINT);
-
-  rv = ngtcp2_transport_params_decode(&params, buf, (size_t)(p - buf));
-
-  assert_int(NGTCP2_ERR_MALFORMED_TRANSPORT_PARAM, ==, rv);
-}

--- a/tests/ngtcp2_transport_params_test.h
+++ b/tests/ngtcp2_transport_params_test.h
@@ -40,6 +40,5 @@ munit_void_test_decl(test_ngtcp2_transport_params_decode)
 munit_void_test_decl(test_ngtcp2_transport_params_decode_new)
 munit_void_test_decl(test_ngtcp2_transport_params_convert_to_latest)
 munit_void_test_decl(test_ngtcp2_transport_params_convert_to_old)
-munit_void_test_decl(test_ngtcp2_transport_params_decode_max_idle_timeout_overflow)
 
 #endif /* !defined(NGTCP2_TRANSPORT_PARAMS_TEST_H) */


### PR DESCRIPTION
Reverts ngtcp2/ngtcp2#2139