### PR TITLE
crypto: Add openssl libs to cryptotest

### DIFF
--- a/crypto/ossl/Makefile.am
+++ b/crypto/ossl/Makefile.am
@@ -51,6 +51,7 @@ cryptotest_SOURCES = \
 cryptotest_CPPFLAGS = ${AM_CPPFLAGS} -I$(top_srcdir)/tests/munit
 cryptotest_LDADD = \
 	libngtcp2_crypto_ossl.la \
-	$(top_builddir)/lib/libngtcp2.la
+	$(top_builddir)/lib/libngtcp2.la \
+	@OPENSSL_LIBS@
 
 TESTS = cryptotest

--- a/crypto/quictls/Makefile.am
+++ b/crypto/quictls/Makefile.am
@@ -64,7 +64,7 @@ cryptotest_LDADD = libngtcp2_crypto_libressl.la
 else # !HAVE_LIBRESSL
 cryptotest_LDADD = libngtcp2_crypto_quictls.la
 endif # !HAVE_LIBRESSL
-cryptotest_LDADD += $(top_builddir)/lib/libngtcp2.la
+cryptotest_LDADD += $(top_builddir)/lib/libngtcp2.la @OPENSSL_LIBS@
 
 TESTS = cryptotest
 


### PR DESCRIPTION
This is needed because openssl is not a libtool project.