### PR TITLE
Add handshake_pto_ceiling setting

### DIFF
--- a/lib/includes/ngtcp2/ngtcp2.h
+++ b/lib/includes/ngtcp2/ngtcp2.h
@@ -1861,7 +1861,8 @@ typedef enum ngtcp2_token_type {
 #define NGTCP2_SETTINGS_V2 2
 #define NGTCP2_SETTINGS_V3 3
 #define NGTCP2_SETTINGS_V4 4
-#define NGTCP2_SETTINGS_VERSION NGTCP2_SETTINGS_V4
+#define NGTCP2_SETTINGS_V5 5
+#define NGTCP2_SETTINGS_VERSION NGTCP2_SETTINGS_V5
 
 /**
  * @struct
@@ -2116,6 +2117,7 @@ typedef struct ngtcp2_settings {
    * .. version-added:: 1.23.0
    */
   ngtcp2_log_write log_write;
+  /* The following fields have been added since NGTCP2_SETTINGS_V5. */
   /**
    * :member:`handshake_pto_ceiling` is the maximum probe timeout
    * duration for the Initial and Handshake packet number spaces.

--- a/lib/includes/ngtcp2/ngtcp2.h
+++ b/lib/includes/ngtcp2/ngtcp2.h
@@ -2116,6 +2116,17 @@ typedef struct ngtcp2_settings {
    * .. version-added:: 1.23.0
    */
   ngtcp2_log_write log_write;
+  /**
+   * :member:`handshake_pto_ceiling` is the maximum probe timeout
+   * duration for the Initial and Handshake packet number spaces.
+   * When set to a nonzero value, the exponential backoff duration is
+   * capped at this value during the QUIC handshake.  The PTO still
+   * grows exponentially but will not exceed this ceiling.  After the
+   * handshake is confirmed, standard uncapped exponential backoff is
+   * used for the Application packet number space regardless of this
+   * setting.  Setting this to 0 (the default) applies no ceiling.
+   */
+  ngtcp2_duration handshake_pto_ceiling;
 } ngtcp2_settings;
 
 /**

--- a/lib/ngtcp2_conn.c
+++ b/lib/ngtcp2_conn.c
@@ -13326,9 +13326,14 @@ static ngtcp2_tstamp conn_get_earliest_pto_expiry(const ngtcp2_conn *conn,
     (1ULL << cstat->pto_count);
 
   if (!(conn->flags & NGTCP2_CONN_FLAG_HANDSHAKE_CONFIRMED) &&
-      conn->local.settings.handshake_pto_ceiling &&
-      duration > conn->local.settings.handshake_pto_ceiling) {
-    duration = conn->local.settings.handshake_pto_ceiling;
+      conn->local.settings.handshake_pto_ceiling) {
+    ngtcp2_duration ceiling =
+        ngtcp2_max(conn->local.settings.handshake_pto_ceiling,
+                   NGTCP2_GRANULARITY);
+
+    if (duration > ceiling) {
+      duration = ceiling;
+    }
   }
 
   for (i = NGTCP2_PKTNS_ID_INITIAL; i < NGTCP2_PKTNS_ID_MAX; ++i) {

--- a/lib/ngtcp2_conn.c
+++ b/lib/ngtcp2_conn.c
@@ -13325,6 +13325,12 @@ static ngtcp2_tstamp conn_get_earliest_pto_expiry(const ngtcp2_conn *conn,
     compute_pto(cstat->smoothed_rtt, cstat->rttvar, /* max_ack_delay = */ 0) *
     (1ULL << cstat->pto_count);
 
+  if (!(conn->flags & NGTCP2_CONN_FLAG_HANDSHAKE_CONFIRMED) &&
+      conn->local.settings.handshake_pto_ceiling &&
+      duration > conn->local.settings.handshake_pto_ceiling) {
+    duration = conn->local.settings.handshake_pto_ceiling;
+  }
+
   for (i = NGTCP2_PKTNS_ID_INITIAL; i < NGTCP2_PKTNS_ID_MAX; ++i) {
     if (ns[i] == NULL || ns[i]->rtb.num_pto_eliciting == 0 ||
         (times[i] == UINT64_MAX ||

--- a/lib/ngtcp2_settings.c
+++ b/lib/ngtcp2_settings.c
@@ -37,6 +37,7 @@ void ngtcp2_settings_default_versioned(int settings_version,
 
   switch (settings_version) {
   case NGTCP2_SETTINGS_VERSION:
+  case NGTCP2_SETTINGS_V4:
   case NGTCP2_SETTINGS_V3:
     settings->glitch_ratelim_burst = NGTCP2_DEFAULT_GLITCH_RATELIM_BURST;
     settings->glitch_ratelim_rate = NGTCP2_DEFAULT_GLITCH_RATELIM_RATE;
@@ -87,6 +88,8 @@ size_t ngtcp2_settingslen_version(int settings_version) {
   switch (settings_version) {
   case NGTCP2_SETTINGS_VERSION:
     return sizeof(settings);
+  case NGTCP2_SETTINGS_V4:
+    return offsetof(ngtcp2_settings, log_write) + sizeof(settings.log_write);
   case NGTCP2_SETTINGS_V3:
     return offsetof(ngtcp2_settings, glitch_ratelim_rate) +
            sizeof(settings.glitch_ratelim_rate);


### PR DESCRIPTION
Add a new ngtcp2_settings field that caps the probe timeout duration during the QUIC handshake.  When handshake_pto_ceiling is set to a nonzero value, the exponentially backed-off PTO duration for the Initial and Handshake packet number spaces is clamped to this ceiling. After the handshake is confirmed, standard uncapped exponential backoff applies to the Application packet number space.

This is useful in environments where aggressive retransmission during the handshake is desired regardless of how many PTOs have fired (e.g., mobile networks with high jitter where the default backoff grows too large).