### PR TITLE
lib: Tweak ngtcp2_conn_set_max_stream_data_thresh

### DIFF
--- a/lib/includes/ngtcp2/ngtcp2.h
+++ b/lib/includes/ngtcp2/ngtcp2.h
@@ -5489,7 +5489,9 @@ NGTCP2_EXTERN int ngtcp2_conn_extend_max_stream_offset(ngtcp2_conn *conn,
  * is used.  Normally, there is no need to use this function.
  *
  * This function returns 0 if a stream denoted by |stream_id| is not
- * found.
+ * found.  If the stream-level window auto-tuning is enabled (see
+ * :member:`ngtcp2_settings.max_stream_window`), this function is
+ * noop.
  *
  * This function returns 0 if it succeeds, or one of the following
  * negative error codes:

--- a/lib/ngtcp2_conn.c
+++ b/lib/ngtcp2_conn.c
@@ -3218,11 +3218,7 @@ static int conn_should_send_max_stream_data(const ngtcp2_conn *conn,
   uint64_t inc = strm->rx.unsent_max_offset - strm->rx.max_offset;
   (void)conn;
 
-  if (strm->rx.max_stream_data_thresh) {
-    return strm->rx.max_stream_data_thresh < inc;
-  }
-
-  return strm->rx.window < 4 * inc;
+  return strm->rx.window < NGTCP2_MAX_STREAM_DATA_THRESH_FACTOR * inc;
 }
 
 /*
@@ -3232,7 +3228,7 @@ static int conn_should_send_max_stream_data(const ngtcp2_conn *conn,
 static int conn_should_send_max_data(const ngtcp2_conn *conn) {
   uint64_t inc = conn->rx.unsent_max_offset - conn->rx.max_offset;
 
-  return conn->rx.window < 4 * inc;
+  return conn->rx.window < NGTCP2_MAX_STREAM_DATA_THRESH_FACTOR * inc;
 }
 
 /*
@@ -13121,6 +13117,10 @@ int ngtcp2_conn_set_max_stream_data_thresh(ngtcp2_conn *conn, int64_t stream_id,
                                            uint64_t thresh) {
   ngtcp2_strm *strm;
 
+  if (conn->local.settings.max_stream_window) {
+    return 0;
+  }
+
   if (!bidi_stream(stream_id) && conn_local_stream(conn, stream_id)) {
     return NGTCP2_ERR_INVALID_ARGUMENT;
   }
@@ -13130,7 +13130,21 @@ int ngtcp2_conn_set_max_stream_data_thresh(ngtcp2_conn *conn, int64_t stream_id,
     return 0;
   }
 
-  strm->rx.max_stream_data_thresh = thresh;
+  if (thresh == 0) {
+    if (bidi_stream(stream_id)) {
+      strm->rx.window =
+        conn_local_stream(conn, stream_id)
+          ? conn->local.transport_params.initial_max_stream_data_bidi_local
+          : conn->local.transport_params.initial_max_stream_data_bidi_remote;
+    } else {
+      strm->rx.window =
+        conn->local.transport_params.initial_max_stream_data_uni;
+    }
+  } else if (thresh > UINT64_MAX / NGTCP2_MAX_STREAM_DATA_THRESH_FACTOR) {
+    strm->rx.window = UINT64_MAX;
+  } else {
+    strm->rx.window = thresh * NGTCP2_MAX_STREAM_DATA_THRESH_FACTOR;
+  }
 
   return conn_extend_max_stream_offset(conn, strm, 0);
 }

--- a/lib/ngtcp2_conn.h
+++ b/lib/ngtcp2_conn.h
@@ -112,6 +112,10 @@ typedef enum {
    packet as much as possible if the packet is not empty. */
 #define NGTCP2_WRITE_PKT_FLAG_PADDING_IF_NOT_EMPTY 0x08U
 
+/* NGTCP2_MAX_STREAM_DATA_THRESH_FACTOR is the factor of threshold
+   against stream window size that triggers MAX_STREAM_DATA. */
+#define NGTCP2_MAX_STREAM_DATA_THRESH_FACTOR 4
+
 typedef struct ngtcp2_path_challenge_entry {
   ngtcp2_path_storage ps;
   ngtcp2_path_challenge_data data;

--- a/lib/ngtcp2_strm.h
+++ b/lib/ngtcp2_strm.h
@@ -166,9 +166,6 @@ struct ngtcp2_strm {
         uint64_t unsent_max_offset;
         /* window is the stream-level flow control window size. */
         uint64_t window;
-        /* max_stream_data_thresh, if nonzero, is the threshold to
-           decide when MAX_STREAM_DATA frame is sent. */
-        uint64_t max_stream_data_thresh;
       } rx;
 
       const ngtcp2_mem *mem;

--- a/tests/ngtcp2_conn_test.c
+++ b/tests/ngtcp2_conn_test.c
@@ -18465,6 +18465,7 @@ void test_ngtcp2_conn_set_max_stream_data_thresh(void) {
   ngtcp2_ksl_it it;
   ngtcp2_rtb_entry *ent;
   ngtcp2_frame_chain *frc;
+  ngtcp2_strm *strm;
   int rv;
   size_t pktlen;
   int64_t stream_id;
@@ -18517,6 +18518,11 @@ void test_ngtcp2_conn_set_max_stream_data_thresh(void) {
 
   assert_int(0, ==, rv);
 
+  strm = ngtcp2_conn_find_stream(conn, stream_id);
+
+  assert_uint64(1199 * NGTCP2_MAX_STREAM_DATA_THRESH_FACTOR, ==,
+                strm->rx.window);
+
   spktlen = ngtcp2_conn_write_pkt(conn, NULL, NULL, buf, sizeof(buf), ++t);
 
   assert_ssize(0, <, spktlen);
@@ -18528,6 +18534,12 @@ void test_ngtcp2_conn_set_max_stream_data_thresh(void) {
   assert_uint64(NGTCP2_FRAME_MAX_STREAM_DATA, ==, frc->fr.hd.type);
   assert_int64(stream_id, ==, frc->fr.max_stream_data.stream_id);
   assert_uint64(65535 + 1200, ==, frc->fr.max_stream_data.max_stream_data);
+
+  /* Check that specifying 0 resets the value to the default value */
+  rv = ngtcp2_conn_set_max_stream_data_thresh(conn, stream_id, 0);
+
+  assert_int(0, ==, rv);
+  assert_uint64(65535, ==, strm->rx.window);
 
   ngtcp2_conn_del(conn);
 }


### PR DESCRIPTION
Make ngtcp2_conn_set_max_stream_data_thresh noop if stream-level window auto-tuning is enabled.  Reuse ngtcp2_strm.rx.window to store threshold.