### PR TITLE
Add callback for extendmaxdata

### DIFF
--- a/lib/includes/ngtcp2/ngtcp2.h
+++ b/lib/includes/ngtcp2/ngtcp2.h
@@ -3721,12 +3721,28 @@ typedef int (*ngtcp2_stream_close2)(ngtcp2_conn *conn, uint32_t flags,
                                     uint64_t tx_app_error_code, void *user_data,
                                     void *stream_user_data);
 
+/**
+ * @functypedef
+ *
+ * :type:`ngtcp2_extend_max_data` is a callback function which
+ * is invoked when max session data is extended.
+ * |max_data| is a cumulative number of bytes
+ * an endpoint can send on this session.
+ *
+ * The callback function must return 0 if it succeeds.  Returning
+ * :macro:`NGTCP2_ERR_CALLBACK_FAILURE` makes the library call return
+ * immediately.
+ */
+typedef int (*ngtcp2_extend_max_data)(ngtcp2_conn *conn,
+                                      uint64_t max_data, void *user_data);
+
 #define NGTCP2_CALLBACKS_V1 1
 #define NGTCP2_CALLBACKS_V2 2
 #define NGTCP2_CALLBACKS_V3 3
 #define NGTCP2_CALLBACKS_V4 4
 #define NGTCP2_CALLBACKS_V5 5
-#define NGTCP2_CALLBACKS_VERSION NGTCP2_CALLBACKS_V5
+#define NGTCP2_CALLBACKS_V6 6
+#define NGTCP2_CALLBACKS_VERSION NGTCP2_CALLBACKS_V6
 
 /**
  * @struct
@@ -4088,6 +4104,17 @@ typedef struct ngtcp2_callbacks {
    * .. version-added:: 1.25.0
    */
   ngtcp2_stream_close2 stream_close2;
+  /* The following fields have been added since
+     NGTCP2_CALLBACKS_V6. */
+  /**
+   * :member:`extend_max_data` is callback function which is
+   * invoked when the maximum offset of session data that a local
+   * endpoint can send is increased.  This callback function is
+   * optional.
+   * 
+   * .. version-added:: v1.26.0
+   */
+  ngtcp2_extend_max_data extend_max_data;
 } ngtcp2_callbacks;
 
 /**

--- a/lib/ngtcp2_conn.c
+++ b/lib/ngtcp2_conn.c
@@ -485,6 +485,23 @@ static int conn_call_extend_max_stream_data(ngtcp2_conn *conn,
   return 0;
 }
 
+static int conn_call_extend_max_data(ngtcp2_conn *conn,
+                                     uint64_t datalen) {
+  int rv;
+
+  if (!conn->callbacks.extend_max_data) {
+    return 0;
+  }
+
+  rv = conn->callbacks.extend_max_data(
+    conn, datalen, conn->user_data);
+  if (rv != 0) {
+    return NGTCP2_ERR_CALLBACK_FAILURE;
+  }
+
+  return 0;
+}
+
 static int conn_call_dcid_status(ngtcp2_conn *conn,
                                  ngtcp2_connection_id_status_type type,
                                  const ngtcp2_dcid *dcid) {
@@ -5786,8 +5803,18 @@ static int conn_recv_max_stream_data(ngtcp2_conn *conn,
 /*
  * conn_recv_max_data processes received MAX_DATA frame |fr|.
  */
-static void conn_recv_max_data(ngtcp2_conn *conn, const ngtcp2_max_data *fr) {
-  conn->tx.max_offset = ngtcp2_max(conn->tx.max_offset, fr->max_data);
+static int conn_recv_max_data(ngtcp2_conn *conn, const ngtcp2_max_data *fr) {
+  int rv;
+
+  if (fr->max_data > conn->tx.max_offset) {
+    conn->tx.max_offset = fr->max_data;
+    rv = conn_call_extend_max_data(conn, fr->max_data);
+    if (rv != 0) {
+      return rv;
+    }
+  }
+
+  return 0;
 }
 
 /*
@@ -10276,6 +10303,14 @@ static ngtcp2_ssize conn_read_handshake(ngtcp2_conn *conn,
     if (rv != 0) {
       return rv;
     }
+    
+    if (conn->tx.max_offset > 0) {
+      rv = conn_call_extend_max_data(conn, conn->tx.max_offset);
+      if (rv != 0) {
+        return rv;
+      }
+    }
+
     conn->state = NGTCP2_CS_POST_HANDSHAKE;
 
     rv = conn_call_activate_dcid(conn, &conn->dcid.current);
@@ -10683,6 +10718,13 @@ static ngtcp2_ssize conn_write_handshake(ngtcp2_conn *conn, ngtcp2_pkt_info *pi,
     rv = conn_sync_stream_data_limit(conn);
     if (rv != 0) {
       return rv;
+    }
+
+    if (conn->tx.max_offset > 0) {
+      rv = conn_call_extend_max_data(conn, conn->tx.max_offset);
+      if (rv != 0) {
+        return rv;
+      }
     }
 
     conn->state = NGTCP2_CS_POST_HANDSHAKE;


### PR DESCRIPTION
Some users of the library (node.js),
require a callback, that signals, when new
maxdata values are available, as the maxdata
value is cached and evaluated outside ngtcp2.

Fixes #2243