### PR TITLE
Partially revert #2242

### DIFF
--- a/lib/ngtcp2_conn.c
+++ b/lib/ngtcp2_conn.c
@@ -12987,16 +12987,8 @@ static int conn_shutdown_stream_write(ngtcp2_conn *conn, ngtcp2_strm *strm,
                                       uint64_t app_error_code) {
   ngtcp2_strm_set_app_error_code(strm, app_error_code);
 
-  if (strm->flags & NGTCP2_STRM_FLAG_RESET_STREAM) {
-    return 0;
-  }
-
-  if (ngtcp2_strm_is_all_tx_data_fin_acked(strm)) {
-    if (!(strm->flags & NGTCP2_STRM_FLAG_TX_RESET_STREAM_APP_ERROR_CODE_SET)) {
-      strm->flags |= NGTCP2_STRM_FLAG_TX_RESET_STREAM_APP_ERROR_CODE_SET;
-      strm->tx.reset_stream_app_error_code = app_error_code;
-    }
-
+  if ((strm->flags & NGTCP2_STRM_FLAG_RESET_STREAM) ||
+      ngtcp2_strm_is_all_tx_data_fin_acked(strm)) {
     return 0;
   }
 
@@ -13029,11 +13021,6 @@ static int conn_shutdown_stream_read(ngtcp2_conn *conn, ngtcp2_strm *strm,
   }
   if ((strm->flags & NGTCP2_STRM_FLAG_SHUT_RD) &&
       ngtcp2_strm_rx_offset(strm) == strm->rx.last_offset) {
-    if (!(strm->flags & NGTCP2_STRM_FLAG_TX_STOP_SENDING_APP_ERROR_CODE_SET)) {
-      strm->flags |= NGTCP2_STRM_FLAG_TX_STOP_SENDING_APP_ERROR_CODE_SET;
-      strm->tx.stop_sending_app_error_code = app_error_code;
-    }
-
     return 0;
   }
 

--- a/lib/ngtcp2_strm.h
+++ b/lib/ngtcp2_strm.h
@@ -150,17 +150,15 @@ struct ngtcp2_strm {
            multiple STREAM frames in one lost packet. */
         int64_t last_lost_pkt_num;
         /* stop_sending_app_error_code is the application specific
-           error code that is sent along with STOP_SENDING.  It might
-           not be sent if the receiving side of the stream has been
-           closed.  If this field is set,
+           error code that is sent along with STOP_SENDING.  If this
+           field is set,
            NGTCP2_STRM_FLAG_TX_STOP_SENDING_APP_ERROR_CODE_SET is set.
            This field is eventually passed to ngtcp2_stream_close2
            callback as rx_app_error_code parameter. */
         uint64_t stop_sending_app_error_code;
         /* reset_stream_app_error_code is the application specific
-           error code that is sent along with RESET_STREAM.  It might
-           not be sent if the sending side of the stream has been
-           closed.  If this field is set,
+           error code that is sent along with RESET_STREAM.  If this
+           field is set,
            NGTCP2_STRM_FLAG_TX_RESET_STREAM_APP_ERROR_CODE_SET is set.
            This field is eventually passed to ngtcp2_stream_close2
            callback as tx_app_error_code parameter. */

--- a/tests/ngtcp2_conn_test.c
+++ b/tests/ngtcp2_conn_test.c
@@ -15638,7 +15638,7 @@ void test_ngtcp2_conn_stream_close(void) {
   ngtcp2_conn_del(conn);
 
   /* stream_close2: Calling ngtcp2_conn_shutdown_stream_read after the
-     incoming fin sets rx_app_error_code */
+     incoming fin does not set rx_app_error_code */
   server_default_callbacks(&callbacks);
   callbacks.stream_close2 = stream_close2;
 
@@ -15683,16 +15683,14 @@ void test_ngtcp2_conn_stream_close(void) {
 
   assert_int(0, ==, rv);
   assert_size(1, ==, ud.stream_close2.ncalled);
-  assert_uint32(NGTCP2_STREAM_CLOSE2_FLAG_RX_APP_ERROR_CODE_SET, ==,
-                ud.stream_close2.flags);
+  assert_uint32(NGTCP2_STREAM_CLOSE2_FLAG_NONE, ==, ud.stream_close2.flags);
   assert_int64(0, ==, ud.stream_close2.stream_id);
-  assert_uint64(NGTCP2_INTERNAL_ERROR, ==, ud.stream_close2.rx_app_error_code);
-  assert_uint64(0, ==, ud.stream_close2.tx_app_error_code);
 
   ngtcp2_conn_del(conn);
 
   /* stream_close2: Calling ngtcp2_conn_shutdown_stream_write after
-     the all outgoing data is acknowledged sets tx_app_error_code */
+     the all outgoing data is acknowledged does not set
+     tx_app_error_code */
   server_default_callbacks(&callbacks);
   callbacks.stream_close2 = stream_close2;
 
@@ -15747,11 +15745,8 @@ void test_ngtcp2_conn_stream_close(void) {
 
   assert_int(0, ==, rv);
   assert_size(1, ==, ud.stream_close2.ncalled);
-  assert_uint32(NGTCP2_STREAM_CLOSE2_FLAG_TX_APP_ERROR_CODE_SET, ==,
-                ud.stream_close2.flags);
+  assert_uint32(NGTCP2_STREAM_CLOSE2_FLAG_NONE, ==, ud.stream_close2.flags);
   assert_int64(0, ==, ud.stream_close2.stream_id);
-  assert_uint64(0, ==, ud.stream_close2.rx_app_error_code);
-  assert_uint64(NGTCP2_INTERNAL_ERROR, ==, ud.stream_close2.tx_app_error_code);
 
   ngtcp2_conn_del(conn);
 }


### PR DESCRIPTION
Setting error code without sending STOP_SENDING or RESET_STREAM is too much and it voids the purpose of telling the detailed error codes to the application.