### PR TITLE
Rename offset in ngtcp2_data_blocked and ngtcp2_stream_data_blocked

### DIFF
--- a/lib/ngtcp2_conn.c
+++ b/lib/ngtcp2_conn.c
@@ -3862,7 +3862,7 @@ static ngtcp2_ssize conn_write_pkt(ngtcp2_conn *conn, ngtcp2_pkt_info *pi,
         }
         break;
       case NGTCP2_FRAME_DATA_BLOCKED:
-        if ((*pfrc)->fr.data_blocked.offset != conn->tx.max_offset) {
+        if ((*pfrc)->fr.data_blocked.max_data != conn->tx.max_offset) {
           frc = *pfrc;
           *pfrc = (*pfrc)->next;
           ngtcp2_frame_chain_objalloc_del(frc, &conn->frc_objalloc, conn->mem);
@@ -4019,7 +4019,7 @@ static ngtcp2_ssize conn_write_pkt(ngtcp2_conn *conn, ngtcp2_pkt_info *pi,
 
               nfrc->fr.data_blocked = (ngtcp2_data_blocked){
                 .type = NGTCP2_FRAME_DATA_BLOCKED,
-                .offset = conn->tx.max_offset,
+                .max_data = conn->tx.max_offset,
               };
               *pfrc = nfrc;
 
@@ -4049,7 +4049,7 @@ static ngtcp2_ssize conn_write_pkt(ngtcp2_conn *conn, ngtcp2_pkt_info *pi,
               nfrc->fr.stream_data_blocked = (ngtcp2_stream_data_blocked){
                 .type = NGTCP2_FRAME_STREAM_DATA_BLOCKED,
                 .stream_id = strm->stream_id,
-                .offset = strm->tx.max_offset,
+                .max_stream_data = strm->tx.max_offset,
               };
               *pfrc = nfrc;
 
@@ -4370,7 +4370,7 @@ static ngtcp2_ssize conn_write_pkt(ngtcp2_conn *conn, ngtcp2_pkt_info *pi,
 
       nfrc->fr.data_blocked = (ngtcp2_data_blocked){
         .type = NGTCP2_FRAME_DATA_BLOCKED,
-        .offset = conn->tx.offset,
+        .max_data = conn->tx.offset,
       };
 
       rv = conn_ppe_write_frame_hd_log(conn, ppe, &hd_logged, hd, &nfrc->fr);
@@ -4410,7 +4410,7 @@ static ngtcp2_ssize conn_write_pkt(ngtcp2_conn *conn, ngtcp2_pkt_info *pi,
       nfrc->fr.stream_data_blocked = (ngtcp2_stream_data_blocked){
         .type = NGTCP2_FRAME_STREAM_DATA_BLOCKED,
         .stream_id = strm->stream_id,
-        .offset = strm->tx.max_offset,
+        .max_stream_data = strm->tx.max_offset,
       };
 
       rv = conn_ppe_write_frame_hd_log(conn, ppe, &hd_logged, hd, &nfrc->fr);
@@ -8569,11 +8569,11 @@ static int conn_recv_stream_data_blocked(ngtcp2_conn *conn,
     }
   }
 
-  if (strm->rx.max_offset < fr->offset) {
+  if (strm->rx.max_offset < fr->max_stream_data) {
     return NGTCP2_ERR_FLOW_CONTROL;
   }
 
-  if (fr->offset <= strm->rx.last_offset) {
+  if (fr->max_stream_data <= strm->rx.last_offset) {
     return 0;
   }
 
@@ -8581,7 +8581,7 @@ static int conn_recv_stream_data_blocked(ngtcp2_conn *conn,
     return NGTCP2_ERR_FINAL_SIZE;
   }
 
-  datalen = fr->offset - strm->rx.last_offset;
+  datalen = fr->max_stream_data - strm->rx.last_offset;
   if (datalen) {
     if (conn_max_data_violated(conn, datalen)) {
       return NGTCP2_ERR_FLOW_CONTROL;
@@ -8590,7 +8590,7 @@ static int conn_recv_stream_data_blocked(ngtcp2_conn *conn,
     conn->rx.offset += datalen;
   }
 
-  strm->rx.last_offset = fr->offset;
+  strm->rx.last_offset = fr->max_stream_data;
 
   return 0;
 }
@@ -8606,7 +8606,7 @@ static int conn_recv_stream_data_blocked(ngtcp2_conn *conn,
  *     It violates connection-level flow control limit.
  */
 static int conn_recv_data_blocked(ngtcp2_conn *conn, ngtcp2_data_blocked *fr) {
-  if (conn->rx.max_offset < fr->offset) {
+  if (conn->rx.max_offset < fr->max_data) {
     return NGTCP2_ERR_FLOW_CONTROL;
   }
 

--- a/lib/ngtcp2_log.c
+++ b/lib/ngtcp2_log.c
@@ -284,7 +284,7 @@ static void log_fr_data_blocked(ngtcp2_log *log, const ngtcp2_pkt_hd *hd,
                                 const char *dir) {
   ngtcp2_log_infof_raw(log, NGTCP2_LOG_EVENT_FRM, NGTCP2_LOG_PKT(dir, hd),
                        " DATA_BLOCKED(0x", hex(fr->type),
-                       ") offset=", fr->offset);
+                       ") max_data=", fr->max_data);
 }
 
 static void log_fr_stream_data_blocked(ngtcp2_log *log, const ngtcp2_pkt_hd *hd,
@@ -292,7 +292,8 @@ static void log_fr_stream_data_blocked(ngtcp2_log *log, const ngtcp2_pkt_hd *hd,
                                        const char *dir) {
   ngtcp2_log_infof_raw(log, NGTCP2_LOG_EVENT_FRM, NGTCP2_LOG_PKT(dir, hd),
                        " STREAM_DATA_BLOCKED(0x", hex(fr->type), ") id=0x",
-                       hex(fr->stream_id), " offset=", fr->offset);
+                       hex(fr->stream_id),
+                       " max_stream_data=", fr->max_stream_data);
 }
 
 static void log_fr_streams_blocked(ngtcp2_log *log, const ngtcp2_pkt_hd *hd,

--- a/lib/ngtcp2_pkt.c
+++ b/lib/ngtcp2_pkt.c
@@ -1087,7 +1087,7 @@ ngtcp2_ssize ngtcp2_pkt_decode_data_blocked_frame(ngtcp2_data_blocked *dest,
   }
 
   dest->type = NGTCP2_FRAME_DATA_BLOCKED;
-  p = ngtcp2_get_uvarint(&dest->offset, p);
+  p = ngtcp2_get_uvarint(&dest->max_data, p);
 
   assert((size_t)(p - payload) == len);
 
@@ -1126,7 +1126,7 @@ ngtcp2_ssize ngtcp2_pkt_decode_stream_data_blocked_frame(
 
   dest->type = NGTCP2_FRAME_STREAM_DATA_BLOCKED;
   p = ngtcp2_get_varint(&dest->stream_id, p);
-  p = ngtcp2_get_uvarint(&dest->offset, p);
+  p = ngtcp2_get_uvarint(&dest->max_stream_data, p);
 
   assert((size_t)(p - payload) == len);
 
@@ -1820,7 +1820,7 @@ ngtcp2_ssize ngtcp2_pkt_encode_ping_frame(uint8_t *out, size_t outlen,
 ngtcp2_ssize
 ngtcp2_pkt_encode_data_blocked_frame(uint8_t *out, size_t outlen,
                                      const ngtcp2_data_blocked *fr) {
-  size_t len = 1 + ngtcp2_put_uvarintlen(fr->offset);
+  size_t len = 1 + ngtcp2_put_uvarintlen(fr->max_data);
   uint8_t *p;
 
   if (outlen < len) {
@@ -1830,7 +1830,7 @@ ngtcp2_pkt_encode_data_blocked_frame(uint8_t *out, size_t outlen,
   p = out;
 
   *p++ = NGTCP2_FRAME_DATA_BLOCKED;
-  p = ngtcp2_put_uvarint(p, fr->offset);
+  p = ngtcp2_put_uvarint(p, fr->max_data);
 
   assert((size_t)(p - out) == len);
 
@@ -1840,7 +1840,7 @@ ngtcp2_pkt_encode_data_blocked_frame(uint8_t *out, size_t outlen,
 ngtcp2_ssize ngtcp2_pkt_encode_stream_data_blocked_frame(
   uint8_t *out, size_t outlen, const ngtcp2_stream_data_blocked *fr) {
   size_t len = 1 + ngtcp2_put_uvarintlen((uint64_t)fr->stream_id) +
-               ngtcp2_put_uvarintlen(fr->offset);
+               ngtcp2_put_uvarintlen(fr->max_stream_data);
   uint8_t *p;
 
   if (outlen < len) {
@@ -1851,7 +1851,7 @@ ngtcp2_ssize ngtcp2_pkt_encode_stream_data_blocked_frame(
 
   *p++ = NGTCP2_FRAME_STREAM_DATA_BLOCKED;
   p = ngtcp2_put_uvarint(p, (uint64_t)fr->stream_id);
-  p = ngtcp2_put_uvarint(p, fr->offset);
+  p = ngtcp2_put_uvarint(p, fr->max_stream_data);
 
   assert((size_t)(p - out) == len);
 

--- a/lib/ngtcp2_pkt.h
+++ b/lib/ngtcp2_pkt.h
@@ -281,13 +281,13 @@ typedef struct ngtcp2_ping {
 
 typedef struct ngtcp2_data_blocked {
   uint64_t type;
-  uint64_t offset;
+  uint64_t max_data;
 } ngtcp2_data_blocked;
 
 typedef struct ngtcp2_stream_data_blocked {
   uint64_t type;
   int64_t stream_id;
-  uint64_t offset;
+  uint64_t max_stream_data;
 } ngtcp2_stream_data_blocked;
 
 typedef struct ngtcp2_streams_blocked {

--- a/lib/ngtcp2_qlog.c
+++ b/lib/ngtcp2_qlog.c
@@ -488,7 +488,7 @@ static uint8_t *write_data_blocked_frame(uint8_t *p,
 #define NGTCP2_QLOG_DATA_BLOCKED_FRAME_OVERHEAD 57
 
   p = write_verbatim(p, "{\"frame_type\":\"data_blocked\",");
-  p = write_pair_number(p, "limit", fr->offset);
+  p = write_pair_number(p, "limit", fr->max_data);
   *p++ = '}';
 
   return p;
@@ -505,7 +505,7 @@ write_stream_data_blocked_frame(uint8_t *p,
   p = write_verbatim(p, "{\"frame_type\":\"stream_data_blocked\",");
   p = write_pair_number(p, "stream_id", (uint64_t)fr->stream_id);
   *p++ = ',';
-  p = write_pair_number(p, "limit", fr->offset);
+  p = write_pair_number(p, "limit", fr->max_stream_data);
   *p++ = '}';
 
   return p;

--- a/lib/ngtcp2_strm.c
+++ b/lib/ngtcp2_strm.c
@@ -734,7 +734,7 @@ int ngtcp2_strm_require_retransmit_max_stream_data(
 
 int ngtcp2_strm_require_retransmit_stream_data_blocked(
   const ngtcp2_strm *strm, const ngtcp2_stream_data_blocked *fr) {
-  return fr->offset == strm->tx.max_offset &&
+  return fr->max_stream_data == strm->tx.max_offset &&
          !(strm->flags & NGTCP2_STRM_FLAG_SHUT_WR);
 }
 

--- a/tests/ngtcp2_conn_test.c
+++ b/tests/ngtcp2_conn_test.c
@@ -3223,7 +3223,7 @@ void test_ngtcp2_conn_recv_stream_data_blocked(void) {
   fr.stream_data_blocked = (ngtcp2_stream_data_blocked){
     .type = NGTCP2_FRAME_STREAM_DATA_BLOCKED,
     .stream_id = stream_id,
-    .offset = 65535,
+    .max_stream_data = 65535,
   };
 
   pktlen = ngtcp2_tpe_write_1rtt(&tpe, buf, sizeof(buf), &fr, 1);
@@ -3245,7 +3245,7 @@ void test_ngtcp2_conn_recv_stream_data_blocked(void) {
 
   fr.stream_data_blocked = (ngtcp2_stream_data_blocked){
     .type = NGTCP2_FRAME_STREAM_DATA_BLOCKED,
-    .offset = 65535,
+    .max_stream_data = 65535,
   };
 
   pktlen = ngtcp2_tpe_write_1rtt(&tpe, buf, sizeof(buf), &fr, 1);
@@ -3262,7 +3262,7 @@ void test_ngtcp2_conn_recv_stream_data_blocked(void) {
 
   fr.stream_data_blocked = (ngtcp2_stream_data_blocked){
     .type = NGTCP2_FRAME_STREAM_DATA_BLOCKED,
-    .offset = 65535,
+    .max_stream_data = 65535,
   };
 
   pktlen = ngtcp2_tpe_write_1rtt(&tpe, buf, sizeof(buf), &fr, 1);
@@ -3285,7 +3285,7 @@ void test_ngtcp2_conn_recv_stream_data_blocked(void) {
   fr.stream_data_blocked = (ngtcp2_stream_data_blocked){
     .type = NGTCP2_FRAME_STREAM_DATA_BLOCKED,
     .stream_id = 1,
-    .offset = 65535,
+    .max_stream_data = 65535,
   };
 
   pktlen = ngtcp2_tpe_write_1rtt(&tpe, buf, sizeof(buf), &fr, 1);
@@ -3304,7 +3304,7 @@ void test_ngtcp2_conn_recv_stream_data_blocked(void) {
   fr.stream_data_blocked = (ngtcp2_stream_data_blocked){
     .type = NGTCP2_FRAME_STREAM_DATA_BLOCKED,
     .stream_id = stream_id,
-    .offset = 65536,
+    .max_stream_data = 65536,
   };
 
   pktlen = ngtcp2_tpe_write_1rtt(&tpe, buf, sizeof(buf), &fr, 1);
@@ -3331,7 +3331,7 @@ void test_ngtcp2_conn_recv_stream_data_blocked(void) {
   fr.stream_data_blocked = (ngtcp2_stream_data_blocked){
     .type = NGTCP2_FRAME_STREAM_DATA_BLOCKED,
     .stream_id = stream_id,
-    .offset = 128 * 1024 + 1,
+    .max_stream_data = 128 * 1024 + 1,
   };
 
   pktlen = ngtcp2_tpe_write_1rtt(&tpe, buf, sizeof(buf), &fr, 1);
@@ -3368,7 +3368,7 @@ void test_ngtcp2_conn_recv_stream_data_blocked(void) {
   fr.stream_data_blocked = (ngtcp2_stream_data_blocked){
     .type = NGTCP2_FRAME_STREAM_DATA_BLOCKED,
     .stream_id = stream_id,
-    .offset = 11999,
+    .max_stream_data = 11999,
   };
 
   pktlen = ngtcp2_tpe_write_1rtt(&tpe, buf, sizeof(buf), &fr, 1);
@@ -3409,7 +3409,7 @@ void test_ngtcp2_conn_recv_stream_data_blocked(void) {
   fr.stream_data_blocked = (ngtcp2_stream_data_blocked){
     .type = NGTCP2_FRAME_STREAM_DATA_BLOCKED,
     .stream_id = stream_id,
-    .offset = 12000,
+    .max_stream_data = 12000,
   };
 
   pktlen = ngtcp2_tpe_write_1rtt(&tpe, buf, sizeof(buf), &fr, 1);
@@ -3437,7 +3437,7 @@ void test_ngtcp2_conn_recv_stream_data_blocked(void) {
   fr.stream_data_blocked = (ngtcp2_stream_data_blocked){
     .type = NGTCP2_FRAME_STREAM_DATA_BLOCKED,
     .stream_id = stream_id,
-    .offset = 7777,
+    .max_stream_data = 7777,
   };
 
   pktlen = ngtcp2_tpe_write_1rtt(&tpe, buf, sizeof(buf), &fr, 1);
@@ -3482,7 +3482,7 @@ void test_ngtcp2_conn_recv_stream_data_blocked(void) {
   fr.stream_data_blocked = (ngtcp2_stream_data_blocked){
     .type = NGTCP2_FRAME_STREAM_DATA_BLOCKED,
     .stream_id = stream_id,
-    .offset = 999,
+    .max_stream_data = 999,
   };
 
   pktlen = ngtcp2_tpe_write_1rtt(&tpe, buf, sizeof(buf), &fr, 1);
@@ -3500,7 +3500,7 @@ void test_ngtcp2_conn_recv_stream_data_blocked(void) {
   fr.stream_data_blocked = (ngtcp2_stream_data_blocked){
     .type = NGTCP2_FRAME_STREAM_DATA_BLOCKED,
     .stream_id = stream_id,
-    .offset = 998,
+    .max_stream_data = 998,
   };
 
   pktlen = ngtcp2_tpe_write_1rtt(&tpe, buf, sizeof(buf), &fr, 1);
@@ -3523,7 +3523,7 @@ void test_ngtcp2_conn_recv_stream_data_blocked(void) {
   fr.stream_data_blocked = (ngtcp2_stream_data_blocked){
     .type = NGTCP2_FRAME_STREAM_DATA_BLOCKED,
     .stream_id = stream_id,
-    .offset = 1,
+    .max_stream_data = 1,
   };
 
   pktlen = ngtcp2_tpe_write_1rtt(&tpe, buf, sizeof(buf), &fr, 1);
@@ -3541,7 +3541,7 @@ void test_ngtcp2_conn_recv_stream_data_blocked(void) {
   fr.stream_data_blocked = (ngtcp2_stream_data_blocked){
     .type = NGTCP2_FRAME_STREAM_DATA_BLOCKED,
     .stream_id = 3,
-    .offset = 719,
+    .max_stream_data = 719,
   };
 
   pktlen = ngtcp2_tpe_write_1rtt(&tpe, buf, sizeof(buf), &fr, 1);
@@ -3567,7 +3567,7 @@ void test_ngtcp2_conn_recv_stream_data_blocked(void) {
   fr.stream_data_blocked = (ngtcp2_stream_data_blocked){
     .type = NGTCP2_FRAME_STREAM_DATA_BLOCKED,
     .stream_id = 11,
-    .offset = 719,
+    .max_stream_data = 719,
   };
 
   pktlen = ngtcp2_tpe_write_1rtt(&tpe, buf, sizeof(buf), &fr, 1);
@@ -3830,7 +3830,7 @@ void test_ngtcp2_conn_recv_data_blocked(void) {
 
   fr.data_blocked = (ngtcp2_data_blocked){
     .type = NGTCP2_FRAME_DATA_BLOCKED,
-    .offset = 128 * 1024,
+    .max_data = 128 * 1024,
   };
 
   pktlen = ngtcp2_tpe_write_1rtt(&tpe, buf, sizeof(buf), &fr, 1);
@@ -3846,7 +3846,7 @@ void test_ngtcp2_conn_recv_data_blocked(void) {
 
   fr.data_blocked = (ngtcp2_data_blocked){
     .type = NGTCP2_FRAME_DATA_BLOCKED,
-    .offset = 128 * 1024 + 1,
+    .max_data = 128 * 1024 + 1,
   };
 
   pktlen = ngtcp2_tpe_write_1rtt(&tpe, buf, sizeof(buf), &fr, 1);
@@ -17543,7 +17543,8 @@ void test_ngtcp2_conn_send_stream_data_blocked(void) {
 
   assert_uint64(NGTCP2_FRAME_STREAM_DATA_BLOCKED, ==, frc->fr.hd.type);
   assert_int64(stream_id, ==, frc->fr.stream_data_blocked.stream_id);
-  assert_uint64(strm->tx.max_offset, ==, frc->fr.stream_data_blocked.offset);
+  assert_uint64(strm->tx.max_offset, ==,
+                frc->fr.stream_data_blocked.max_stream_data);
   assert_uint64(strm->tx.max_offset, ==, strm->tx.last_blocked_offset);
   assert_null(frc->next);
 
@@ -17599,7 +17600,8 @@ void test_ngtcp2_conn_send_stream_data_blocked(void) {
 
   assert_uint64(NGTCP2_FRAME_STREAM_DATA_BLOCKED, ==, frc->fr.hd.type);
   assert_int64(stream_id, ==, frc->fr.stream_data_blocked.stream_id);
-  assert_uint64(strm->tx.max_offset, ==, frc->fr.stream_data_blocked.offset);
+  assert_uint64(strm->tx.max_offset, ==,
+                frc->fr.stream_data_blocked.max_stream_data);
   assert_uint64(strm->tx.max_offset, ==, strm->tx.last_blocked_offset);
   assert_null(frc->next);
 
@@ -17647,7 +17649,8 @@ void test_ngtcp2_conn_send_stream_data_blocked(void) {
 
   assert_uint64(NGTCP2_FRAME_STREAM_DATA_BLOCKED, ==, frc->fr.hd.type);
   assert_int64(stream_id, ==, frc->fr.stream_data_blocked.stream_id);
-  assert_uint64(strm->tx.max_offset, ==, frc->fr.stream_data_blocked.offset);
+  assert_uint64(strm->tx.max_offset, ==,
+                frc->fr.stream_data_blocked.max_stream_data);
   assert_uint64(strm->tx.max_offset, ==, strm->tx.last_blocked_offset);
   assert_null(frc->next);
 
@@ -17714,7 +17717,8 @@ void test_ngtcp2_conn_send_stream_data_blocked(void) {
 
   assert_uint64(NGTCP2_FRAME_STREAM_DATA_BLOCKED, ==, frc->fr.hd.type);
   assert_int64(stream_id, ==, frc->fr.stream_data_blocked.stream_id);
-  assert_uint64(strm->tx.max_offset, ==, frc->fr.stream_data_blocked.offset);
+  assert_uint64(strm->tx.max_offset, ==,
+                frc->fr.stream_data_blocked.max_stream_data);
   assert_uint64(strm->tx.max_offset, ==, strm->tx.last_blocked_offset);
   assert_null(frc->next);
 
@@ -17775,7 +17779,8 @@ void test_ngtcp2_conn_send_stream_data_blocked(void) {
 
   assert_uint64(NGTCP2_FRAME_STREAM_DATA_BLOCKED, ==, frc->fr.hd.type);
   assert_int64(stream_id, ==, frc->fr.stream_data_blocked.stream_id);
-  assert_uint64(strm->tx.max_offset, ==, frc->fr.stream_data_blocked.offset);
+  assert_uint64(strm->tx.max_offset, ==,
+                frc->fr.stream_data_blocked.max_stream_data);
   assert_uint64(strm->tx.max_offset, ==, strm->tx.last_blocked_offset);
   assert_null(frc->next);
 
@@ -17864,7 +17869,7 @@ void test_ngtcp2_conn_send_data_blocked(void) {
   frc = ent->frc;
 
   assert_uint64(NGTCP2_FRAME_DATA_BLOCKED, ==, frc->fr.hd.type);
-  assert_uint64(conn->tx.max_offset, ==, frc->fr.data_blocked.offset);
+  assert_uint64(conn->tx.max_offset, ==, frc->fr.data_blocked.max_data);
   assert_uint64(conn->tx.max_offset, ==, conn->tx.last_blocked_offset);
   assert_null(frc->next);
 
@@ -17907,7 +17912,7 @@ void test_ngtcp2_conn_send_data_blocked(void) {
   frc = frc->next;
 
   assert_uint64(NGTCP2_FRAME_DATA_BLOCKED, ==, frc->fr.hd.type);
-  assert_uint64(conn->tx.max_offset, ==, frc->fr.data_blocked.offset);
+  assert_uint64(conn->tx.max_offset, ==, frc->fr.data_blocked.max_data);
   assert_uint64(conn->tx.max_offset, ==, conn->tx.last_blocked_offset);
   assert_null(frc->next);
 
@@ -17948,7 +17953,7 @@ void test_ngtcp2_conn_send_data_blocked(void) {
   frc = ent->frc;
 
   assert_uint64(NGTCP2_FRAME_DATA_BLOCKED, ==, frc->fr.hd.type);
-  assert_uint64(conn->tx.max_offset, ==, frc->fr.data_blocked.offset);
+  assert_uint64(conn->tx.max_offset, ==, frc->fr.data_blocked.max_data);
   assert_uint64(conn->tx.max_offset, ==, conn->tx.last_blocked_offset);
   assert_null(frc->next);
 

--- a/tests/ngtcp2_log_test.c
+++ b/tests/ngtcp2_log_test.c
@@ -747,7 +747,7 @@ void test_ngtcp2_log_fr(void) {
     .expected =
       {
         "I00001123 0xdeadbeef frm rx 778 1RTT DATA_BLOCKED(0x14) "
-        "offset=1000000007",
+        "max_data=1000000007",
       },
   };
 
@@ -758,7 +758,7 @@ void test_ngtcp2_log_fr(void) {
                      .data_blocked =
                        {
                          .type = NGTCP2_FRAME_DATA_BLOCKED,
-                         .offset = 1000000007,
+                         .max_data = 1000000007,
                        },
                    });
 
@@ -769,7 +769,7 @@ void test_ngtcp2_log_fr(void) {
     .expected =
       {
         "I00001123 0xdeadbeef frm rx 778 1RTT STREAM_DATA_BLOCKED(0x15) "
-        "id=0x3b9aca09 offset=1000000007",
+        "id=0x3b9aca09 max_stream_data=1000000007",
       },
   };
 
@@ -781,7 +781,7 @@ void test_ngtcp2_log_fr(void) {
                        {
                          .type = NGTCP2_FRAME_STREAM_DATA_BLOCKED,
                          .stream_id = 1000000009,
-                         .offset = 1000000007,
+                         .max_stream_data = 1000000007,
                        },
                    });
 

--- a/tests/ngtcp2_pkt_test.c
+++ b/tests/ngtcp2_pkt_test.c
@@ -1367,7 +1367,7 @@ void test_ngtcp2_pkt_encode_data_blocked_frame(void) {
 
   fr = (ngtcp2_data_blocked){
     .type = NGTCP2_FRAME_DATA_BLOCKED,
-    .offset = 0x31F2F3F4F5F6F7F8ULL,
+    .max_data = 0x31F2F3F4F5F6F7F8ULL,
   };
 
   rv = ngtcp2_pkt_encode_data_blocked_frame(buf, sizeof(buf), &fr);
@@ -1378,7 +1378,7 @@ void test_ngtcp2_pkt_encode_data_blocked_frame(void) {
 
   assert_ptrdiff((ngtcp2_ssize)framelen, ==, rv);
   assert_uint64(fr.type, ==, nfr.type);
-  assert_uint64(fr.offset, ==, nfr.offset);
+  assert_uint64(fr.max_data, ==, nfr.max_data);
 
   /* Fail if a frame is truncated. */
   for (i = 1; i < framelen; ++i) {
@@ -1398,7 +1398,7 @@ void test_ngtcp2_pkt_encode_stream_data_blocked_frame(void) {
   fr = (ngtcp2_stream_data_blocked){
     .type = NGTCP2_FRAME_STREAM_DATA_BLOCKED,
     .stream_id = 0xF1F2F3F4U,
-    .offset = 0x35F6F7F8F9FAFBFCULL,
+    .max_stream_data = 0x35F6F7F8F9FAFBFCULL,
   };
 
   rv = ngtcp2_pkt_encode_stream_data_blocked_frame(buf, sizeof(buf), &fr);
@@ -1410,7 +1410,7 @@ void test_ngtcp2_pkt_encode_stream_data_blocked_frame(void) {
   assert_ptrdiff((ngtcp2_ssize)framelen, ==, rv);
   assert_uint64(fr.type, ==, nfr.type);
   assert_int64(fr.stream_id, ==, nfr.stream_id);
-  assert_uint64(fr.offset, ==, nfr.offset);
+  assert_uint64(fr.max_stream_data, ==, nfr.max_stream_data);
 
   /* Fail if a frame is truncated. */
   for (i = 1; i < framelen; ++i) {

--- a/tests/ngtcp2_qlog_test.c
+++ b/tests/ngtcp2_qlog_test.c
@@ -374,7 +374,7 @@ void test_ngtcp2_qlog_write_frame(void) {
   {
     fr.data_blocked = (ngtcp2_data_blocked){
       .type = NGTCP2_FRAME_DATA_BLOCKED,
-      .offset = 141245489541204826,
+      .max_data = 141245489541204826,
     };
 
     ngtcp2_qlog_write_frame(&qlog, &fr);
@@ -391,7 +391,7 @@ void test_ngtcp2_qlog_write_frame(void) {
     fr.stream_data_blocked = (ngtcp2_stream_data_blocked){
       .type = NGTCP2_FRAME_STREAM_DATA_BLOCKED,
       .stream_id = 1000000007,
-      .offset = 3510083742766371473,
+      .max_stream_data = 3510083742766371473,
     };
 
     ngtcp2_qlog_write_frame(&qlog, &fr);


### PR DESCRIPTION
Rename offset in ngtcp2_data_blocked and ngtcp2_stream_data_blocked to max_data and max_stream_data respectively to follow RFC 9000.