### PR TITLE
lib: Add recv_stop_sending callback

### DIFF
--- a/lib/includes/ngtcp2/ngtcp2.h
+++ b/lib/includes/ngtcp2/ngtcp2.h
@@ -3488,6 +3488,24 @@ typedef int (*ngtcp2_stream_stop_sending)(ngtcp2_conn *conn, int64_t stream_id,
 /**
  * @functypedef
  *
+ * :type:`ngtcp2_recv_stop_sending` is invoked when a STOP_SENDING frame
+ * is received from a remote endpoint for a stream identified by
+ * |stream_id|.  |app_error_code| is the application error code carried
+ * by the STOP_SENDING frame.  This callback is called at most
+ * once per stream.
+ *
+ * The callback function must return 0 if it succeeds.  Returning
+ * :macro:`NGTCP2_ERR_CALLBACK_FAILURE` makes the library call return
+ * immediately.
+ */
+typedef int (*ngtcp2_recv_stop_sending)(ngtcp2_conn *conn, int64_t stream_id,
+                                        uint64_t app_error_code,
+                                        void *user_data,
+                                        void *stream_user_data);
+
+/**
+ * @functypedef
+ *
  * :type:`ngtcp2_version_negotiation` is invoked when the compatible
  * version negotiation takes place.  For client, it is called when it
  * sees a change in version field of a long header packet.  This
@@ -3626,7 +3644,8 @@ typedef int (*ngtcp2_get_path_challenge_data2)(ngtcp2_conn *conn,
 #define NGTCP2_CALLBACKS_V1 1
 #define NGTCP2_CALLBACKS_V2 2
 #define NGTCP2_CALLBACKS_V3 3
-#define NGTCP2_CALLBACKS_VERSION NGTCP2_CALLBACKS_V3
+#define NGTCP2_CALLBACKS_V4 4
+#define NGTCP2_CALLBACKS_VERSION NGTCP2_CALLBACKS_V4
 
 /**
  * @struct
@@ -3964,6 +3983,16 @@ typedef struct ngtcp2_callbacks {
    * .. version-added:: 1.22.0
    */
   ngtcp2_get_path_challenge_data2 get_path_challenge_data2;
+  /* The following fields have been added since
+     NGTCP2_CALLBACKS_V3. */
+  /**
+   * :member:`recv_stop_sending` is a callback function which is invoked
+   * when a STOP_SENDING frame is received from a remote endpoint.  This
+   * callback function is optional.
+   *
+   * .. version-added:: 1.24.0
+   */
+  ngtcp2_recv_stop_sending recv_stop_sending;
 } ngtcp2_callbacks;
 
 /**

--- a/lib/ngtcp2_callbacks.c
+++ b/lib/ngtcp2_callbacks.c
@@ -63,6 +63,9 @@ size_t ngtcp2_callbackslen_version(int callbacks_version) {
   switch (callbacks_version) {
   case NGTCP2_CALLBACKS_VERSION:
     return sizeof(callbacks);
+  case NGTCP2_CALLBACKS_V3:
+    return offsetof(ngtcp2_callbacks, get_path_challenge_data2) +
+           sizeof(callbacks.get_path_challenge_data2);
   case NGTCP2_CALLBACKS_V2:
     return offsetof(ngtcp2_callbacks, begin_path_validation) +
            sizeof(callbacks.begin_path_validation);

--- a/lib/ngtcp2_conn.c
+++ b/lib/ngtcp2_conn.c
@@ -230,6 +230,24 @@ static int conn_call_stream_reset(ngtcp2_conn *conn, int64_t stream_id,
   return 0;
 }
 
+static int conn_call_recv_stop_sending(ngtcp2_conn *conn, int64_t stream_id,
+                                       uint64_t app_error_code,
+                                       void *stream_user_data) {
+  int rv;
+
+  if (!conn->callbacks.recv_stop_sending) {
+    return 0;
+  }
+
+  rv = conn->callbacks.recv_stop_sending(conn, stream_id, app_error_code,
+                                         conn->user_data, stream_user_data);
+  if (rv != 0) {
+    return NGTCP2_ERR_CALLBACK_FAILURE;
+  }
+
+  return 0;
+}
+
 static int conn_call_extend_max_local_streams_bidi(ngtcp2_conn *conn,
                                                    uint64_t max_streams) {
   int rv;
@@ -7931,6 +7949,12 @@ static int conn_recv_stop_sending(ngtcp2_conn *conn,
   }
 
   ngtcp2_strm_set_app_error_code(strm, fr->app_error_code);
+
+  rv = conn_call_recv_stop_sending(conn, fr->stream_id, fr->app_error_code,
+                                   strm->stream_user_data);
+  if (rv != 0) {
+    return rv;
+  }
 
   /* No RESET_STREAM is required if we have sent FIN and all data have
      been acknowledged. */

--- a/tests/ngtcp2_callbacks_test.c
+++ b/tests/ngtcp2_callbacks_test.c
@@ -437,6 +437,18 @@ static int stream_stop_sending(ngtcp2_conn *conn, int64_t stream_id,
   return 0;
 }
 
+static int recv_stop_sending(ngtcp2_conn *conn, int64_t stream_id,
+                             uint64_t app_error_code, void *user_data,
+                             void *stream_user_data) {
+  (void)conn;
+  (void)stream_id;
+  (void)app_error_code;
+  (void)user_data;
+  (void)stream_user_data;
+
+  return 0;
+}
+
 static int version_negotiation(ngtcp2_conn *conn, uint32_t version,
                                const ngtcp2_cid *client_dcid, void *user_data) {
   (void)conn;
@@ -646,6 +658,7 @@ void test_ngtcp2_callbacks_convert_to_latest(void) {
   assert_null(dest->get_new_connection_id2);
   assert_null(dest->dcid_status2);
   assert_null(dest->get_path_challenge_data2);
+  assert_null(dest->recv_stop_sending);
 }
 
 void test_ngtcp2_callbacks_convert_to_old(void) {
@@ -695,6 +708,7 @@ void test_ngtcp2_callbacks_convert_to_old(void) {
     .get_new_connection_id2 = get_new_connection_id2,
     .dcid_status2 = dcid_status2,
     .get_path_challenge_data2 = get_path_challenge_data2,
+    .recv_stop_sending = recv_stop_sending,
   };
   ngtcp2_callbacks *dest, destbuf = {0};
   size_t v2len;
@@ -763,4 +777,5 @@ void test_ngtcp2_callbacks_convert_to_old(void) {
   assert_null(destbuf.get_new_connection_id2);
   assert_null(destbuf.dcid_status2);
   assert_null(destbuf.get_path_challenge_data2);
+  assert_null(destbuf.recv_stop_sending);
 }

--- a/tests/ngtcp2_conn_test.c
+++ b/tests/ngtcp2_conn_test.c
@@ -324,6 +324,11 @@ typedef struct {
     uint8_t token[256];
     size_t tokenlen;
   } new_token;
+  struct {
+    int64_t stream_id;
+    uint64_t app_error_code;
+    size_t ncalled;
+  } stop_sending;
 } my_user_data;
 
 static int client_initial(ngtcp2_conn *conn, void *user_data) {
@@ -667,6 +672,22 @@ static int stream_close(ngtcp2_conn *conn, uint32_t flags, int64_t stream_id,
     ud->stream_close.flags = flags;
     ud->stream_close.stream_id = stream_id;
     ud->stream_close.app_error_code = app_error_code;
+  }
+
+  return 0;
+}
+
+static int recv_stop_sending(ngtcp2_conn *conn, int64_t stream_id,
+                             uint64_t app_error_code, void *user_data,
+                             void *stream_user_data) {
+  my_user_data *ud = user_data;
+  (void)conn;
+  (void)stream_user_data;
+
+  if (ud) {
+    ud->stop_sending.stream_id = stream_id;
+    ud->stop_sending.app_error_code = app_error_code;
+    ++ud->stop_sending.ncalled;
   }
 
   return 0;
@@ -2844,10 +2865,15 @@ void test_ngtcp2_conn_recv_stop_sending(void) {
   ngtcp2_ksl_it it;
   ngtcp2_rtb_entry *ent;
   ngtcp2_tpe tpe;
+  my_user_data ud;
 
   /* Receive STOP_SENDING */
   setup_default_client(&conn);
   ngtcp2_tpe_init_conn(&tpe, conn);
+
+  ud = (my_user_data){0};
+  conn->user_data = &ud;
+  conn->callbacks.recv_stop_sending = recv_stop_sending;
 
   ngtcp2_conn_open_bidi_stream(conn, &stream_id, NULL);
   ngtcp2_conn_write_stream(conn, NULL, NULL, buf, sizeof(buf), NULL,
@@ -2864,6 +2890,12 @@ void test_ngtcp2_conn_recv_stop_sending(void) {
   rv = ngtcp2_conn_read_pkt(conn, &null_path.path, NULL, buf, pktlen, ++t);
 
   assert_int(0, ==, rv);
+
+  /* recv_stop_sending callback is invoked once with the frame's stream
+     ID and application error code. */
+  assert_size(1, ==, ud.stop_sending.ncalled);
+  assert_int64(stream_id, ==, ud.stop_sending.stream_id);
+  assert_uint64(NGTCP2_APP_ERR01, ==, ud.stop_sending.app_error_code);
 
   strm = ngtcp2_conn_find_stream(conn, stream_id);
 
@@ -2900,11 +2932,18 @@ void test_ngtcp2_conn_recv_stop_sending(void) {
   assert_true(strm->flags & NGTCP2_STRM_FLAG_RESET_STREAM);
   assert_false(strm->flags & NGTCP2_STRM_FLAG_SEND_RESET_STREAM);
 
+  /* Duplicate STOP_SENDING does not invoke the callback again. */
+  assert_size(1, ==, ud.stop_sending.ncalled);
+
   ngtcp2_conn_del(conn);
 
   /* Receive STOP_SENDING after receiving RESET_STREAM */
   setup_default_client(&conn);
   ngtcp2_tpe_init_conn(&tpe, conn);
+
+  ud = (my_user_data){0};
+  conn->user_data = &ud;
+  conn->callbacks.recv_stop_sending = recv_stop_sending;
 
   t = 0;
 
@@ -2936,6 +2975,10 @@ void test_ngtcp2_conn_recv_stop_sending(void) {
   assert_int(0, ==, rv);
   assert_not_null(ngtcp2_conn_find_stream(conn, stream_id));
 
+  /* Callback fires even though the read side was already reset. */
+  assert_size(1, ==, ud.stop_sending.ncalled);
+  assert_int64(stream_id, ==, ud.stop_sending.stream_id);
+
   spktlen = ngtcp2_conn_write_pkt(conn, NULL, NULL, buf, sizeof(buf), ++t);
 
   assert_ptrdiff(0, <, spktlen);
@@ -2962,12 +3005,30 @@ void test_ngtcp2_conn_recv_stop_sending(void) {
   assert_int(0, ==, rv);
   assert_null(ngtcp2_conn_find_stream(conn, stream_id));
 
+  /* STOP_SENDING for a local stream that no longer has a stream object
+     does not invoke the callback. */
+  fr.stop_sending = (ngtcp2_stop_sending){
+    .type = NGTCP2_FRAME_STOP_SENDING,
+    .stream_id = stream_id,
+    .app_error_code = NGTCP2_APP_ERR01,
+  };
+
+  pktlen = ngtcp2_tpe_write_1rtt(&tpe, buf, sizeof(buf), &fr, 1);
+  rv = ngtcp2_conn_read_pkt(conn, &null_path.path, NULL, buf, pktlen, ++t);
+
+  assert_int(0, ==, rv);
+  assert_size(1, ==, ud.stop_sending.ncalled);
+
   ngtcp2_conn_del(conn);
 
   /* STOP_SENDING against remote bidirectional stream which has not
      been initiated. */
   setup_default_server(&conn);
   ngtcp2_tpe_init_conn(&tpe, conn);
+
+  ud = (my_user_data){0};
+  conn->user_data = &ud;
+  conn->callbacks.recv_stop_sending = recv_stop_sending;
 
   fr.stop_sending = (ngtcp2_stop_sending){
     .type = NGTCP2_FRAME_STOP_SENDING,
@@ -2983,6 +3044,10 @@ void test_ngtcp2_conn_recv_stop_sending(void) {
 
   assert_not_null(strm);
   assert_true(strm->flags & NGTCP2_STRM_FLAG_SHUT_WR);
+
+  /* Stream object is created on receipt, then the callback fires. */
+  assert_size(1, ==, ud.stop_sending.ncalled);
+  assert_int64(0, ==, ud.stop_sending.stream_id);
 
   ngtcp2_conn_del(conn);
 

--- a/tests/ngtcp2_conn_test.c
+++ b/tests/ngtcp2_conn_test.c
@@ -2866,14 +2866,22 @@ void test_ngtcp2_conn_recv_stop_sending(void) {
   ngtcp2_rtb_entry *ent;
   ngtcp2_tpe tpe;
   my_user_data ud;
+  ngtcp2_callbacks callbacks;
+  conn_options opts;
 
   /* Receive STOP_SENDING */
-  setup_default_client(&conn);
-  ngtcp2_tpe_init_conn(&tpe, conn);
+  client_default_callbacks(&callbacks);
+  callbacks.recv_stop_sending = recv_stop_sending;
 
   ud = (my_user_data){0};
-  conn->user_data = &ud;
-  conn->callbacks.recv_stop_sending = recv_stop_sending;
+
+  opts = (conn_options){
+    .callbacks = &callbacks,
+    .user_data = &ud,
+  };
+
+  setup_default_client_with_options(&conn, opts);
+  ngtcp2_tpe_init_conn(&tpe, conn);
 
   ngtcp2_conn_open_bidi_stream(conn, &stream_id, NULL);
   ngtcp2_conn_write_stream(conn, NULL, NULL, buf, sizeof(buf), NULL,
@@ -2938,12 +2946,18 @@ void test_ngtcp2_conn_recv_stop_sending(void) {
   ngtcp2_conn_del(conn);
 
   /* Receive STOP_SENDING after receiving RESET_STREAM */
-  setup_default_client(&conn);
-  ngtcp2_tpe_init_conn(&tpe, conn);
+  client_default_callbacks(&callbacks);
+  callbacks.recv_stop_sending = recv_stop_sending;
 
   ud = (my_user_data){0};
-  conn->user_data = &ud;
-  conn->callbacks.recv_stop_sending = recv_stop_sending;
+
+  opts = (conn_options){
+    .callbacks = &callbacks,
+    .user_data = &ud,
+  };
+
+  setup_default_client_with_options(&conn, opts);
+  ngtcp2_tpe_init_conn(&tpe, conn);
 
   t = 0;
 
@@ -3023,12 +3037,18 @@ void test_ngtcp2_conn_recv_stop_sending(void) {
 
   /* STOP_SENDING against remote bidirectional stream which has not
      been initiated. */
-  setup_default_server(&conn);
-  ngtcp2_tpe_init_conn(&tpe, conn);
+  server_default_callbacks(&callbacks);
+  callbacks.recv_stop_sending = recv_stop_sending;
 
   ud = (my_user_data){0};
-  conn->user_data = &ud;
-  conn->callbacks.recv_stop_sending = recv_stop_sending;
+
+  opts = (conn_options){
+    .callbacks = &callbacks,
+    .user_data = &ud,
+  };
+
+  setup_default_server_with_options(&conn, opts);
+  ngtcp2_tpe_init_conn(&tpe, conn);
 
   fr.stop_sending = (ngtcp2_stop_sending){
     .type = NGTCP2_FRAME_STOP_SENDING,


### PR DESCRIPTION
This adds a new optional callback, which fires when a remote STOP_SENDING frame is received.

Until now, the only way to observe this was detecting the SHUT_WR error on the next write. That's a bit limiting in itself, but also may never happen for streams that are blocked by flow control, if the application deschedules them and waits for extend_max_stream_data to resume writing. With this callback it's easy for applications to clean up stopped streams immediately instead.

I've tried to mirror the equivalent callback for received RESET_STREAM here. This is my first contribution to ngtcp2 directly, and this is a bit outside my normal area, so do let me know if I've missed something in the process here.