### PR TITLE
Add --disable-crypto configure option

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -110,6 +110,11 @@ AC_ARG_ENABLE([lib-only],
                     [Build libngtcp2 and libngtcp2_crypto only.])],
     [lib_only=$enableval], [lib_only=no])
 
+AC_ARG_ENABLE([cryptotest],
+    [AS_HELP_STRING([--disable-cryptotest],
+                    [Disable cryptotest under crypto directory])],
+    [cryptotest=$enableval], [cryptotest=yes])
+
 AC_ARG_WITH([jemalloc],
     [AS_HELP_STRING([--with-jemalloc],
                     [Use jemalloc [default=check]])],
@@ -453,6 +458,7 @@ if test "x${have_quictls}" = "xyes" ||
 fi
 
 AM_CONDITIONAL([HAVE_CRYPTO], [ test "x${have_crypto}" = "xyes" ])
+AM_CONDITIONAL([HAVE_CRYPTOTEST], [ test "x${cryptotest}" = "xyes" ])
 
 # libnghttp3 (required for examples)
 have_libnghttp3=no
@@ -857,6 +863,7 @@ AC_MSG_NOTICE([summary of build options:
       libngtcp2_crypto_picotls:   ${have_picotls}
       libngtcp2_crypto_wolfssl:   ${have_wolfssl}
       libngtcp2_crypto_ossl:      ${have_ossl}
+    Cryptotest:       ${cryptotest}
     Debug:
       Debug:          ${debug} (CFLAGS='${DEBUGCFLAGS}')
     Libs:

--- a/crypto/boringssl/Makefile.am
+++ b/crypto/boringssl/Makefile.am
@@ -38,6 +38,7 @@ lib_LIBRARIES = libngtcp2_crypto_boringssl.a
 
 libngtcp2_crypto_boringssl_a_SOURCES = boringssl.c ../shared.c ../shared.h
 
+if HAVE_CRYPTOTEST
 if HAVE_BORINGSSL_STDCXXLIB
 check_PROGRAMS = cryptotest
 
@@ -54,3 +55,4 @@ cryptotest_LDADD = \
 
 TESTS = cryptotest
 endif # HAVE_BORINGSSL_STDCXXLIB
+endif # HAVE_CRYPTOTEST

--- a/crypto/gnutls/Makefile.am
+++ b/crypto/gnutls/Makefile.am
@@ -42,6 +42,7 @@ libngtcp2_crypto_gnutls_la_LDFLAGS = -no-undefined \
 libngtcp2_crypto_gnutls_la_LIBADD = $(top_builddir)/lib/libngtcp2.la \
 	@GNUTLS_LIBS@
 
+if HAVE_CRYPTOTEST
 check_PROGRAMS = cryptotest
 
 cryptotest_SOURCES = \
@@ -54,3 +55,4 @@ cryptotest_LDADD = \
 	$(top_builddir)/lib/libngtcp2.la
 
 TESTS = cryptotest
+endif # HAVE_CRYPTOTEST

--- a/crypto/ossl/Makefile.am
+++ b/crypto/ossl/Makefile.am
@@ -42,6 +42,7 @@ libngtcp2_crypto_ossl_la_LDFLAGS = -no-undefined \
 libngtcp2_crypto_ossl_la_LIBADD = $(top_builddir)/lib/libngtcp2.la \
 	@OPENSSL_LIBS@
 
+if HAVE_CRYPTOTEST
 check_PROGRAMS = cryptotest
 
 cryptotest_SOURCES = \
@@ -55,3 +56,4 @@ cryptotest_LDADD = \
 	@OPENSSL_LIBS@
 
 TESTS = cryptotest
+endif # HAVE_CRYPTOTEST

--- a/crypto/picotls/Makefile.am
+++ b/crypto/picotls/Makefile.am
@@ -38,6 +38,7 @@ lib_LIBRARIES = libngtcp2_crypto_picotls.a
 
 libngtcp2_crypto_picotls_a_SOURCES = picotls.c ../shared.c ../shared.h
 
+if HAVE_CRYPTOTEST
 check_PROGRAMS = cryptotest
 
 cryptotest_SOURCES = \
@@ -51,3 +52,4 @@ cryptotest_LDADD = \
 	@PICOTLS_LIBS@ @VANILLA_OPENSSL_LIBS@
 
 TESTS = cryptotest
+endif # HAVE_CRYPTOTEST

--- a/crypto/quictls/Makefile.am
+++ b/crypto/quictls/Makefile.am
@@ -52,6 +52,7 @@ libngtcp2_crypto_quictls_la_LIBADD = $(top_builddir)/lib/libngtcp2.la \
 	@OPENSSL_LIBS@
 endif
 
+if HAVE_CRYPTOTEST
 check_PROGRAMS = cryptotest
 
 cryptotest_SOURCES = \
@@ -67,5 +68,6 @@ endif # !HAVE_LIBRESSL
 cryptotest_LDADD += $(top_builddir)/lib/libngtcp2.la @OPENSSL_LIBS@
 
 TESTS = cryptotest
+endif # HAVE_CRYPTOTEST
 
 DISTCLEANFILES = $(pkgconfig_DATA)

--- a/crypto/wolfssl/Makefile.am
+++ b/crypto/wolfssl/Makefile.am
@@ -42,6 +42,7 @@ libngtcp2_crypto_wolfssl_la_LDFLAGS = -no-undefined \
 libngtcp2_crypto_wolfssl_la_LIBADD = $(top_builddir)/lib/libngtcp2.la \
 	@WOLFSSL_LIBS@
 
+if HAVE_CRYPTOTEST
 check_PROGRAMS = cryptotest
 
 cryptotest_SOURCES = \
@@ -54,3 +55,4 @@ cryptotest_LDADD = \
 	$(top_builddir)/lib/libngtcp2.la
 
 TESTS = cryptotest
+endif # HAVE_CRYPTOTEST


### PR DESCRIPTION
We have some issues in cryptotest when linked with OpenSSL that is not libtool project, especially when ngtcp2 is built in third-party projects where it is not desirable to set rpath.  To workaround this issue, add --disable-crypto configure option that disables cryptotest.