### PR TITLE
ksl: Align keys in 8 bytes boundary

### DIFF
--- a/lib/ngtcp2_ksl.c
+++ b/lib/ngtcp2_ksl.c
@@ -36,8 +36,11 @@ static ngtcp2_ksl_blk null_blk;
 
 ngtcp2_objalloc_def(ksl_blk, ngtcp2_ksl_blk, oplent)
 
+#define NGTCP2_KSL_ALIGNED_BLKLEN                                              \
+  ((sizeof(ngtcp2_ksl_blk) + 0x7U) & ~(size_t)0x7U)
+
 static size_t ksl_blklen(size_t aligned_keylen) {
-  return sizeof(ngtcp2_ksl_blk) + NGTCP2_KSL_MAX_NBLK * aligned_keylen;
+  return NGTCP2_KSL_ALIGNED_BLKLEN + NGTCP2_KSL_MAX_NBLK * aligned_keylen;
 }
 
 /*
@@ -79,7 +82,7 @@ static ngtcp2_ksl_blk *ksl_blk_objalloc_new(ngtcp2_ksl *ksl) {
     return NULL;
   }
 
-  blk->keys = (uint8_t *)blk + sizeof(*blk);
+  blk->keys = (uint8_t *)blk + NGTCP2_KSL_ALIGNED_BLKLEN;
   blk->aligned_keylen = (uint16_t)ksl->aligned_keylen;
 
   return blk;


### PR DESCRIPTION
Fixes #2230 