### PR TITLE
Fix incorrect initialization of remote unidirectional streams when they are opened by a reset-stream message

### DIFF
--- a/lib/ngtcp2_conn.c
+++ b/lib/ngtcp2_conn.c
@@ -5711,11 +5711,6 @@ static int conn_recv_max_stream_data(ngtcp2_conn *conn,
       return rv;
     }
 
-    if (!bidi) {
-      ngtcp2_strm_shutdown(strm, NGTCP2_STRM_FLAG_SHUT_WR);
-      strm->flags |= NGTCP2_STRM_FLAG_FIN_ACKED;
-    }
-
     rv = conn_call_stream_open(conn, strm);
     if (rv != 0) {
       return rv;
@@ -7931,11 +7926,6 @@ static int conn_recv_stop_sending(ngtcp2_conn *conn,
     if (rv != 0) {
       ngtcp2_objalloc_strm_release(&conn->strm_objalloc, strm);
       return rv;
-    }
-
-    if (!bidi) {
-      ngtcp2_strm_shutdown(strm, NGTCP2_STRM_FLAG_SHUT_WR);
-      strm->flags |= NGTCP2_STRM_FLAG_FIN_ACKED;
     }
 
     rv = conn_call_stream_open(conn, strm);

--- a/lib/ngtcp2_conn.c
+++ b/lib/ngtcp2_conn.c
@@ -5711,6 +5711,11 @@ static int conn_recv_max_stream_data(ngtcp2_conn *conn,
       return rv;
     }
 
+    if (!bidi) {
+      ngtcp2_strm_shutdown(strm, NGTCP2_STRM_FLAG_SHUT_WR);
+      strm->flags |= NGTCP2_STRM_FLAG_FIN_ACKED;
+    }
+
     rv = conn_call_stream_open(conn, strm);
     if (rv != 0) {
       return rv;
@@ -7783,6 +7788,11 @@ static int conn_recv_reset_stream(ngtcp2_conn *conn,
       return rv;
     }
 
+    if (!bidi) {
+      ngtcp2_strm_shutdown(strm, NGTCP2_STRM_FLAG_SHUT_WR);
+      strm->flags |= NGTCP2_STRM_FLAG_FIN_ACKED;
+    }
+
     rv = conn_call_stream_open(conn, strm);
     if (rv != 0) {
       return rv;
@@ -7921,6 +7931,11 @@ static int conn_recv_stop_sending(ngtcp2_conn *conn,
     if (rv != 0) {
       ngtcp2_objalloc_strm_release(&conn->strm_objalloc, strm);
       return rv;
+    }
+
+    if (!bidi) {
+      ngtcp2_strm_shutdown(strm, NGTCP2_STRM_FLAG_SHUT_WR);
+      strm->flags |= NGTCP2_STRM_FLAG_FIN_ACKED;
     }
 
     rv = conn_call_stream_open(conn, strm);


### PR DESCRIPTION
I have found a bug in my integration tests, where some streams would never get released. This turned out to be due to bad initialization in a code path, where the remote unidirectional stream's writing end is not shut down as it is supposed to be.

The streams are opened on different code paths depending on what kind of message they receive first. If they first receive data, they work as expected. If they are reset first instead, they would get leaked: the remote uni stream is opened, but the writing-end is left open; nothing ever shuts it down; closure of the stream requires both ends to be closed; stream never closes. My changes fix this.

I have copied the same initialization code from `conn_recv_stream()` to `conn_recv_reset_stream()`.

All ngtcp2 tests pass with my change + all of my own integration tests where I use ngtcp2.