### PR TITLE
Make max CRYPTO offsets configurable

### DIFF
--- a/lib/includes/ngtcp2/ngtcp2.h
+++ b/lib/includes/ngtcp2/ngtcp2.h
@@ -1861,7 +1861,8 @@ typedef enum ngtcp2_token_type {
 #define NGTCP2_SETTINGS_V2 2
 #define NGTCP2_SETTINGS_V3 3
 #define NGTCP2_SETTINGS_V4 4
-#define NGTCP2_SETTINGS_VERSION NGTCP2_SETTINGS_V4
+#define NGTCP2_SETTINGS_V5 5
+#define NGTCP2_SETTINGS_VERSION NGTCP2_SETTINGS_V5
 
 /**
  * @struct
@@ -2116,6 +2117,28 @@ typedef struct ngtcp2_settings {
    * .. version-added:: 1.23.0
    */
   ngtcp2_log_write log_write;
+  /* The following fields have been added since NGTCP2_SETTINGS_V5. */
+  /**
+   * :member:`max_initial_crypto_offset` is the maximum offset of
+   * CRYPTO data at the Initial encryption level.
+   *
+   * .. version-added:: 1.25.0
+   */
+  size_t max_initial_crypto_offset;
+  /**
+   * :member:`max_handshake_crypto_offset` is the maximum offset of
+   * CRYPTO data at the Handshake encryption level.
+   *
+   * .. version-added:: 1.25.0
+   */
+  size_t max_handshake_crypto_offset;
+  /**
+   * :member:`max_1rtt_crypto_offset` is the maximum offset of CRYPTO
+   * data at the 1RTT encryption level.
+   *
+   * .. version-added:: 1.25.0
+   */
+  size_t max_1rtt_crypto_offset;
 } ngtcp2_settings;
 
 /**
@@ -7125,6 +7148,12 @@ NGTCP2_EXTERN void ngtcp2_path_storage_zero(ngtcp2_path_storage *ps);
  *   <ngtcp2_settings.glitch_ratelim_burst>` = 10000
  * * :member:`glitch_ratelim_rate
  *   <ngtcp2_settings.glitch_ratelim_rate>` = 330
+ * * :member:`max_initial_crypto_offset
+ *   <ngtcp2_settings.max_initial_crypto_offset>` = 65536
+ * * :member:`max_handshake_crypto_offset
+ *   <ngtcp2_settings.max_handshake_crypto_offset>` = 65536
+ * * :member:`max_1rtt_crypto_offset
+ *   <ngtcp2_settings.max_1rtt_crypto_offset>` = 262144
  */
 NGTCP2_EXTERN void ngtcp2_settings_default_versioned(int settings_version,
                                                      ngtcp2_settings *settings);

--- a/lib/ngtcp2_conn.c
+++ b/lib/ngtcp2_conn.c
@@ -58,16 +58,6 @@
    are not processed. */
 #define NGTCP2_MAX_ACK_PER_PKT 1
 
-/* NGTCP2_MAX_INITIAL_CRYPTO_OFFSET is the maximum offset of CRYPTO
-   data at Initial encryption level. */
-#define NGTCP2_MAX_INITIAL_CRYPTO_OFFSET (64 * 1024)
-/* NGTCP2_MAX_HANDSHAKE_CRYPTO_OFFSET is the maximum offset of CRYPTO
-   data at Handshake encryption level. */
-#define NGTCP2_MAX_HANDSHAKE_CRYPTO_OFFSET (64 * 1024)
-/* NGTCP2_MAX_1RTT_CRYPTO_OFFSET is the maximum offset of CRYPTO data
-   at 1RTT encryption level. */
-#define NGTCP2_MAX_1RTT_CRYPTO_OFFSET (256 * 1024)
-
 ngtcp2_objalloc_def(strm, ngtcp2_strm, oplent)
 
 /*
@@ -7318,13 +7308,13 @@ static int conn_recv_crypto(ngtcp2_conn *conn,
      store. */
   switch (encryption_level) {
   case NGTCP2_ENCRYPTION_LEVEL_INITIAL:
-    max_offset = NGTCP2_MAX_INITIAL_CRYPTO_OFFSET;
+    max_offset = conn->local.settings.max_initial_crypto_offset;
     break;
   case NGTCP2_ENCRYPTION_LEVEL_HANDSHAKE:
-    max_offset = NGTCP2_MAX_HANDSHAKE_CRYPTO_OFFSET;
+    max_offset = conn->local.settings.max_handshake_crypto_offset;
     break;
   case NGTCP2_ENCRYPTION_LEVEL_1RTT:
-    max_offset = NGTCP2_MAX_1RTT_CRYPTO_OFFSET;
+    max_offset = conn->local.settings.max_1rtt_crypto_offset;
     break;
   default:
     ngtcp2_unreachable();

--- a/lib/ngtcp2_settings.c
+++ b/lib/ngtcp2_settings.c
@@ -37,6 +37,13 @@ void ngtcp2_settings_default_versioned(int settings_version,
 
   switch (settings_version) {
   case NGTCP2_SETTINGS_VERSION:
+    settings->max_initial_crypto_offset =
+      NGTCP2_DEFAULT_MAX_INITIAL_CRYPTO_OFFSET;
+    settings->max_handshake_crypto_offset =
+      NGTCP2_DEFAULT_MAX_HANDSHAKE_CRYPTO_OFFSET;
+    settings->max_1rtt_crypto_offset = NGTCP2_DEFAULT_MAX_1RTT_CRYPTO_OFFSET;
+    /* fall through */
+  case NGTCP2_SETTINGS_V4:
   case NGTCP2_SETTINGS_V3:
     settings->glitch_ratelim_burst = NGTCP2_DEFAULT_GLITCH_RATELIM_BURST;
     settings->glitch_ratelim_rate = NGTCP2_DEFAULT_GLITCH_RATELIM_RATE;
@@ -87,6 +94,8 @@ size_t ngtcp2_settingslen_version(int settings_version) {
   switch (settings_version) {
   case NGTCP2_SETTINGS_VERSION:
     return sizeof(settings);
+  case NGTCP2_SETTINGS_V4:
+    return offsetof(ngtcp2_settings, log_write) + sizeof(settings.log_write);
   case NGTCP2_SETTINGS_V3:
     return offsetof(ngtcp2_settings, glitch_ratelim_rate) +
            sizeof(settings.glitch_ratelim_rate);

--- a/lib/ngtcp2_settings.h
+++ b/lib/ngtcp2_settings.h
@@ -38,6 +38,16 @@
    per second for glitch rate limiter. */
 #define NGTCP2_DEFAULT_GLITCH_RATELIM_RATE 330
 
+/* NGTCP2_DEFAULT_MAX_INITIAL_CRYPTO_OFFSET is the maximum offset of
+   CRYPTO data at the Initial encryption level. */
+#define NGTCP2_DEFAULT_MAX_INITIAL_CRYPTO_OFFSET (64 * 1024)
+/* NGTCP2_DEFAULT_MAX_HANDSHAKE_CRYPTO_OFFSET is the maximum offset of
+   CRYPTO data at the Handshake encryption level. */
+#define NGTCP2_DEFAULT_MAX_HANDSHAKE_CRYPTO_OFFSET (64 * 1024)
+/* NGTCP2_DEFAULT_MAX_1RTT_CRYPTO_OFFSET is the maximum offset of
+   CRYPTO data at the 1RTT encryption level. */
+#define NGTCP2_DEFAULT_MAX_1RTT_CRYPTO_OFFSET (256 * 1024)
+
 /*
  * ngtcp2_settings_convert_to_latest converts |src| of version
  * |settings_version| to the latest version NGTCP2_SETTINGS_VERSION.

--- a/tests/ngtcp2_settings_test.c
+++ b/tests/ngtcp2_settings_test.c
@@ -67,7 +67,7 @@ static const uint32_t available_versions[] = {534114833, 797700084, 96134021,
 static const uint16_t pmtud_probes[] = {65466, 47820, 27776};
 
 void test_ngtcp2_settings_convert_to_latest(void) {
-  const int srcver = NGTCP2_SETTINGS_V3;
+  const int srcver = NGTCP2_SETTINGS_V4;
   ngtcp2_settings *src, srcbuf, settingsbuf;
   const ngtcp2_settings *dest;
   size_t srclen;
@@ -100,6 +100,7 @@ void test_ngtcp2_settings_convert_to_latest(void) {
   srcbuf.pmtud_probeslen = ngtcp2_arraylen(pmtud_probes);
   srcbuf.glitch_ratelim_burst = 1000000007;
   srcbuf.glitch_ratelim_rate = 1000000009;
+  srcbuf.log_write = log_write;
 
   srclen = ngtcp2_settingslen_version(srcver);
 
@@ -140,11 +141,17 @@ void test_ngtcp2_settings_convert_to_latest(void) {
   assert_size(srcbuf.pmtud_probeslen, ==, dest->pmtud_probeslen);
   assert_uint64(srcbuf.glitch_ratelim_burst, ==, dest->glitch_ratelim_burst);
   assert_uint64(srcbuf.glitch_ratelim_rate, ==, dest->glitch_ratelim_rate);
-  assert_null(dest->log_write);
+  assert_ptr_equal(srcbuf.log_write, dest->log_write);
+  assert_size(NGTCP2_DEFAULT_MAX_INITIAL_CRYPTO_OFFSET, ==,
+              dest->max_initial_crypto_offset);
+  assert_size(NGTCP2_DEFAULT_MAX_HANDSHAKE_CRYPTO_OFFSET, ==,
+              dest->max_handshake_crypto_offset);
+  assert_size(NGTCP2_DEFAULT_MAX_1RTT_CRYPTO_OFFSET, ==,
+              dest->max_1rtt_crypto_offset);
 }
 
 void test_ngtcp2_settings_convert_to_old(void) {
-  const int destver = NGTCP2_SETTINGS_V3;
+  const int destver = NGTCP2_SETTINGS_V4;
   ngtcp2_settings src, *dest, destbuf = {0};
   size_t destlen;
 
@@ -180,6 +187,9 @@ void test_ngtcp2_settings_convert_to_old(void) {
   src.glitch_ratelim_burst = 1999;
   src.glitch_ratelim_rate = 78;
   src.log_write = log_write;
+  src.max_initial_crypto_offset = 32423;
+  src.max_handshake_crypto_offset = 8899327;
+  src.max_1rtt_crypto_offset = 291111;
 
   ngtcp2_settings_convert_to_old(destver, dest, &src);
 
@@ -214,5 +224,8 @@ void test_ngtcp2_settings_convert_to_old(void) {
   assert_size(src.pmtud_probeslen, ==, destbuf.pmtud_probeslen);
   assert_uint64(1999, ==, destbuf.glitch_ratelim_burst);
   assert_uint64(78, ==, destbuf.glitch_ratelim_rate);
-  assert_null(destbuf.log_write);
+  assert_ptr_equal(src.log_write, destbuf.log_write);
+  assert_size(0, ==, destbuf.max_initial_crypto_offset);
+  assert_size(0, ==, destbuf.max_handshake_crypto_offset);
+  assert_size(0, ==, destbuf.max_1rtt_crypto_offset);
 }


### PR DESCRIPTION
Previously, the maximum offsets in each encryption level are hard-coded.  Now they are configurable via ngtcp2_settings.