### PR TITLE
Rework connection flow window accounting after sending STOP_SENDING

### DIFF
--- a/lib/ngtcp2_conn.c
+++ b/lib/ngtcp2_conn.c
@@ -7194,9 +7194,13 @@ static int conn_emit_pending_stream_data(ngtcp2_conn *conn, ngtcp2_strm *strm,
 
   for (;;) {
     /* Stop calling callback if application has called
-       ngtcp2_conn_shutdown_stream_read() inside the callback.
-       Because it doubly counts connection window. */
+       ngtcp2_conn_shutdown_stream_read() inside the callback. */
     if (strm->flags & NGTCP2_STRM_FLAG_STOP_SENDING) {
+      datalen = ngtcp2_strm_discard_ordered_data(strm, rx_offset);
+      if (datalen) {
+        ngtcp2_conn_extend_max_offset(conn, datalen);
+      }
+
       return 0;
     }
 
@@ -7529,10 +7533,6 @@ static int conn_recv_stream(ngtcp2_conn *conn, const ngtcp2_stream *fr,
     }
 
     conn->rx.offset += len;
-
-    if (strm->flags & NGTCP2_STRM_FLAG_STOP_SENDING) {
-      ngtcp2_conn_extend_max_offset(conn, len);
-    }
   }
 
   rx_offset = ngtcp2_strm_rx_offset(strm);
@@ -7597,31 +7597,32 @@ static int conn_recv_stream(ngtcp2_conn *conn, const ngtcp2_stream *fr,
     }
 
     if (strm->flags & NGTCP2_STRM_FLAG_STOP_SENDING) {
-      return ngtcp2_conn_close_stream_if_shut_rdwr(conn, strm);
-    }
+      datalen += ngtcp2_strm_discard_ordered_data(strm, rx_offset);
+      ngtcp2_conn_extend_max_offset(conn, datalen);
+    } else {
+      fin = (strm->flags & NGTCP2_STRM_FLAG_SHUT_RD) &&
+            rx_offset == strm->rx.last_offset;
 
-    fin = (strm->flags & NGTCP2_STRM_FLAG_SHUT_RD) &&
-          rx_offset == strm->rx.last_offset;
+      assert(fin || datalen);
 
-    assert(fin || datalen);
+      if (fin) {
+        sdflags |= NGTCP2_STREAM_DATA_FLAG_FIN;
+      }
+      if (!conn_is_tls_handshake_completed(conn)) {
+        sdflags |= NGTCP2_STREAM_DATA_FLAG_0RTT;
+      }
+      rv = conn_call_recv_stream_data(conn, strm, sdflags, offset, data,
+                                      (size_t)datalen);
+      if (rv != 0) {
+        return rv;
+      }
 
-    if (fin) {
-      sdflags |= NGTCP2_STREAM_DATA_FLAG_FIN;
+      rv = conn_emit_pending_stream_data(conn, strm, rx_offset);
+      if (rv != 0) {
+        return rv;
+      }
     }
-    if (!conn_is_tls_handshake_completed(conn)) {
-      sdflags |= NGTCP2_STREAM_DATA_FLAG_0RTT;
-    }
-    rv = conn_call_recv_stream_data(conn, strm, sdflags, offset, data,
-                                    (size_t)datalen);
-    if (rv != 0) {
-      return rv;
-    }
-
-    rv = conn_emit_pending_stream_data(conn, strm, rx_offset);
-    if (rv != 0) {
-      return rv;
-    }
-  } else if (fr->datacnt && !(strm->flags & NGTCP2_STRM_FLAG_STOP_SENDING)) {
+  } else if (fr->datacnt) {
     nwrite = ngtcp2_strm_recv_reordering(strm, fr->data[0].base,
                                          fr->data[0].len, fr->offset);
     if (nwrite < 0) {
@@ -7844,15 +7845,12 @@ static int conn_recv_reset_stream(ngtcp2_conn *conn,
     return rv;
   }
 
+  conn->rx.offset += datalen;
+
   /* Extend connection flow control window for the amount of data
      which are not passed to application. */
-  if (!(strm->flags & NGTCP2_STRM_FLAG_STOP_SENDING)) {
-    ngtcp2_conn_extend_max_offset(conn, strm->rx.last_offset -
-                                          ngtcp2_strm_rx_offset(strm));
-  }
-
-  conn->rx.offset += datalen;
-  ngtcp2_conn_extend_max_offset(conn, datalen);
+  ngtcp2_conn_extend_max_offset(conn,
+                                fr->final_size - ngtcp2_strm_rx_offset(strm));
 
   strm->rx.last_offset = fr->final_size;
   strm->flags |=
@@ -8533,10 +8531,6 @@ static int conn_recv_stream_data_blocked(ngtcp2_conn *conn,
     }
 
     conn->rx.offset += datalen;
-
-    if (strm->flags & NGTCP2_STRM_FLAG_STOP_SENDING) {
-      ngtcp2_conn_extend_max_offset(conn, datalen);
-    }
   }
 
   strm->rx.last_offset = fr->offset;
@@ -13000,14 +12994,7 @@ static int conn_shutdown_stream_read(ngtcp2_conn *conn, ngtcp2_strm *strm,
     return 0;
   }
 
-  /* Extend connection flow control window for the amount of data
-     which are not passed to application. */
-  ngtcp2_conn_extend_max_offset(conn, strm->rx.last_offset -
-                                        ngtcp2_strm_rx_offset(strm));
-
   strm->flags |= NGTCP2_STRM_FLAG_STOP_SENDING;
-
-  ngtcp2_strm_discard_reordered_data(strm);
 
   return conn_stop_sending(conn, strm, app_error_code);
 }

--- a/lib/ngtcp2_strm.c
+++ b/lib/ngtcp2_strm.c
@@ -157,18 +157,6 @@ void ngtcp2_strm_update_rx_offset(ngtcp2_strm *strm, uint64_t offset) {
   ngtcp2_rob_remove_prefix(strm->rx.rob, offset);
 }
 
-void ngtcp2_strm_discard_reordered_data(ngtcp2_strm *strm) {
-  if (strm->rx.rob == NULL) {
-    return;
-  }
-
-  strm->rx.cont_offset = ngtcp2_strm_rx_offset(strm);
-
-  ngtcp2_rob_free(strm->rx.rob);
-  ngtcp2_mem_free(strm->mem, strm->rx.rob);
-  strm->rx.rob = NULL;
-}
-
 void ngtcp2_strm_shutdown(ngtcp2_strm *strm, uint32_t flags) {
   strm->flags |= flags & NGTCP2_STRM_FLAG_SHUT_RDWR;
 }
@@ -744,4 +732,27 @@ int ngtcp2_strm_require_retransmit_stream_data_blocked(
   const ngtcp2_strm *strm, const ngtcp2_stream_data_blocked *fr) {
   return fr->offset == strm->tx.max_offset &&
          !(strm->flags & NGTCP2_STRM_FLAG_SHUT_WR);
+}
+
+size_t ngtcp2_strm_discard_ordered_data(ngtcp2_strm *strm, uint64_t rx_offset) {
+  size_t datalen;
+  const uint8_t *data;
+  uint64_t orig_rx_offset = rx_offset;
+
+  if (!strm->rx.rob) {
+    return 0;
+  }
+
+  for (;;) {
+    datalen = ngtcp2_rob_data_at(strm->rx.rob, &data, rx_offset);
+    if (datalen == 0) {
+      break;
+    }
+
+    ngtcp2_rob_pop(strm->rx.rob, rx_offset, datalen);
+
+    rx_offset += datalen;
+  }
+
+  return (size_t)(rx_offset - orig_rx_offset);
 }

--- a/lib/ngtcp2_strm.h
+++ b/lib/ngtcp2_strm.h
@@ -224,12 +224,6 @@ ngtcp2_ssize ngtcp2_strm_recv_reordering(ngtcp2_strm *strm, const uint8_t *data,
 void ngtcp2_strm_update_rx_offset(ngtcp2_strm *strm, uint64_t offset);
 
 /*
- * ngtcp2_strm_discard_reordered_data discards all buffered reordered
- * data.
- */
-void ngtcp2_strm_discard_reordered_data(ngtcp2_strm *strm);
-
-/*
  * ngtcp2_strm_shutdown shutdowns |strm|.  |flags| should be one of
  * NGTCP2_STRM_FLAG_SHUT_RD, NGTCP2_STRM_FLAG_SHUT_WR, and
  * NGTCP2_STRM_FLAG_SHUT_RDWR.
@@ -357,5 +351,11 @@ int ngtcp2_strm_require_retransmit_max_stream_data(
  */
 int ngtcp2_strm_require_retransmit_stream_data_blocked(
   const ngtcp2_strm *strm, const ngtcp2_stream_data_blocked *fr);
+
+/* ngtcp2_strm_discard_ordered_data discards the ordered data starting
+   at |rx_offset|.  It stops when it finds a gap, which means that a
+   portion of the data has not been received yet.  It returns the size
+   of the buffered bytes discarded. */
+size_t ngtcp2_strm_discard_ordered_data(ngtcp2_strm *strm, uint64_t rx_offset);
 
 #endif /* !defined(NGTCP2_STRM_H) */

--- a/tests/ngtcp2_conn_test.c
+++ b/tests/ngtcp2_conn_test.c
@@ -2832,7 +2832,7 @@ void test_ngtcp2_conn_recv_reset_stream(void) {
   ngtcp2_conn_shutdown_stream_read(conn, 0, 4, NGTCP2_APP_ERR01);
   ngtcp2_conn_write_pkt(conn, NULL, NULL, buf, sizeof(buf), 3);
 
-  assert_uint64(128 * 1024 + 956, ==, conn->rx.unsent_max_offset);
+  assert_uint64(128 * 1024, ==, conn->rx.unsent_max_offset);
 
   fr.reset_stream = (ngtcp2_reset_stream){
     .type = NGTCP2_FRAME_RESET_STREAM,
@@ -3421,7 +3421,7 @@ void test_ngtcp2_conn_recv_stream_data_blocked(void) {
 
   assert_uint64(7777, ==, strm->rx.last_offset);
   assert_uint64(7777, ==, conn->rx.offset);
-  assert_uint64(128 * 1024 + 7777, ==, conn->rx.unsent_max_offset);
+  assert_uint64(128 * 1024, ==, conn->rx.unsent_max_offset);
 
   fr.stream = (ngtcp2_stream){
     .type = NGTCP2_FRAME_STREAM,
@@ -3442,7 +3442,7 @@ void test_ngtcp2_conn_recv_stream_data_blocked(void) {
   assert_int(0, ==, rv);
   assert_uint64(7778, ==, strm->rx.last_offset);
   assert_uint64(7778, ==, conn->rx.offset);
-  assert_uint64(128 * 1024 + 7778, ==, conn->rx.unsent_max_offset);
+  assert_uint64(128 * 1024, ==, conn->rx.unsent_max_offset);
 
   ngtcp2_conn_del(conn);
 
@@ -7831,6 +7831,123 @@ void test_ngtcp2_conn_recv_stream_data(void) {
   rv = ngtcp2_conn_read_pkt(conn, &null_path.path, NULL, buf, pktlen, ++t);
 
   assert_int(NGTCP2_ERR_INTERNAL, ==, rv);
+
+  ngtcp2_conn_del(conn);
+
+  /* After stream shutdown, the completion of the incoming data closes
+     the stream. */
+  setup_default_server(&conn);
+  ngtcp2_tpe_init_conn(&tpe, conn);
+
+  fr.stream = (ngtcp2_stream){
+    .type = NGTCP2_FRAME_STREAM,
+  };
+
+  pktlen = ngtcp2_tpe_write_1rtt(&tpe, buf, sizeof(buf), &fr, 1);
+
+  rv = ngtcp2_conn_read_pkt(conn, &null_path.path, NULL, buf, pktlen, ++t);
+
+  assert_int(0, ==, rv);
+
+  strm = ngtcp2_conn_find_stream(conn, 0);
+
+  assert_not_null(strm);
+
+  rv = ngtcp2_conn_shutdown_stream(conn, 0, 0, NGTCP2_APP_ERR01);
+
+  assert_int(0, ==, rv);
+
+  spktlen = ngtcp2_conn_write_pkt(conn, NULL, NULL, buf, sizeof(buf), ++t);
+
+  assert_ptrdiff(0, <, spktlen);
+
+  fr.ack = (ngtcp2_ack){
+    .type = NGTCP2_FRAME_ACK,
+    .largest_ack = conn->pktns.tx.last_pkt_num,
+  };
+
+  pktlen = ngtcp2_tpe_write_1rtt(&tpe, buf, sizeof(buf), &fr, 1);
+
+  rv = ngtcp2_conn_read_pkt(conn, &null_path.path, NULL, buf, pktlen, ++t);
+
+  assert_int(0, ==, rv);
+
+  strm = ngtcp2_conn_find_stream(conn, 0);
+
+  assert_not_null(strm);
+
+  datav = (ngtcp2_vec){
+    .base = null_data,
+    .len = 1,
+  };
+  frs[0].stream = (ngtcp2_stream){
+    .type = NGTCP2_FRAME_STREAM,
+    .offset = 1,
+    .datacnt = 1,
+    .data = &datav,
+  };
+  frs[1].stream = (ngtcp2_stream){
+    .type = NGTCP2_FRAME_STREAM,
+    .fin = 1,
+    .offset = 3,
+    .datacnt = 1,
+    .data = &datav,
+  };
+
+  pktlen = ngtcp2_tpe_write_1rtt(&tpe, buf, sizeof(buf), frs, 2);
+
+  rv = ngtcp2_conn_read_pkt(conn, &null_path.path, NULL, buf, pktlen, ++t);
+
+  assert_int(0, ==, rv);
+  assert_uint64(128 * 1024, ==, conn->rx.unsent_max_offset);
+
+  strm = ngtcp2_conn_find_stream(conn, 0);
+
+  assert_not_null(strm);
+
+  fr.stream = (ngtcp2_stream){
+    .type = NGTCP2_FRAME_STREAM,
+    .datacnt = 1,
+    .data = &datav,
+  };
+  datav = (ngtcp2_vec){
+    .base = null_data,
+    .len = 1,
+  };
+
+  pktlen = ngtcp2_tpe_write_1rtt(&tpe, buf, sizeof(buf), &fr, 1);
+
+  rv = ngtcp2_conn_read_pkt(conn, &null_path.path, NULL, buf, pktlen, ++t);
+
+  assert_int(0, ==, rv);
+  assert_uint64(128 * 1024 + 2, ==, conn->rx.unsent_max_offset);
+
+  strm = ngtcp2_conn_find_stream(conn, 0);
+
+  assert_not_null(strm);
+  assert_uint64(2, ==, ngtcp2_strm_rx_offset(strm));
+
+  fr.stream = (ngtcp2_stream){
+    .type = NGTCP2_FRAME_STREAM,
+    .offset = 2,
+    .datacnt = 1,
+    .data = &datav,
+  };
+  datav = (ngtcp2_vec){
+    .base = null_data,
+    .len = 1,
+  };
+
+  pktlen = ngtcp2_tpe_write_1rtt(&tpe, buf, sizeof(buf), &fr, 1);
+
+  rv = ngtcp2_conn_read_pkt(conn, &null_path.path, NULL, buf, pktlen, ++t);
+
+  assert_int(0, ==, rv);
+  assert_uint64(128 * 1024 + 4, ==, conn->rx.unsent_max_offset);
+
+  strm = ngtcp2_conn_find_stream(conn, 0);
+
+  assert_null(strm);
 
   ngtcp2_conn_del(conn);
 }

--- a/tests/ngtcp2_strm_test.c
+++ b/tests/ngtcp2_strm_test.c
@@ -35,7 +35,7 @@ static const MunitTest tests[] = {
   munit_void_test(test_ngtcp2_strm_streamfrq_pop),
   munit_void_test(test_ngtcp2_strm_streamfrq_unacked_offset),
   munit_void_test(test_ngtcp2_strm_streamfrq_unacked_pop),
-  munit_void_test(test_ngtcp2_strm_discard_reordered_data),
+  munit_void_test(test_ngtcp2_strm_discard_ordered_data),
   munit_test_end(),
 };
 
@@ -805,7 +805,7 @@ void test_ngtcp2_strm_streamfrq_unacked_pop(void) {
   ngtcp2_objalloc_free(&frc_objalloc);
 }
 
-void test_ngtcp2_strm_discard_reordered_data(void) {
+void test_ngtcp2_strm_discard_ordered_data(void) {
   ngtcp2_strm strm;
   const ngtcp2_mem *mem = ngtcp2_mem_default();
 
@@ -813,26 +813,27 @@ void test_ngtcp2_strm_discard_reordered_data(void) {
   ngtcp2_strm_init(&strm, 0, NGTCP2_STRM_FLAG_NONE, 0, 0, NULL, NULL, mem);
 
   ngtcp2_strm_update_rx_offset(&strm, 1000000007);
-  ngtcp2_strm_discard_reordered_data(&strm);
+  ngtcp2_strm_discard_ordered_data(&strm, 1000000007);
 
   assert_null(strm.rx.rob);
   assert_uint64(1000000007, ==, ngtcp2_strm_rx_offset(&strm));
 
   ngtcp2_strm_free(&strm);
 
-  /* Discard reordered data */
+  /* Discard the ordered data */
   ngtcp2_strm_init(&strm, 0, NGTCP2_STRM_FLAG_NONE, 0, 0, NULL, NULL, mem);
 
-  ngtcp2_strm_update_rx_offset(&strm, 1000000007);
-  ngtcp2_strm_recv_reordering(&strm, nulldata, 117, 1000000008);
+  ngtcp2_strm_recv_reordering(&strm, nulldata, 1024, 1000000007);
+  ngtcp2_strm_recv_reordering(&strm, nulldata, 999, 1000001032);
 
   assert_not_null(strm.rx.rob);
-  assert_uint64(1000000007, ==, ngtcp2_strm_rx_offset(&strm));
+  assert_uint64(0, ==, ngtcp2_strm_rx_offset(&strm));
 
-  ngtcp2_strm_discard_reordered_data(&strm);
+  ngtcp2_strm_update_rx_offset(&strm, 1000000007);
 
-  assert_null(strm.rx.rob);
-  assert_uint64(1000000007, ==, ngtcp2_strm_rx_offset(&strm));
+  ngtcp2_strm_discard_ordered_data(&strm, 1000000007);
+
+  assert_uint64(1000001031, ==, ngtcp2_strm_rx_offset(&strm));
 
   ngtcp2_strm_free(&strm);
 }

--- a/tests/ngtcp2_strm_test.h
+++ b/tests/ngtcp2_strm_test.h
@@ -38,6 +38,6 @@ extern const MunitSuite strm_suite;
 munit_void_test_decl(test_ngtcp2_strm_streamfrq_pop)
 munit_void_test_decl(test_ngtcp2_strm_streamfrq_unacked_offset)
 munit_void_test_decl(test_ngtcp2_strm_streamfrq_unacked_pop)
-munit_void_test_decl(test_ngtcp2_strm_discard_reordered_data)
+munit_void_test_decl(test_ngtcp2_strm_discard_ordered_data)
 
 #endif /* !defined(NGTCP2_STRM_TEST_H) */


### PR DESCRIPTION
Instead of immediately recovering connection flow window, only recover the amount of data that would otherwise are passed to the application. The stream data are still buffered for STOP_SENDING and the received offset is updated, so that we can close the stream when all stream data are received to its fin.  This is required because the remote endpoint might still send all its data after receiving STOP_SENDING.