### PR TITLE
qlog: Write CONNECTION_CLOSE reason and trigger

### DIFF
--- a/lib/ngtcp2_qlog.c
+++ b/lib/ngtcp2_qlog.c
@@ -55,6 +55,80 @@ static uint8_t *write_string_impl(uint8_t *p, const uint8_t *data,
 #define write_string(DEST, S)                                                  \
   write_string_impl((DEST), (const uint8_t *)(S), ngtcp2_strlen_lit(S))
 
+static size_t escaped_stringlen(const uint8_t *data, size_t datalen) {
+  size_t len = 0;
+  size_t i;
+  size_t n;
+
+  for (i = 0; i < datalen; ++i) {
+    switch (data[i]) {
+    case '"':
+    case '\\':
+    case '\b':
+    case '\f':
+    case '\n':
+    case '\r':
+    case '\t':
+      n = 2;
+      break;
+    default:
+      n = data[i] < 0x20 ? 6 : 1;
+    }
+
+    if (len > NGTCP2_QLOG_BUFLEN - n) {
+      return NGTCP2_QLOG_BUFLEN;
+    }
+
+    len += n;
+  }
+
+  return len;
+}
+
+static uint8_t *write_escaped_string(uint8_t *p, const uint8_t *data,
+                                     size_t datalen) {
+  size_t i;
+
+  *p++ = '"';
+
+  for (i = 0; i < datalen; ++i) {
+    switch (data[i]) {
+    case '"':
+      p = write_verbatim(p, "\\\"");
+      break;
+    case '\\':
+      p = write_verbatim(p, "\\\\");
+      break;
+    case '\b':
+      p = write_verbatim(p, "\\b");
+      break;
+    case '\f':
+      p = write_verbatim(p, "\\f");
+      break;
+    case '\n':
+      p = write_verbatim(p, "\\n");
+      break;
+    case '\r':
+      p = write_verbatim(p, "\\r");
+      break;
+    case '\t':
+      p = write_verbatim(p, "\\t");
+      break;
+    default:
+      if (data[i] < 0x20) {
+        p = write_verbatim(p, "\\u00");
+        p = ngtcp2_encode_hex(p, &data[i], 1);
+      } else {
+        *p++ = data[i];
+      }
+    }
+  }
+
+  *p++ = '"';
+
+  return p;
+}
+
 static uint8_t *write_hex(uint8_t *p, const uint8_t *data, size_t datalen) {
   *p++ = '"';
   p = ngtcp2_encode_hex(p, data, datalen);
@@ -103,6 +177,18 @@ static uint8_t *write_pair_hex_impl(uint8_t *p, const uint8_t *name,
 #define write_pair_hex(DEST, NAME, VALUE, VALUELEN)                            \
   write_pair_hex_impl((DEST), (const uint8_t *)(NAME),                         \
                       ngtcp2_strlen_lit(NAME), (VALUE), (VALUELEN))
+
+static uint8_t *write_pair_escaped_impl(uint8_t *p, const uint8_t *name,
+                                        size_t namelen, const uint8_t *value,
+                                        size_t valuelen) {
+  p = write_string_impl(p, name, namelen);
+  *p++ = ':';
+  return write_escaped_string(p, value, valuelen);
+}
+
+#define write_pair_escaped(DEST, NAME, VALUE, VALUELEN)                        \
+  write_pair_escaped_impl((DEST), (const uint8_t *)(NAME),                     \
+                          ngtcp2_strlen_lit(NAME), (VALUE), (VALUELEN))
 
 static uint8_t *write_pair_number_impl(uint8_t *p, const uint8_t *name,
                                        size_t namelen, uint64_t value) {
@@ -603,6 +689,8 @@ write_connection_close_frame(uint8_t *p, const ngtcp2_connection_close *fr) {
    * {"frame_type":"connection_close","error_space":"application","error_code":0000000000000000000,"raw_error_code":0000000000000000000}
    */
 #define NGTCP2_QLOG_CONNECTION_CLOSE_FRAME_OVERHEAD 131
+#define NGTCP2_QLOG_CONNECTION_CLOSE_REASON_OVERHEAD 12
+#define NGTCP2_QLOG_CONNECTION_CLOSE_TRIGGER_OVERHEAD 42
 
   p =
     write_verbatim(p, "{\"frame_type\":\"connection_close\",\"error_space\":");
@@ -615,8 +703,14 @@ write_connection_close_frame(uint8_t *p, const ngtcp2_connection_close *fr) {
   p = write_pair_number(p, "error_code", fr->error_code);
   *p++ = ',';
   p = write_pair_number(p, "raw_error_code", fr->error_code);
-  /* TODO Write reason by escaping non-printables */
-  /* TODO Write trigger_frame_type */
+  if (fr->reasonlen) {
+    *p++ = ',';
+    p = write_pair_escaped(p, "reason", fr->reason, fr->reasonlen);
+  }
+  if (fr->type == NGTCP2_FRAME_CONNECTION_CLOSE) {
+    *p++ = ',';
+    p = write_pair_number(p, "trigger_frame_type", fr->frame_type);
+  }
   *p++ = '}';
 
   return p;
@@ -851,11 +945,21 @@ void ngtcp2_qlog_write_frame(ngtcp2_qlog *qlog, const ngtcp2_frame *fr) {
     p = write_path_response_frame(p, &fr->path_response);
     break;
   case NGTCP2_FRAME_CONNECTION_CLOSE:
-  case NGTCP2_FRAME_CONNECTION_CLOSE_APP:
-    if (ngtcp2_buf_left(&qlog->buf) <
-        NGTCP2_QLOG_CONNECTION_CLOSE_FRAME_OVERHEAD + 1) {
+  case NGTCP2_FRAME_CONNECTION_CLOSE_APP: {
+    size_t len = NGTCP2_QLOG_CONNECTION_CLOSE_FRAME_OVERHEAD + 1;
+
+    if (fr->connection_close.reasonlen) {
+      len += NGTCP2_QLOG_CONNECTION_CLOSE_REASON_OVERHEAD +
+             escaped_stringlen(fr->connection_close.reason,
+                               fr->connection_close.reasonlen);
+    }
+    if (fr->hd.type == NGTCP2_FRAME_CONNECTION_CLOSE) {
+      len += NGTCP2_QLOG_CONNECTION_CLOSE_TRIGGER_OVERHEAD;
+    }
+    if (ngtcp2_buf_left(&qlog->buf) < len) {
       return;
     }
+  }
     p = write_connection_close_frame(p, &fr->connection_close);
     break;
   case NGTCP2_FRAME_HANDSHAKE_DONE:

--- a/tests/ngtcp2_qlog_test.c
+++ b/tests/ngtcp2_qlog_test.c
@@ -522,9 +522,14 @@ void test_ngtcp2_qlog_write_frame(void) {
   ngtcp2_buf_reset(&qlog.buf);
 
   {
+    static uint8_t reason[] = "bad \"reason\"\\line\n";
+
     fr.connection_close = (ngtcp2_connection_close){
       .type = NGTCP2_FRAME_CONNECTION_CLOSE,
       .error_code = 3270540419184339176,
+      .frame_type = NGTCP2_FRAME_CRYPTO,
+      .reason = reason,
+      .reasonlen = sizeof(reason) - 1,
     };
 
     ngtcp2_qlog_write_frame(&qlog, &fr);
@@ -533,7 +538,9 @@ void test_ngtcp2_qlog_write_frame(void) {
     assert_string_equal(
       "{\"frame_type\":\"connection_close\",\"error_space\":"
       "\"transport\",\"error_code\":3270540419184339176,\"raw_"
-      "error_code\":3270540419184339176},",
+      "error_code\":3270540419184339176,"
+      "\"reason\":\"bad \\\"reason\\\"\\\\line\\n\","
+      "\"trigger_frame_type\":6},",
       (const char *)qlog.buf.begin);
   }
 
@@ -552,6 +559,47 @@ void test_ngtcp2_qlog_write_frame(void) {
                         "\"application\",\"error_code\":1069447711149177103,"
                         "\"raw_error_code\":1069447711149177103},",
                         (const char *)qlog.buf.begin);
+  }
+
+  ngtcp2_buf_reset(&qlog.buf);
+
+  {
+    static uint8_t reason[] = {'\b', '\f', '\r', '\t', 0x01};
+
+    fr.connection_close = (ngtcp2_connection_close){
+      .type = NGTCP2_FRAME_CONNECTION_CLOSE_APP,
+      .error_code = 1069447711149177103,
+      .reason = reason,
+      .reasonlen = sizeof(reason),
+    };
+
+    ngtcp2_qlog_write_frame(&qlog, &fr);
+    *qlog.buf.last = '\0';
+
+    assert_string_equal("{\"frame_type\":\"connection_close\",\"error_space\":"
+                        "\"application\",\"error_code\":1069447711149177103,"
+                        "\"raw_error_code\":1069447711149177103,"
+                        "\"reason\":\"\\b\\f\\r\\t\\u0001\"},",
+                        (const char *)qlog.buf.begin);
+  }
+
+  ngtcp2_buf_reset(&qlog.buf);
+
+  {
+    static uint8_t reason[NGTCP2_QLOG_BUFLEN];
+
+    memset(reason, 0x01, sizeof(reason));
+
+    fr.connection_close = (ngtcp2_connection_close){
+      .type = NGTCP2_FRAME_CONNECTION_CLOSE_APP,
+      .error_code = 1,
+      .reason = reason,
+      .reasonlen = sizeof(reason),
+    };
+
+    ngtcp2_qlog_write_frame(&qlog, &fr);
+
+    assert_ptr_equal(qlog.buf.begin, qlog.buf.last);
   }
 
   ngtcp2_buf_reset(&qlog.buf);


### PR DESCRIPTION
Complete the existing CONNECTION_CLOSE qlog handling by writing the reason phrase and transport trigger frame type.

Reason phrases are escaped as JSON strings, and their encoded size is checked before writing to the fixed qlog buffer. Application CONNECTION_CLOSE frames omit the transport-only trigger field. Tests cover regular and escaped reasons, application closure, and insufficient buffer space.

Verified with CMake/GCC, CMake/Clang ASan+UBSan, and Autotools/GCC with warnings treated as errors.