### PR TITLE
Tweak stream_close2 callback behavior

### DIFF
--- a/lib/includes/ngtcp2/ngtcp2.h
+++ b/lib/includes/ngtcp2/ngtcp2.h
@@ -3687,10 +3687,10 @@ typedef int (*ngtcp2_get_path_challenge_data2)(ngtcp2_conn *conn,
  * existing streams are closed.  |flags| is the bitwise-OR of zero or
  * more of :macro:`NGTCP2_STREAM_CLOSE2_FLAG_*
  * <NGTCP2_STREAM_CLOSE2_FLAG_NONE>`.  |rx_app_error_code| indicates
- * the error code received from the remote endpoint in RESET_STREAM
- * frame if :macro:`NGTCP2_STREAM_CLOSE2_FLAG_RX_APP_ERROR_CODE_SET`
- * is set in |flags|.  |tx_app_error_code| indicates the error code
- * sent to the remote endpoint in RESET_STREAM frame if
+ * the error code that shut down the receiving side of the stream if
+ * :macro:`NGTCP2_STREAM_CLOSE2_FLAG_RX_APP_ERROR_CODE_SET` is set in
+ * |flags|.  |tx_app_error_code| indicates the error code that shut
+ * down the sending side of the stream if
  * :macro:`NGTCP2_STREAM_CLOSE2_FLAG_TX_APP_ERROR_CODE_SET` is set in
  * |flags|.
  *

--- a/lib/ngtcp2_conn.c
+++ b/lib/ngtcp2_conn.c
@@ -193,20 +193,27 @@ static int conn_call_stream_open(ngtcp2_conn *conn, ngtcp2_strm *strm) {
 static int conn_call_stream_close(ngtcp2_conn *conn, ngtcp2_strm *strm) {
   int rv;
   uint32_t flags;
+  uint64_t rx_app_error_code;
 
   if (conn->callbacks.stream_close2) {
     flags = NGTCP2_STREAM_CLOSE2_FLAG_NONE;
 
-    if (strm->flags & NGTCP2_STRM_FLAG_RX_APP_ERROR_CODE_SET) {
+    if (strm->flags & NGTCP2_STRM_FLAG_TX_STOP_SENDING_APP_ERROR_CODE_SET) {
       flags |= NGTCP2_STREAM_CLOSE2_FLAG_RX_APP_ERROR_CODE_SET;
+      rx_app_error_code = strm->tx.stop_sending_app_error_code;
+    } else if (strm->flags & NGTCP2_STRM_FLAG_RX_APP_ERROR_CODE_SET) {
+      flags |= NGTCP2_STREAM_CLOSE2_FLAG_RX_APP_ERROR_CODE_SET;
+      rx_app_error_code = strm->rx.app_error_code;
+    } else {
+      rx_app_error_code = 0;
     }
 
-    if (strm->flags & NGTCP2_STRM_FLAG_TX_APP_ERROR_CODE_SET) {
+    if (strm->flags & NGTCP2_STRM_FLAG_TX_RESET_STREAM_APP_ERROR_CODE_SET) {
       flags |= NGTCP2_STREAM_CLOSE2_FLAG_TX_APP_ERROR_CODE_SET;
     }
 
     rv = conn->callbacks.stream_close2(conn, flags, strm->stream_id,
-                                       strm->rx.app_error_code,
+                                       rx_app_error_code,
                                        strm->tx.reset_stream_app_error_code,
                                        conn->user_data, strm->stream_user_data);
     if (rv != 0) {
@@ -7667,8 +7674,8 @@ static int conn_recv_stream(ngtcp2_conn *conn, const ngtcp2_stream *fr,
  */
 static int conn_reset_stream(ngtcp2_conn *conn, ngtcp2_strm *strm,
                              uint64_t app_error_code) {
-  strm->flags |=
-    NGTCP2_STRM_FLAG_SEND_RESET_STREAM | NGTCP2_STRM_FLAG_TX_APP_ERROR_CODE_SET;
+  strm->flags |= NGTCP2_STRM_FLAG_SEND_RESET_STREAM |
+                 NGTCP2_STRM_FLAG_TX_RESET_STREAM_APP_ERROR_CODE_SET;
   strm->tx.reset_stream_app_error_code = app_error_code;
 
   if (ngtcp2_strm_is_tx_queued(strm)) {
@@ -7692,7 +7699,8 @@ static int conn_reset_stream(ngtcp2_conn *conn, ngtcp2_strm *strm,
  */
 static int conn_stop_sending(ngtcp2_conn *conn, ngtcp2_strm *strm,
                              uint64_t app_error_code) {
-  strm->flags |= NGTCP2_STRM_FLAG_SEND_STOP_SENDING;
+  strm->flags |= NGTCP2_STRM_FLAG_SEND_STOP_SENDING |
+                 NGTCP2_STRM_FLAG_TX_STOP_SENDING_APP_ERROR_CODE_SET;
   strm->tx.stop_sending_app_error_code = app_error_code;
 
   if (ngtcp2_strm_is_tx_queued(strm)) {
@@ -12979,8 +12987,16 @@ static int conn_shutdown_stream_write(ngtcp2_conn *conn, ngtcp2_strm *strm,
                                       uint64_t app_error_code) {
   ngtcp2_strm_set_app_error_code(strm, app_error_code);
 
-  if ((strm->flags & NGTCP2_STRM_FLAG_RESET_STREAM) ||
-      ngtcp2_strm_is_all_tx_data_fin_acked(strm)) {
+  if (strm->flags & NGTCP2_STRM_FLAG_RESET_STREAM) {
+    return 0;
+  }
+
+  if (ngtcp2_strm_is_all_tx_data_fin_acked(strm)) {
+    if (!(strm->flags & NGTCP2_STRM_FLAG_TX_RESET_STREAM_APP_ERROR_CODE_SET)) {
+      strm->flags |= NGTCP2_STRM_FLAG_TX_RESET_STREAM_APP_ERROR_CODE_SET;
+      strm->tx.reset_stream_app_error_code = app_error_code;
+    }
+
     return 0;
   }
 
@@ -13013,6 +13029,11 @@ static int conn_shutdown_stream_read(ngtcp2_conn *conn, ngtcp2_strm *strm,
   }
   if ((strm->flags & NGTCP2_STRM_FLAG_SHUT_RD) &&
       ngtcp2_strm_rx_offset(strm) == strm->rx.last_offset) {
+    if (!(strm->flags & NGTCP2_STRM_FLAG_TX_STOP_SENDING_APP_ERROR_CODE_SET)) {
+      strm->flags |= NGTCP2_STRM_FLAG_TX_STOP_SENDING_APP_ERROR_CODE_SET;
+      strm->tx.stop_sending_app_error_code = app_error_code;
+    }
+
     return 0;
   }
 

--- a/lib/ngtcp2_strm.h
+++ b/lib/ngtcp2_strm.h
@@ -95,9 +95,12 @@ typedef struct ngtcp2_frame_chain ngtcp2_frame_chain;
 /* NGTCP2_STRM_FLAG_RX_APP_ERROR_CODE_SET is set when
    ngtcp2_strm.rx.app_error_code is set. */
 #define NGTCP2_STRM_FLAG_RX_APP_ERROR_CODE_SET 0x4000U
-/* NGTCP2_STRM_FLAG_TX_APP_ERROR_CODE_SET is set when
+/* NGTCP2_STRM_FLAG_TX_RESET_STREAM_APP_ERROR_CODE_SET is set when
    ngtcp2_strm.tx.reset_stream_app_error_code is set. */
-#define NGTCP2_STRM_FLAG_TX_APP_ERROR_CODE_SET 0x8000U
+#define NGTCP2_STRM_FLAG_TX_RESET_STREAM_APP_ERROR_CODE_SET 0x8000U
+/* NGTCP2_STRM_FLAG_TX_STOP_SENDING_APP_ERROR_CODE_SET is set when
+   ngtcp2_strm.tx.stop_sending_app_error_code is set. */
+#define NGTCP2_STRM_FLAG_TX_STOP_SENDING_APP_ERROR_CODE_SET 0x10000U
 
 typedef struct ngtcp2_strm ngtcp2_strm;
 
@@ -147,14 +150,20 @@ struct ngtcp2_strm {
            multiple STREAM frames in one lost packet. */
         int64_t last_lost_pkt_num;
         /* stop_sending_app_error_code is the application specific
-           error code that is sent along with STOP_SENDING. */
+           error code that is sent along with STOP_SENDING.  It might
+           not be sent if the receiving side of the stream has been
+           closed.  If this field is set,
+           NGTCP2_STRM_FLAG_TX_STOP_SENDING_APP_ERROR_CODE_SET is set.
+           This field is eventually passed to ngtcp2_stream_close2
+           callback as rx_app_error_code parameter. */
         uint64_t stop_sending_app_error_code;
         /* reset_stream_app_error_code is the application specific
-           error code that is sent along with RESET_STREAM.  If this
-           field is set, NGTCP2_STRM_FLAG_TX_APP_ERROR_CODE_SET is
-           set.  This field is eventually passed to
-           ngtcp2_stream_close2 callback as tx_app_error_code
-           parameter. */
+           error code that is sent along with RESET_STREAM.  It might
+           not be sent if the sending side of the stream has been
+           closed.  If this field is set,
+           NGTCP2_STRM_FLAG_TX_RESET_STREAM_APP_ERROR_CODE_SET is set.
+           This field is eventually passed to ngtcp2_stream_close2
+           callback as tx_app_error_code parameter. */
         uint64_t reset_stream_app_error_code;
       } tx;
 

--- a/tests/ngtcp2_conn_test.c
+++ b/tests/ngtcp2_conn_test.c
@@ -15632,8 +15632,126 @@ void test_ngtcp2_conn_stream_close(void) {
   assert_uint32(NGTCP2_STREAM_CLOSE2_FLAG_RX_APP_ERROR_CODE_SET, ==,
                 ud.stream_close2.flags);
   assert_int64(0, ==, ud.stream_close2.stream_id);
-  assert_uint64(NGTCP2_APP_ERR02, ==, ud.stream_close2.rx_app_error_code);
+  assert_uint64(NGTCP2_APP_ERR01, ==, ud.stream_close2.rx_app_error_code);
   assert_uint64(0, ==, ud.stream_close2.tx_app_error_code);
+
+  ngtcp2_conn_del(conn);
+
+  /* stream_close2: Calling ngtcp2_conn_shutdown_stream_read after the
+     incoming fin sets rx_app_error_code */
+  server_default_callbacks(&callbacks);
+  callbacks.stream_close2 = stream_close2;
+
+  opts = (conn_options){
+    .callbacks = &callbacks,
+    .user_data = &ud,
+  };
+
+  setup_default_server_with_options(&conn, opts);
+  ngtcp2_tpe_init_conn(&tpe, conn);
+
+  frs[0].stream = (ngtcp2_stream){
+    .type = NGTCP2_FRAME_STREAM,
+    .fin = 1,
+  };
+
+  pktlen = ngtcp2_tpe_write_1rtt(&tpe, buf, sizeof(buf), frs, 1);
+
+  rv = ngtcp2_conn_read_pkt(conn, &null_path.path, NULL, buf, pktlen, ++t);
+
+  assert_int(0, ==, rv);
+
+  rv = ngtcp2_conn_shutdown_stream_read(conn, 0, 0, NGTCP2_INTERNAL_ERROR);
+
+  assert_int(0, ==, rv);
+
+  spktlen = ngtcp2_conn_write_stream(conn, NULL, NULL, buf, sizeof(buf), NULL,
+                                     NGTCP2_WRITE_STREAM_FLAG_FIN, 0, null_data,
+                                     1, ++t);
+
+  assert_ptrdiff(0, <, spktlen);
+
+  frs[0].ack = (ngtcp2_ack){
+    .type = NGTCP2_FRAME_ACK,
+    .largest_ack = conn->pktns.tx.last_pkt_num,
+  };
+
+  pktlen = ngtcp2_tpe_write_1rtt(&tpe, buf, sizeof(buf), frs, 1);
+
+  ud = (my_user_data){0};
+  rv = ngtcp2_conn_read_pkt(conn, &null_path.path, NULL, buf, pktlen, ++t);
+
+  assert_int(0, ==, rv);
+  assert_size(1, ==, ud.stream_close2.ncalled);
+  assert_uint32(NGTCP2_STREAM_CLOSE2_FLAG_RX_APP_ERROR_CODE_SET, ==,
+                ud.stream_close2.flags);
+  assert_int64(0, ==, ud.stream_close2.stream_id);
+  assert_uint64(NGTCP2_INTERNAL_ERROR, ==, ud.stream_close2.rx_app_error_code);
+  assert_uint64(0, ==, ud.stream_close2.tx_app_error_code);
+
+  ngtcp2_conn_del(conn);
+
+  /* stream_close2: Calling ngtcp2_conn_shutdown_stream_write after
+     the all outgoing data is acknowledged sets tx_app_error_code */
+  server_default_callbacks(&callbacks);
+  callbacks.stream_close2 = stream_close2;
+
+  opts = (conn_options){
+    .callbacks = &callbacks,
+    .user_data = &ud,
+  };
+
+  setup_default_server_with_options(&conn, opts);
+  ngtcp2_tpe_init_conn(&tpe, conn);
+
+  frs[0].stream = (ngtcp2_stream){
+    .type = NGTCP2_FRAME_STREAM,
+  };
+
+  pktlen = ngtcp2_tpe_write_1rtt(&tpe, buf, sizeof(buf), frs, 1);
+
+  rv = ngtcp2_conn_read_pkt(conn, &null_path.path, NULL, buf, pktlen, ++t);
+
+  assert_int(0, ==, rv);
+
+  spktlen = ngtcp2_conn_write_stream(conn, NULL, NULL, buf, sizeof(buf), NULL,
+                                     NGTCP2_WRITE_STREAM_FLAG_FIN, 0, null_data,
+                                     1, ++t);
+
+  assert_ptrdiff(0, <, spktlen);
+
+  frs[0].ack = (ngtcp2_ack){
+    .type = NGTCP2_FRAME_ACK,
+    .largest_ack = conn->pktns.tx.last_pkt_num,
+  };
+
+  pktlen = ngtcp2_tpe_write_1rtt(&tpe, buf, sizeof(buf), frs, 1);
+
+  rv = ngtcp2_conn_read_pkt(conn, &null_path.path, NULL, buf, pktlen, ++t);
+
+  assert_int(0, ==, rv);
+
+  rv = ngtcp2_conn_shutdown_stream_write(conn, 0, 0, NGTCP2_INTERNAL_ERROR);
+
+  assert_int(0, ==, rv);
+
+  frs[0].stream = (ngtcp2_stream){
+    .type = NGTCP2_FRAME_STREAM,
+    .fin = 1,
+  };
+
+  pktlen = ngtcp2_tpe_write_1rtt(&tpe, buf, sizeof(buf), frs, 1);
+
+  ud = (my_user_data){0};
+  rv = ngtcp2_conn_read_pkt(conn, &null_path.path, NULL, buf, pktlen, ++t);
+
+  assert_int(0, ==, rv);
+  assert_size(1, ==, ud.stream_close2.ncalled);
+  assert_uint32(NGTCP2_STREAM_CLOSE2_FLAG_TX_APP_ERROR_CODE_SET, ==,
+                ud.stream_close2.flags);
+  assert_int64(0, ==, ud.stream_close2.stream_id);
+  assert_uint64(0, ==, ud.stream_close2.rx_app_error_code);
+  assert_uint64(NGTCP2_INTERNAL_ERROR, ==, ud.stream_close2.tx_app_error_code);
 
   ngtcp2_conn_del(conn);
 }


### PR DESCRIPTION
For rx_app_error_code, if the local endpoint shuts down the receiving side of the stream, the error code is used as rx_app_error_code.  It is preferred to the error code in the incoming RESET_STREAM frame.

If ngtcp2_conn_shutdown_stream_read or
ngtcp2_conn_shutdown_stream_write is called, and the local endpoint does not send STOP_SENDING or RESET_STREAM frame due to some conditions, the app error code is still recorded if it has not been recorded.

These change aims to match the behavior of the existing single app_error_code handling for stream_close callback.