### PR TITLE
examples: Enable X25519MLKEM768 for LibreSSL

### DIFF
--- a/examples/util_openssl.cc
+++ b/examples/util_openssl.cc
@@ -166,7 +166,7 @@ const char *crypto_default_ciphers() {
 
 const char *crypto_default_groups() {
   return "X25519:P-256:P-384:P-521"
-#if defined(WITH_EXAMPLE_BORINGSSL) || defined(WITH_EXAMPLE_OSSL)
+#if defined(WITH_EXAMPLE_BORINGSSL) || defined(WITH_EXAMPLE_OSSL) || defined(LIBRESSL_VERSION_NUMBER)
          ":X25519MLKEM768"
 #endif // defined(WITH_EXAMPLE_BORINGSSL) || defined(WITH_EXAMPLE_OSSL)
     ;


### PR DESCRIPTION
Since LibreSSL v4.3.1 supports X25519MLKEM768 now, enables it like https://github.com/ngtcp2/ngtcp2/pull/1426