### PR TITLE
Deal with the case where client migrate back to the original path

### DIFF
--- a/lib/ngtcp2_conn.c
+++ b/lib/ngtcp2_conn.c
@@ -8828,13 +8828,16 @@ static void conn_rotate_keys(ngtcp2_conn *conn, int64_t pkt_num,
 
 /*
  * conn_path_validation_in_progress returns nonzero if path validation
- * against |path| is underway.
+ * against |path| is underway.  Ignore the path validation with
+ * NGTCP2_PV_FLAG_DONT_CARE flag set, that is performed after the
+ * successful migration.  Client might migrate back to this path.
  */
 static int conn_path_validation_in_progress(const ngtcp2_conn *conn,
                                             const ngtcp2_path *path) {
   const ngtcp2_pv *pv = conn->pv;
 
-  return pv && ngtcp2_path_eq(&pv->dcid.ps.path, path);
+  return pv && ngtcp2_path_eq(&pv->dcid.ps.path, path) &&
+         !(pv->flags & NGTCP2_PV_FLAG_DONT_CARE);
 }
 
 /*

--- a/tests/ngtcp2_conn_test.c
+++ b/tests/ngtcp2_conn_test.c
@@ -10504,6 +10504,7 @@ void test_ngtcp2_conn_server_path_validation(void) {
     .data = {0xFF},
   };
   ngtcp2_path_storage new_path1, new_path2, new_path3;
+  ngtcp2_path_storage dst_path;
   ngtcp2_ksl_it it;
   ngtcp2_path_history_entry *ph_ent;
   ngtcp2_tpe tpe;
@@ -10950,6 +10951,107 @@ void test_ngtcp2_conn_server_path_validation(void) {
   assert_true(ngtcp2_path_eq(&null_path.path, &conn->pv->dcid.ps.path));
   assert_true(ngtcp2_path_eq(&new_path1.path, &conn->dcid.current.ps.path));
   assert_true(ngtcp2_cid_eq(&zerolen_cid, &conn->dcid.current.cid));
+
+  ngtcp2_conn_del(conn);
+
+  /* Client migrates back to the original path while server is doing
+     path validation to the original path after successful path
+     validation to the new path. */
+  setup_default_server(&conn);
+  ngtcp2_tpe_init_conn(&tpe, conn);
+
+  /* This will send NEW_CONNECTION_ID frames */
+  spktlen = ngtcp2_conn_write_pkt(conn, NULL, NULL, buf, sizeof(buf), ++t);
+
+  assert_ptrdiff(0, <, spktlen);
+  assert_size(1, <, ngtcp2_ksl_len(&conn->scid.set));
+
+  frs[0].new_connection_id = (ngtcp2_new_connection_id){
+    .type = NGTCP2_FRAME_NEW_CONNECTION_ID,
+    .seq = 1,
+    .cid = cid,
+    .token = token,
+  };
+  frs[1].new_connection_id = (ngtcp2_new_connection_id){
+    .type = NGTCP2_FRAME_NEW_CONNECTION_ID,
+    .seq = 2,
+    .cid =
+      {
+        .datalen = 4,
+        .data = {0x1F, 0x00, 0x00, 0x00},
+      },
+    .token = token,
+  };
+
+  pktlen = ngtcp2_tpe_write_1rtt(&tpe, buf, sizeof(buf), frs, 2);
+
+  rv = ngtcp2_conn_read_pkt(conn, &null_path.path, NULL, buf, pktlen, ++t);
+
+  assert_int(0, ==, rv);
+
+  /* A remote endpoint changes DCID as well */
+  frs[0].ping.type = NGTCP2_FRAME_PING;
+  frs[1].padding = (ngtcp2_padding){
+    .type = NGTCP2_FRAME_PADDING,
+    .len = 1200,
+  };
+
+  it = ngtcp2_ksl_begin(&conn->scid.set);
+
+  assert(!ngtcp2_ksl_it_end(&it));
+
+  new_cid = &(((ngtcp2_scid *)ngtcp2_ksl_it_get(&it))->cid);
+  tpe.dcid = *new_cid;
+
+  pktlen = ngtcp2_tpe_write_1rtt(&tpe, buf, sizeof(buf), frs, 2);
+
+  rv = ngtcp2_conn_read_pkt(conn, &new_path1.path, NULL, buf, pktlen, ++t);
+
+  assert_int(0, ==, rv);
+  assert_not_null(conn->pv);
+
+  ngtcp2_path_storage_zero(&dst_path);
+  spktlen =
+    ngtcp2_conn_write_pkt(conn, &dst_path.path, NULL, buf, sizeof(buf), ++t);
+
+  assert_ptrdiff(NGTCP2_MAX_UDP_PAYLOAD_SIZE, <=, spktlen);
+  assert_size(0, <, ngtcp2_ringbuf_len(&conn->pv->ents.rb));
+  assert_true(ngtcp2_path_eq(&new_path1.path, &dst_path.path));
+
+  fr.path_response = (ngtcp2_path_response){
+    .type = NGTCP2_FRAME_PATH_RESPONSE,
+  };
+
+  pktlen = ngtcp2_tpe_write_1rtt(&tpe, buf, sizeof(buf), &fr, 1);
+  rv = ngtcp2_conn_read_pkt(conn, &new_path1.path, NULL, buf, pktlen, ++t);
+
+  assert_int(0, ==, rv);
+  assert_true(ngtcp2_path_eq(&new_path1.path, &conn->dcid.current.ps.path));
+  assert_true(ngtcp2_cid_eq(&cid, &conn->dcid.current.cid));
+  /* Path validation against the old path has started. */
+  assert_not_null(conn->pv);
+  assert_true(ngtcp2_path_eq(&null_path.path, &conn->pv->dcid.ps.path));
+  assert_true(conn->pv->flags & NGTCP2_PV_FLAG_DONT_CARE);
+
+  /* A remote endpoint migrates back to the old path.  Path validation
+     is skipped because old path is considered to be validated. */
+  fr.ping.type = NGTCP2_FRAME_PING;
+
+  ngtcp2_ksl_it_next(&it);
+
+  assert(!ngtcp2_ksl_it_end(&it));
+
+  new_cid = &(((ngtcp2_scid *)ngtcp2_ksl_it_get(&it))->cid);
+  tpe.dcid = *new_cid;
+
+  pktlen = ngtcp2_tpe_write_1rtt(&tpe, buf, sizeof(buf), &fr, 1);
+
+  rv = ngtcp2_conn_read_pkt(conn, &null_path.path, NULL, buf, pktlen, ++t);
+
+  assert_int(0, ==, rv);
+  assert_null(conn->pv);
+  assert_true(ngtcp2_path_eq(&null_path.path, &conn->dcid.current.ps.path));
+  assert_true(conn->dcid.current.flags & NGTCP2_DCID_FLAG_PATH_VALIDATED);
 
   ngtcp2_conn_del(conn);
 }


### PR DESCRIPTION
Previously, we have handled the case when client migrates back to the original path while the server is validating the new path, but we missed the case where the client migrates back to the original path after successful validation and server is doing the path validation to the original path with NGTCP2_PV_FLAG_DONT_CARE flag set.  This commit fixes it.

Fixes #2257 