### PR TITLE
ppe: Robust ngtcp2_ppe_padding_size

### DIFF
--- a/lib/ngtcp2_conn.c
+++ b/lib/ngtcp2_conn.c
@@ -2545,10 +2545,6 @@ conn_write_handshake_pkt(ngtcp2_conn *conn, ngtcp2_pkt_info *pi, uint8_t *dest,
     return 0;
   }
 
-  if (!ngtcp2_ppe_ensure_hp_sample(&ppe)) {
-    return 0;
-  }
-
   lfr.ack.ranges = ack_ranges;
   if (ngtcp2_acktr_create_ack_frame(&pktns->acktr, &lfr.ack, type, ts,
                                     /* ack_delay = */ 0,
@@ -3662,10 +3658,6 @@ static ngtcp2_ssize conn_write_pkt(ngtcp2_conn *conn, ngtcp2_pkt_info *pi,
       return 0;
     }
 
-    if (!ngtcp2_ppe_ensure_hp_sample(ppe)) {
-      return 0;
-    }
-
     if (ngtcp2_ringbuf_len(&conn->rx.path_challenge.rb)) {
       pcent = ngtcp2_ringbuf_get(&conn->rx.path_challenge.rb, 0);
 
@@ -4645,10 +4637,6 @@ ngtcp2_ssize ngtcp2_conn_write_single_frame_pkt(
   rv = ngtcp2_ppe_encode_hd(&ppe, &hd);
   if (rv != 0) {
     assert(NGTCP2_ERR_NOBUF == rv);
-    return 0;
-  }
-
-  if (!ngtcp2_ppe_ensure_hp_sample(&ppe)) {
     return 0;
   }
 
@@ -14424,10 +14412,6 @@ ngtcp2_ssize ngtcp2_pkt_write_connection_close(
   if (rv != 0) {
     assert(NGTCP2_ERR_NOBUF == rv);
     return rv;
-  }
-
-  if (!ngtcp2_ppe_ensure_hp_sample(&ppe)) {
-    return NGTCP2_ERR_NOBUF;
   }
 
   fr.connection_close = (ngtcp2_connection_close){

--- a/lib/ngtcp2_ppe.c
+++ b/lib/ngtcp2_ppe.c
@@ -44,6 +44,14 @@ void ngtcp2_ppe_init(ngtcp2_ppe *ppe, uint8_t *out, size_t outlen,
   ppe->cc = cc;
 }
 
+/*
+ * ppe_sample_offset returns the offset to sample for packet number
+ * encryption.
+ */
+static size_t ppe_sample_offset(ngtcp2_ppe *ppe) {
+  return ppe->pkt_num_offset + 4;
+}
+
 int ngtcp2_ppe_encode_hd(ngtcp2_ppe *ppe, const ngtcp2_pkt_hd *hd) {
   ngtcp2_ssize rv;
   ngtcp2_buf *buf = &ppe->buf;
@@ -78,6 +86,10 @@ int ngtcp2_ppe_encode_hd(ngtcp2_ppe *ppe, const ngtcp2_pkt_hd *hd) {
 
   buf->last += rv;
 
+  if (ngtcp2_buf_cap(buf) < ppe_sample_offset(ppe) + NGTCP2_HP_SAMPLELEN) {
+    return NGTCP2_ERR_NOBUF;
+  }
+
   ppe->pkt_numlen = hd->pkt_numlen;
   ppe->hdlen = (size_t)rv;
   ppe->pkt_num = hd->pkt_num;
@@ -103,14 +115,6 @@ int ngtcp2_ppe_encode_frame(ngtcp2_ppe *ppe, ngtcp2_frame *fr) {
   buf->last += rv;
 
   return 0;
-}
-
-/*
- * ppe_sample_offset returns the offset to sample for packet number
- * encryption.
- */
-static size_t ppe_sample_offset(ngtcp2_ppe *ppe) {
-  return ppe->pkt_num_offset + 4;
 }
 
 ngtcp2_ssize ngtcp2_ppe_final(ngtcp2_ppe *ppe, const uint8_t **ppkt) {
@@ -187,7 +191,7 @@ size_t ngtcp2_ppe_padding_size(ngtcp2_ppe *ppe, size_t n) {
   ngtcp2_buf *buf = &ppe->buf;
   size_t pktlen = ngtcp2_buf_len(buf) + cc->aead.max_overhead;
   size_t len = 0;
-  size_t max_samplelen;
+  size_t min_pktlen;
 
   n = ngtcp2_min(n, ngtcp2_buf_cap(buf));
   if (pktlen < n) {
@@ -195,13 +199,13 @@ size_t ngtcp2_ppe_padding_size(ngtcp2_ppe *ppe, size_t n) {
   }
 
   /* Ensure header protection sample */
-  max_samplelen =
-    ngtcp2_buf_len(buf) + cc->aead.max_overhead - ppe_sample_offset(ppe);
-
-  if (max_samplelen < NGTCP2_HP_SAMPLELEN) {
-    len = ngtcp2_max(len, NGTCP2_HP_SAMPLELEN - max_samplelen);
+  min_pktlen = ppe_sample_offset(ppe) + NGTCP2_HP_SAMPLELEN;
+  if (pktlen < min_pktlen) {
+    len = ngtcp2_max(len, min_pktlen - pktlen);
   }
 
+  /* ngtcp2_ppe_encode_hd ensures that the buffer has enough capacity
+     for the padding required for header protection sample. */
   assert(ngtcp2_buf_left(buf) >= len + cc->aead.max_overhead);
 
   if (len == 0) {
@@ -234,10 +238,4 @@ size_t ngtcp2_ppe_dgram_padding_size(ngtcp2_ppe *ppe, size_t n) {
   buf->last = ngtcp2_setmem(buf->last, 0, len);
 
   return len;
-}
-
-int ngtcp2_ppe_ensure_hp_sample(ngtcp2_ppe *ppe) {
-  ngtcp2_buf *buf = &ppe->buf;
-
-  return ngtcp2_buf_left(buf) >= (4 - ppe->pkt_numlen) + NGTCP2_HP_SAMPLELEN;
 }

--- a/lib/ngtcp2_ppe.h
+++ b/lib/ngtcp2_ppe.h
@@ -138,20 +138,11 @@ size_t ngtcp2_ppe_dgram_padding_size(ngtcp2_ppe *ppe, size_t n);
  * PADDING at least |n| bytes, this function still adds PADDING frames
  * as much as possible.  This function also adds PADDING frames so
  * that the minimum padding requirement of header protection is met.
- * Those padding may be larger than |n| bytes.  It is recommended to
- * make sure that ngtcp2_ppe_ensure_hp_sample succeeds after writing
- * QUIC packet header.  This function should be called just before
- * calling ngtcp2_ppe_final().
+ * Those padding may be larger than |n| bytes.  This function should
+ * be called just before calling ngtcp2_ppe_final().
  *
  * This function returns the number of bytes added as padding.
  */
 size_t ngtcp2_ppe_padding_size(ngtcp2_ppe *ppe, size_t n);
-
-/*
- * ngtcp2_ppe_ensure_hp_sample returns nonzero if the buffer has
- * enough space for header protection sample.  This should be called
- * right after packet header is written.
- */
-int ngtcp2_ppe_ensure_hp_sample(ngtcp2_ppe *ppe);
 
 #endif /* !defined(NGTCP2_PPE_H) */

--- a/tests/ngtcp2_conn_test.c
+++ b/tests/ngtcp2_conn_test.c
@@ -8361,7 +8361,7 @@ void test_ngtcp2_conn_writev_stream(void) {
   assert_int(0, ==, rv);
 
   /*
-   * Long header (1+18+1)
+   * Short header (1+18+1)
    * STREAM overhead (+3)
    * AEAD overhead (16)
    */

--- a/tests/ngtcp2_ppe_test.c
+++ b/tests/ngtcp2_ppe_test.c
@@ -30,6 +30,7 @@
 #include "ngtcp2_test_helper.h"
 
 static const MunitTest tests[] = {
+  munit_void_test(test_ngtcp2_ppe_encode_hd),
   munit_void_test(test_ngtcp2_ppe_dgram_padding_size),
   munit_void_test(test_ngtcp2_ppe_padding_size),
   munit_test_end(),
@@ -39,6 +40,54 @@ const MunitSuite ppe_suite = {
   .prefix = "/ppe",
   .tests = tests,
 };
+
+void test_ngtcp2_ppe_encode_hd(void) {
+  ngtcp2_ppe ppe;
+  ngtcp2_crypto_cc cc = {
+    .aead.max_overhead = NGTCP2_FAKE_AEAD_OVERHEAD,
+  };
+  uint8_t buf[1200];
+  ngtcp2_pkt_hd hd;
+  const ngtcp2_cid scid = make_scid();
+  const ngtcp2_cid dcid = make_dcid();
+  int rv;
+
+  /* Long packet */
+  ngtcp2_pkt_hd_init(&hd, NGTCP2_PKT_FLAG_LONG_FORM, NGTCP2_PKT_INITIAL, &dcid,
+                     &scid, 0, 1, NGTCP2_PROTO_VER_V1);
+
+  ngtcp2_ppe_init(&ppe, buf, sizeof(buf), 0, &cc);
+
+  rv = ngtcp2_ppe_encode_hd(&ppe, &hd);
+
+  assert_int(0, ==, rv);
+  assert_size(1 + 4 + 1 + dcid.datalen + 1 + scid.datalen + 1 +
+                NGTCP2_PKT_LENGTHLEN,
+              ==, ppe.pkt_num_offset);
+
+  /* Short packet */
+  ngtcp2_pkt_hd_init(&hd, NGTCP2_PKT_FLAG_NONE, NGTCP2_PKT_1RTT, &dcid, NULL, 0,
+                     1, NGTCP2_PROTO_VER_V1);
+
+  ngtcp2_ppe_init(&ppe, buf, sizeof(buf), 0, &cc);
+
+  rv = ngtcp2_ppe_encode_hd(&ppe, &hd);
+
+  assert_int(0, ==, rv);
+  assert_size(1 + dcid.datalen, ==, ppe.pkt_num_offset);
+
+  /* Insufficient buffer size; buffer size is less than the minimum
+     packet size to ensure header protection samples.  */
+  ngtcp2_pkt_hd_init(&hd, NGTCP2_PKT_FLAG_NONE, NGTCP2_PKT_1RTT, &dcid, NULL, 0,
+                     1, NGTCP2_PROTO_VER_V1);
+
+  ngtcp2_ppe_init(&ppe, buf, 1 + dcid.datalen + 4 + NGTCP2_HP_SAMPLELEN - 1, 0,
+                  &cc);
+
+  rv = ngtcp2_ppe_encode_hd(&ppe, &hd);
+
+  assert_int(NGTCP2_ERR_NOBUF, ==, rv);
+}
 
 static void set_padding_range(uint8_t *buf, size_t buflen, size_t offset,
                               size_t len) {
@@ -162,6 +211,19 @@ void test_ngtcp2_ppe_padding_size(void) {
 
   set_padding_range(pkt, sizeof(pkt), 0, 0);
   memset(buf, 0xFF, sizeof(buf));
+
+  ngtcp2_ppe_padding_size(&ppe, 0);
+
+  assert_memory_equal(NGTCP2_MAX_UDP_PAYLOAD_SIZE, pkt, buf);
+
+  /* 0 AEAD overhead */
+  cc.aead.max_overhead = 0;
+  ngtcp2_ppe_init(&ppe, buf, 1280, /* should be ignored */ 0, &cc);
+  ppe.buf.last += 5;
+  ppe.pkt_num_offset = 4;
+
+  set_padding_range(pkt, sizeof(pkt), 5, 3 + NGTCP2_HP_SAMPLELEN);
+  memset(buf, 0XFF, sizeof(buf));
 
   ngtcp2_ppe_padding_size(&ppe, 0);
 

--- a/tests/ngtcp2_ppe_test.h
+++ b/tests/ngtcp2_ppe_test.h
@@ -35,6 +35,7 @@
 
 extern const MunitSuite ppe_suite;
 
+munit_void_test_decl(test_ngtcp2_ppe_encode_hd)
 munit_void_test_decl(test_ngtcp2_ppe_dgram_padding_size)
 munit_void_test_decl(test_ngtcp2_ppe_padding_size)
 


### PR DESCRIPTION
Robust ngtcp2_ppe_padding_size without any assumption of AEAD overhead.